### PR TITLE
Decouple report from program execution

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -48,8 +48,8 @@ func (c *collector) Collect(eventName string, properties map[string]interface{})
 	if c.Token == "" {
 		return nil
 	}
-	(*properties)["runnerId"] = c.RunnerId
-	(*properties)["order"] = c.Order
+	properties["runnerId"] = c.RunnerId
+	properties["order"] = c.Order
 	c.Order = c.Order + 1
 	return c.Client.Track(c.Id, eventName, &mixpanel.Event{
 		Properties: properties,

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Collector interface {
-	Collect(eventName string, properties *map[string]interface{}) error
+	Collect(eventName string, properties map[string]interface{}) error
 }
 
 type collector struct {
@@ -44,7 +44,7 @@ func NewCollector(token string, id string) Collector {
 	return &c
 }
 
-func (c *collector) Collect(eventName string, properties *map[string]interface{}) error {
+func (c *collector) Collect(eventName string, properties map[string]interface{}) error {
 	if c.Token == "" {
 		return nil
 	}
@@ -52,6 +52,6 @@ func (c *collector) Collect(eventName string, properties *map[string]interface{}
 	(*properties)["order"] = c.Order
 	c.Order = c.Order + 1
 	return c.Client.Track(c.Id, eventName, &mixpanel.Event{
-		Properties: *properties,
+		Properties: properties,
 	})
 }

--- a/engine/env.go
+++ b/engine/env.go
@@ -26,12 +26,12 @@ type Interpreter interface {
 }
 
 type Env struct {
-	Ctx          context.Context
-	Client       *github.Client
-	ClientGQL    *githubv4.Client
-	Collector    collector.Collector
-	PullRequest  *github.PullRequest
-	Interpreters map[string]Interpreter
+	Ctx         context.Context
+	Client      *github.Client
+	ClientGQL   *githubv4.Client
+	Collector   collector.Collector
+	PullRequest *github.PullRequest
+	Interpreter Interpreter
 }
 
 func NewEvalEnv(
@@ -40,15 +40,15 @@ func NewEvalEnv(
 	clientGQL *githubv4.Client,
 	collector collector.Collector,
 	pullRequest *github.PullRequest,
-	interpreters map[string]Interpreter,
+	interpreter Interpreter,
 ) (*Env, error) {
 	input := &Env{
-		Ctx:          ctx,
-		Client:       client,
-		ClientGQL:    clientGQL,
-		Collector:    collector,
-		PullRequest:  pullRequest,
-		Interpreters: interpreters,
+		Ctx:         ctx,
+		Client:      client,
+		ClientGQL:   clientGQL,
+		Collector:   collector,
+		PullRequest: pullRequest,
+		Interpreter: interpreter,
 	}
 
 	return input, nil

--- a/engine/env.go
+++ b/engine/env.go
@@ -23,6 +23,7 @@ type Interpreter interface {
 	ProcessGroup(name string, kind GroupKind, typeOf GroupType, expr, paramExpr, whereExpr string) error
 	EvalExpr(kind, expr string) (bool, error)
 	ExecProgram(mode string, program *Program) error
+	ExecStatement(statement *Statement) error
 }
 
 type Env struct {

--- a/engine/env.go
+++ b/engine/env.go
@@ -22,7 +22,7 @@ const GroupTypeFilter GroupType = "filter"
 type Interpreter interface {
 	ProcessGroup(name string, kind GroupKind, typeOf GroupType, expr, paramExpr, whereExpr string) error
 	EvalExpr(kind, expr string) (bool, error)
-	ExecActions(program *[]string) error
+	ExecProgram(mode string, program *[]string) error
 }
 
 type Env struct {

--- a/engine/env.go
+++ b/engine/env.go
@@ -22,7 +22,7 @@ const GroupTypeFilter GroupType = "filter"
 type Interpreter interface {
 	ProcessGroup(name string, kind GroupKind, typeOf GroupType, expr, paramExpr, whereExpr string) error
 	EvalExpr(kind, expr string) (bool, error)
-	ExecProgram(mode string, program *Program) error
+	ExecProgram(program *Program) error
 	ExecStatement(statement *Statement) error
 	Report(mode string) error
 }

--- a/engine/env.go
+++ b/engine/env.go
@@ -24,6 +24,7 @@ type Interpreter interface {
 	EvalExpr(kind, expr string) (bool, error)
 	ExecProgram(mode string, program *Program) error
 	ExecStatement(statement *Statement) error
+	Report(mode string) error
 }
 
 type Env struct {

--- a/engine/env.go
+++ b/engine/env.go
@@ -22,7 +22,7 @@ const GroupTypeFilter GroupType = "filter"
 type Interpreter interface {
 	ProcessGroup(name string, kind GroupKind, typeOf GroupType, expr, paramExpr, whereExpr string) error
 	EvalExpr(kind, expr string) (bool, error)
-	ExecProgram(mode string, program *[]string) error
+	ExecProgram(mode string, program *Program) error
 }
 
 type Env struct {

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -35,6 +35,8 @@ func CollectError(env *Env, err error) {
 func Eval(file *ReviewpadFile, env *Env) (*[]string, error) {
 	execLogf("file to evaluate:\n%+v", file)
 
+	interpreter := env.Interpreter
+
 	reg := regexp.MustCompile(`github\.com\/repos\/(.*)\/pulls\/\d+$$`)
 	matches := reg.FindStringSubmatch(*env.PullRequest.URL)
 
@@ -71,12 +73,6 @@ func Eval(file *ReviewpadFile, env *Env) (*[]string, error) {
 			CollectError(env, err)
 			return nil, err
 		}
-	}
-
-	// lang := file.Language
-	interpreter, ok := env.Interpreters["aladino"]
-	if !ok {
-		return nil, execError("no interpreter for aladino")
 	}
 
 	// process groups

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -24,7 +24,7 @@ func execLog(val string) {
 }
 
 func CollectError(env *Env, err error) {
-	env.Collector.Collect("Error", &map[string]interface{}{
+	env.Collector.Collect("Error", map[string]interface{}{
 		"pullRequestUrl": env.PullRequest.URL,
 		"details":        err.Error(),
 	})
@@ -40,7 +40,7 @@ func Eval(file *ReviewpadFile, env *Env) (*Program, error) {
 	reg := regexp.MustCompile(`github\.com\/repos\/(.*)\/pulls\/\d+$$`)
 	matches := reg.FindStringSubmatch(*env.PullRequest.URL)
 
-	env.Collector.Collect("Trigger Analysis", &map[string]interface{}{
+	env.Collector.Collect("Trigger Analysis", map[string]interface{}{
 		"pullRequestUrl": env.PullRequest.URL,
 		"project":        matches[1],
 		"version":        file.Version,

--- a/engine/flags.go
+++ b/engine/flags.go
@@ -1,9 +1,0 @@
-// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
-// Use of this source code is governed by a license that can be
-// found in the LICENSE file.
-
-package engine
-
-type Flags struct {
-	Dryrun bool
-}

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -140,7 +140,6 @@ type ReviewpadFile struct {
 	Version   string              `yaml:"api-version"`
 	Edition   string              `yaml:"edition"`
 	Mode      string              `yaml:"mode"`
-	Language  string              `yaml:"language"`
 	Imports   []PadImport         `yaml:"imports"`
 	Groups    map[string]PadGroup `yaml:"groups"`
 	Rules     map[string]PadRule  `yaml:"rules"`
@@ -158,10 +157,6 @@ func (r *ReviewpadFile) equals(o *ReviewpadFile) bool {
 	}
 
 	if r.Mode != o.Mode {
-		return false
-	}
-
-	if r.Language != o.Language {
 		return false
 	}
 

--- a/engine/program.go
+++ b/engine/program.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package engine
+
+type Metadata struct {
+	Workflow    PadWorkflow
+	TriggeredBy []PadWorkflowRule
+}
+
+type Statement struct {
+	Code     string
+	Metadata *Metadata
+}
+
+type Program struct {
+	Statements []*Statement
+}
+
+func (program *Program) append(actions []string, workflow PadWorkflow, rules []PadWorkflowRule) {
+	for _, action := range actions {
+		statement := &Statement{
+			Code: action,
+			Metadata: &Metadata{
+				Workflow:    workflow,
+				TriggeredBy: rules,
+			},
+		}
+
+		program.Statements = append(program.Statements, statement)
+	}
+}

--- a/engine/report.go
+++ b/engine/report.go
@@ -102,7 +102,7 @@ func addReportComment(env *Env, prNum int, report string) error {
 	return nil
 }
 
-func reportProgram(env *Env, reportDetails *[]ReportWorkflowDetails) (string, error) {
+func ReportProgram(env *Env, reportDetails *[]ReportWorkflowDetails) (string, error) {
 	owner := utils.GetPullRequestOwnerName(env.PullRequest)
 	repo := utils.GetPullRequestRepoName(env.PullRequest)
 	prNum := utils.GetPullRequestNumber(env.PullRequest)

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -30,6 +30,7 @@ type Env interface {
 	GetPatch() Patch
 	GetRegisterMap() RegisterMap
 	GetBuiltIns() *BuiltIns
+	GetReport() *Report
 }
 
 type BaseEnv struct {
@@ -41,6 +42,7 @@ type BaseEnv struct {
 	Patch       Patch
 	RegisterMap RegisterMap
 	BuiltIns    *BuiltIns
+	Report      *Report
 }
 
 func (e *BaseEnv) GetCtx() context.Context {
@@ -73,6 +75,10 @@ func (e *BaseEnv) GetRegisterMap() RegisterMap {
 
 func (e *BaseEnv) GetBuiltIns() *BuiltIns {
 	return e.BuiltIns
+}
+
+func (e *BaseEnv) GetReport() *Report {
+	return e.Report
 }
 
 func NewTypeEnv(e Env) *TypeEnv {
@@ -120,6 +126,7 @@ func NewEvalEnv(
 
 	patch := Patch(patchMap)
 	registerMap := RegisterMap(make(map[string]Value))
+	report := &Report{WorkflowDetails: make(map[string]ReportWorkflowDetails, 0)}
 
 	input := &BaseEnv{
 		Ctx:         ctx,
@@ -130,6 +137,7 @@ func NewEvalEnv(
 		Patch:       patch,
 		RegisterMap: registerMap,
 		BuiltIns:    builtIns,
+		Report:      report,
 	}
 
 	return input, nil

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -98,9 +98,9 @@ func NewEvalEnv(
 	pullRequest *github.PullRequest,
 	builtIns *BuiltIns,
 ) (Env, error) {
-	owner := *pullRequest.Base.Repo.Owner.Login
-	repo := *pullRequest.Base.Repo.Name
-	number := *pullRequest.Number
+	owner := utils.GetPullRequestOwnerName(pullRequest)
+	repo := utils.GetPullRequestRepoName(pullRequest)
+	number := utils.GetPullRequestNumber(pullRequest)
 
 	files, err := getPullRequestFiles(ctx, gitHubClient, owner, repo, number)
 	if err != nil {

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -27,8 +27,8 @@ type Env interface {
 	GetClientGQL() *githubv4.Client
 	GetCollector() collector.Collector
 	GetPullRequest() *github.PullRequest
-	GetPatch() *Patch
-	GetRegisterMap() *RegisterMap
+	GetPatch() Patch
+	GetRegisterMap() RegisterMap
 	GetBuiltIns() *BuiltIns
 }
 
@@ -38,8 +38,8 @@ type BaseEnv struct {
 	ClientGQL   *githubv4.Client
 	Collector   collector.Collector
 	PullRequest *github.PullRequest
-	Patch       *Patch
-	RegisterMap *RegisterMap
+	Patch       Patch
+	RegisterMap RegisterMap
 	BuiltIns    *BuiltIns
 }
 
@@ -63,11 +63,11 @@ func (e *BaseEnv) GetPullRequest() *github.PullRequest {
 	return e.PullRequest
 }
 
-func (e *BaseEnv) GetPatch() *Patch {
+func (e *BaseEnv) GetPatch() Patch {
 	return e.Patch
 }
 
-func (e *BaseEnv) GetRegisterMap() *RegisterMap {
+func (e *BaseEnv) GetRegisterMap() RegisterMap {
 	return e.RegisterMap
 }
 
@@ -127,8 +127,8 @@ func NewEvalEnv(
 		ClientGQL:   gitHubClientGQL,
 		Collector:   collector,
 		PullRequest: pullRequest,
-		Patch:       &patch,
-		RegisterMap: &registerMap,
+		Patch:       patch,
+		RegisterMap: registerMap,
 		BuiltIns:    builtIns,
 	}
 

--- a/lang/aladino/eval.go
+++ b/lang/aladino/eval.go
@@ -42,7 +42,7 @@ func (b *BinaryOp) Eval(e Env) (Value, error) {
 func (v *Variable) Eval(e Env) (Value, error) {
 	variableName := v.ident
 
-	if val, ok := (*e.GetRegisterMap())[variableName]; ok {
+	if val, ok := e.GetRegisterMap()[variableName]; ok {
 		return val, nil
 	}
 
@@ -92,7 +92,7 @@ func (lambda *Lambda) Eval(e Env) (Value, error) {
 		for i, elem := range lambda.parameters {
 			paramIdent := elem.(*TypedExpr).expr.(*Variable).ident
 
-			(*e.GetRegisterMap())[paramIdent] = args[i]
+			e.GetRegisterMap()[paramIdent] = args[i]
 		}
 
 		fnVal, err := lambda.body.Eval(e)

--- a/lang/aladino/exec.go
+++ b/lang/aladino/exec.go
@@ -48,7 +48,3 @@ func (fc *FunctionCall) exec(env Env) error {
 
 	return action.Code(env, args)
 }
-
-func ExecAction(env Env, expr ExecExpr) error {
-	return expr.exec(env)
-}

--- a/lang/aladino/exec.go
+++ b/lang/aladino/exec.go
@@ -41,7 +41,7 @@ func (fc *FunctionCall) exec(env Env) error {
 		return fmt.Errorf("exec: %v not found. are you sure this is a built-in function?", fc.name.ident)
 	}
 
-	env.GetCollector().Collect("Ran Builtin", &map[string]interface{}{
+	env.GetCollector().Collect("Ran Builtin", map[string]interface{}{
 		"pullRequestUrl": env.GetPullRequest().URL,
 		"builtin":        fc.name.ident,
 	})

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -81,7 +81,7 @@ func (i *Interpreter) EvalExpr(kind, expr string) (bool, error) {
 	return EvalCondition(i.Env, exprAST)
 }
 
-func (i *Interpreter) ExecProgram(mode string, program *engine.Program) error {
+func (i *Interpreter) ExecProgram(program *engine.Program) error {
 	execLog("executing program:")
 
 	for _, statement := range program.Statements {
@@ -90,8 +90,6 @@ func (i *Interpreter) ExecProgram(mode string, program *engine.Program) error {
 			return err
 		}
 	}
-
-	i.Report(mode)
 
 	execLog("execution done")
 
@@ -122,6 +120,8 @@ func (i *Interpreter) ExecStatement(statement *engine.Statement) error {
 }
 
 func (i *Interpreter) Report(mode string) error {
+	execLog("generating report")
+
 	if mode == engine.SILENT_MODE {
 		return nil
 	}

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -96,27 +96,35 @@ func (i *Interpreter) ExecProgram(mode string, program *engine.Program) error {
 	execLog("executing program:")
 
 	for _, statement := range program.Statements {
-		statRaw := statement.Code
-		statAST, err := Parse(statRaw)
+		err := i.ExecStatement(statement)
 		if err != nil {
 			return err
 		}
-
-		execStatAST, err := TypeCheckExec(i.Env, statAST)
-		if err != nil {
-			return err
-		}
-
-		err = ExecAction(i.Env, execStatAST)
-		if err != nil {
-			return err
-		}
-
-		execLogf("\taction %v executed", statRaw)
 	}
 
 	execLog("execution done")
 
+	return nil
+}
+
+func (i *Interpreter) ExecStatement(statement *engine.Statement) error {
+	statRaw := statement.Code
+	statAST, err := Parse(statRaw)
+	if err != nil {
+		return err
+	}
+
+	execStatAST, err := TypeCheckExec(i.Env, statAST)
+	if err != nil {
+		return err
+	}
+
+	err = ExecAction(i.Env, execStatAST)
+	if err != nil {
+		return err
+	}
+
+	execLogf("\taction %v executed", statRaw)
 	return nil
 }
 

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -32,7 +32,7 @@ func (i *Interpreter) ProcessGroup(groupName string, kind engine.GroupKind, type
 	exprAST, _ := buildGroupAST(typeOf, expr, paramExpr, whereExpr)
 	value, err := evalGroup(i.Env, exprAST)
 
-	(*i.Env.GetRegisterMap())[groupName] = value
+	i.Env.GetRegisterMap()[groupName] = value
 
 	return err
 }

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -66,7 +66,7 @@ func (i *Interpreter) EvalExpr(kind, expr string) (bool, error) {
 		return false, err
 	}
 
-	if exprType.Kind() != "BoolType" {
+	if exprType.Kind() != BOOL_TYPE {
 		return false, fmt.Errorf("expression %v is not a condition", expr)
 	}
 

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -122,11 +122,29 @@ func (i *Interpreter) ExecStatement(statement *engine.Statement) error {
 func (i *Interpreter) Report(mode string) error {
 	execLog("generating report")
 
+	var err error
+
+	env := i.Env
+
+	comment, err := FindReportComment(env)
+	if err != nil {
+		return err
+	}
+
 	if mode == engine.SILENT_MODE {
+		if comment != nil {
+			return DeleteReportComment(env, *comment.ID)
+		}
 		return nil
 	}
 
-	return ReportProgram(i.Env)
+	report := buildReport(env.GetReport())
+
+	if comment == nil {
+		return AddReportComment(env, report)
+	}
+
+	return UpdateReportComment(env, *comment.ID, report)
 }
 
 func NewInterpreter(

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -92,10 +92,11 @@ func execLogf(format string, a ...interface{}) {
 	log.Println(fmtio.Sprintf("aladino", format, a...))
 }
 
-func (i *Interpreter) ExecProgram(mode string, program *[]string) error {
+func (i *Interpreter) ExecProgram(mode string, program *engine.Program) error {
 	execLog("executing program:")
 
-	for _, statRaw := range *program {
+	for _, statement := range program.Statements {
+		statRaw := statement.Code
 		statAST, err := Parse(statRaw)
 		if err != nil {
 			return err

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -108,7 +108,7 @@ func (i *Interpreter) ExecStatement(statement *engine.Statement) error {
 		return err
 	}
 
-	err = ExecAction(i.Env, execStatAST)
+	err = execStatAST.exec(i.Env)
 	if err != nil {
 		return err
 	}

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -20,6 +20,14 @@ type Interpreter struct {
 	Env Env
 }
 
+func execLog(val string) {
+	log.Println(fmtio.Sprint("aladino", val))
+}
+
+func execLogf(format string, a ...interface{}) {
+	log.Println(fmtio.Sprintf("aladino", format, a...))
+}
+
 func (i *Interpreter) ProcessGroup(groupName string, kind engine.GroupKind, typeOf engine.GroupType, expr, paramExpr, whereExpr string) error {
 	exprAST, _ := buildGroupAST(typeOf, expr, paramExpr, whereExpr)
 	value, err := evalGroup(i.Env, exprAST)
@@ -71,14 +79,6 @@ func (i *Interpreter) EvalExpr(kind, expr string) (bool, error) {
 	}
 
 	return EvalCondition(i.Env, exprAST)
-}
-
-func execLog(val string) {
-	log.Println(fmtio.Sprint("aladino", val))
-}
-
-func execLogf(format string, a ...interface{}) {
-	log.Println(fmtio.Sprintf("aladino", format, a...))
 }
 
 func (i *Interpreter) ExecProgram(mode string, program *engine.Program) error {

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -70,18 +70,7 @@ func (i *Interpreter) EvalExpr(kind, expr string) (bool, error) {
 		return false, fmt.Errorf("expression %v is not a condition", expr)
 	}
 
-	cleanTemporaryVariables(i.Env)
-
 	return EvalCondition(i.Env, exprAST)
-}
-
-func cleanTemporaryVariables(env Env) {
-	registerMap := env.GetRegisterMap()
-	for varName := range *registerMap {
-		if varName[0] == '@' {
-			delete(*registerMap, varName)
-		}
-	}
 }
 
 func execLog(val string) {

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -91,6 +91,8 @@ func (i *Interpreter) ExecProgram(mode string, program *engine.Program) error {
 		}
 	}
 
+	i.Report(mode)
+
 	execLog("execution done")
 
 	return nil
@@ -113,8 +115,18 @@ func (i *Interpreter) ExecStatement(statement *engine.Statement) error {
 		return err
 	}
 
+	i.Env.GetReport().addToReport(statement)
+
 	execLogf("\taction %v executed", statRaw)
 	return nil
+}
+
+func (i *Interpreter) Report(mode string) error {
+	if mode == engine.SILENT_MODE {
+		return nil
+	}
+
+	return ReportProgram(i.Env)
 }
 
 func NewInterpreter(

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -92,8 +92,8 @@ func execLogf(format string, a ...interface{}) {
 	log.Println(fmtio.Sprintf("aladino", format, a...))
 }
 
-func (i *Interpreter) ExecActions(program *[]string) error {
-	execLog("executing actions:")
+func (i *Interpreter) ExecProgram(mode string, program *[]string) error {
+	execLog("executing program:")
 
 	for _, statRaw := range *program {
 		statAST, err := Parse(statRaw)

--- a/lang/aladino/report.go
+++ b/lang/aladino/report.go
@@ -20,10 +20,10 @@ type Report struct {
 }
 
 type ReportWorkflowDetails struct {
-	name        string
-	description string
-	rules       map[string]bool
-	actions     []string
+	Name        string
+	Description string
+	Rules       map[string]bool
+	Actions     []string
 }
 
 var reviewpadReportCommentAnnotation = "<!--@annotation-reviewpad-->"
@@ -33,9 +33,9 @@ func reportError(format string, a ...interface{}) error {
 }
 
 func mergeReportWorkflowDetails(left, right ReportWorkflowDetails) ReportWorkflowDetails {
-	for rule, _ := range right.rules {
-		if _, ok := left.rules[rule]; !ok {
-			left.rules[rule] = true
+	for rule, _ := range right.Rules {
+		if _, ok := left.Rules[rule]; !ok {
+			left.Rules[rule] = true
 		}
 	}
 
@@ -51,10 +51,10 @@ func (report *Report) addToReport(statement *engine.Statement) {
 	}
 
 	reportWorkflow := ReportWorkflowDetails{
-		name:        workflowName,
-		description: statement.Metadata.Workflow.Description,
-		rules:       rules,
-		actions:     []string{statement.Code},
+		Name:        workflowName,
+		Description: statement.Metadata.Workflow.Description,
+		Rules:       rules,
+		Actions:     []string{statement.Code},
 	}
 
 	workflow, ok := report.WorkflowDetails[workflowName]
@@ -86,16 +86,16 @@ func buildReport(reportDetails map[string]ReportWorkflowDetails) string {
 
 	for _, workflow := range reportDetails {
 		actRules := ""
-		for _, actRule := range workflow.rules {
+		for _, actRule := range workflow.Rules {
 			actRules += fmt.Sprintf("%v<br>", actRule)
 		}
 
 		actActions := ""
-		for _, actAction := range workflow.actions {
+		for _, actAction := range workflow.Actions {
 			actActions += fmt.Sprintf("`%v`<br>", actAction)
 		}
 
-		sb.WriteString(fmt.Sprintf("| %v | %v | %v | %v |\n", workflow.name, actRules, actActions, workflow.description))
+		sb.WriteString(fmt.Sprintf("| %v | %v | %v | %v |\n", workflow.Name, actRules, actActions, workflow.Description))
 	}
 
 	msg := sb.String()

--- a/lang/aladino/report.go
+++ b/lang/aladino/report.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a license that can be
 // found in the LICENSE file.
 
-package engine
+package aladino
 
 import (
 	"fmt"
@@ -68,15 +68,16 @@ func buildReport(reportDetails *[]ReportWorkflowDetails) string {
 	return msg
 }
 
-func updateReportComment(env *Env, commentId int64, report string) error {
+func updateReportComment(env Env, commentId int64, report string) error {
 	gitHubComment := github.IssueComment{
 		Body: &report,
 	}
 
-	owner := utils.GetPullRequestOwnerName(env.PullRequest)
-	repo := utils.GetPullRequestRepoName(env.PullRequest)
+	pullRequest := env.GetPullRequest()
+	owner := utils.GetPullRequestOwnerName(pullRequest)
+	repo := utils.GetPullRequestRepoName(pullRequest)
 
-	_, _, err := env.Client.Issues.EditComment(env.Ctx, owner, repo, commentId, &gitHubComment)
+	_, _, err := env.GetClient().Issues.EditComment(env.GetCtx(), owner, repo, commentId, &gitHubComment)
 
 	if err != nil {
 		return reportError("error on updating report comment %v", err.(*github.ErrorResponse).Message)
@@ -85,15 +86,16 @@ func updateReportComment(env *Env, commentId int64, report string) error {
 	return nil
 }
 
-func addReportComment(env *Env, prNum int, report string) error {
+func addReportComment(env Env, prNum int, report string) error {
 	gitHubComment := github.IssueComment{
 		Body: &report,
 	}
 
-	owner := utils.GetPullRequestOwnerName(env.PullRequest)
-	repo := utils.GetPullRequestRepoName(env.PullRequest)
+	pullRequest := env.GetPullRequest()
+	owner := utils.GetPullRequestOwnerName(pullRequest)
+	repo := utils.GetPullRequestRepoName(pullRequest)
 
-	_, _, err := env.Client.Issues.CreateComment(env.Ctx, owner, repo, prNum, &gitHubComment)
+	_, _, err := env.GetClient().Issues.CreateComment(env.GetCtx(), owner, repo, prNum, &gitHubComment)
 
 	if err != nil {
 		return reportError("error on creating report comment %v", err.(*github.ErrorResponse).Message)
@@ -102,12 +104,13 @@ func addReportComment(env *Env, prNum int, report string) error {
 	return nil
 }
 
-func ReportProgram(env *Env, reportDetails *[]ReportWorkflowDetails) (string, error) {
-	owner := utils.GetPullRequestOwnerName(env.PullRequest)
-	repo := utils.GetPullRequestRepoName(env.PullRequest)
-	prNum := utils.GetPullRequestNumber(env.PullRequest)
+func ReportProgram(env Env, reportDetails *[]ReportWorkflowDetails) (string, error) {
+	pullRequest := env.GetPullRequest()
+	owner := utils.GetPullRequestOwnerName(pullRequest)
+	repo := utils.GetPullRequestRepoName(pullRequest)
+	prNum := utils.GetPullRequestNumber(pullRequest)
 
-	comments, _, err := env.Client.Issues.ListComments(env.Ctx, owner, repo, prNum, &github.IssueListCommentsOptions{
+	comments, _, err := env.GetClient().Issues.ListComments(env.GetCtx(), owner, repo, prNum, &github.IssueListCommentsOptions{
 		Sort:      github.String("created"),
 		Direction: github.String("asc"),
 	})

--- a/plugins/aladino/actions.go
+++ b/plugins/aladino/actions.go
@@ -337,6 +337,63 @@ func assignReviewerCode(e aladino.Env, args []aladino.Value) error {
 /*
 reviewpad-an: builtin-docs
 
+## close
+______________
+
+**Description**:
+
+Closes a pull request.
+
+**Parameters**:
+
+*none*
+
+**Return value**:
+
+*none*
+
+**Examples**:
+
+```yml
+$close()
+```
+
+A `revy.yml` example:
+
+```yml
+workflows:
+  - name: close-pull-request
+    description: Close pull request
+    if:
+      - rule: stalePullRequest
+    then:
+      - $close()
+```
+*/
+func close() *aladino.BuiltInAction {
+	return &aladino.BuiltInAction{
+		Type: aladino.BuildFunctionType([]aladino.Type{}, nil),
+		Code: closeCode,
+	}
+}
+
+func closeCode(e aladino.Env, args []aladino.Value) error {
+	pullRequest := e.GetPullRequest()
+
+	prNum := utils.GetPullRequestNumber(pullRequest)
+	owner := utils.GetPullRequestOwnerName(pullRequest)
+	repo := utils.GetPullRequestRepoName(pullRequest)
+
+	closedState := "closed"
+	pullRequest.State = &closedState
+	_, _, err := e.GetClient().PullRequests.Edit(e.GetCtx(), owner, repo, prNum, pullRequest)
+
+	return err
+}
+
+/*
+reviewpad-an: builtin-docs
+
 ## comment
 ______________
 

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -49,6 +49,7 @@ func PluginBuiltIns() *aladino.BuiltIns {
 			"addLabel":             addLabel(),
 			"assignRandomReviewer": assignRandomReviewer(),
 			"assignReviewer":       assignReviewer(),
+			"close":                close(),
 			"comment":              comment(),
 			"merge":                merge(),
 			"removeLabel":          removeLabel(),

--- a/plugins/aladino/functions.go
+++ b/plugins/aladino/functions.go
@@ -443,7 +443,7 @@ func fileCount() *aladino.BuiltInFunction {
 
 func fileCountCode(e aladino.Env, _ []aladino.Value) (aladino.Value, error) {
 	patch := e.GetPatch()
-	return aladino.BuildIntValue(len(*patch)), nil
+	return aladino.BuildIntValue(len(patch)), nil
 }
 
 /*
@@ -497,7 +497,7 @@ func patchHasCodePatternCode(e aladino.Env, args []aladino.Value) (aladino.Value
 	arg := args[0].(*aladino.StringValue)
 	patch := e.GetPatch()
 
-	for _, file := range *patch {
+	for _, file := range patch {
 		if file == nil {
 			continue
 		}
@@ -574,7 +574,7 @@ func patchHasFileExtensionsCode(e aladino.Env, args []aladino.Value) (aladino.Va
 	}
 
 	patch := e.GetPatch()
-	for fp := range *patch {
+	for fp := range patch {
 		fpExt := utils.FileExt(fp)
 		normalizedExt := strings.ToLower(fpExt)
 
@@ -637,7 +637,7 @@ func patchHasFileNameCode(e aladino.Env, args []aladino.Value) (aladino.Value, e
 	fileNameStr := args[0].(*aladino.StringValue)
 
 	patch := e.GetPatch()
-	for fp := range *patch {
+	for fp := range patch {
 		if fp == fileNameStr.Val {
 			return aladino.BuildTrueValue(), nil
 		}
@@ -697,7 +697,7 @@ func patchHasFilePatternCode(e aladino.Env, args []aladino.Value) (aladino.Value
 	filePatternRegex := args[0].(*aladino.StringValue)
 
 	patch := e.GetPatch()
-	for fp := range *patch {
+	for fp := range patch {
 		re, err := doublestar.Match(filePatternRegex.Val, fp)
 		if err != nil {
 			return aladino.BuildFalseValue(), err
@@ -1680,7 +1680,7 @@ func group() *aladino.BuiltInFunction {
 func groupCode(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
 	groupName := args[0].(*aladino.StringValue).Val
 
-	if val, ok := (*e.GetRegisterMap())[groupName]; ok {
+	if val, ok := e.GetRegisterMap()[groupName]; ok {
 		return val, nil
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -59,14 +59,18 @@ func Run(
 	}
 
 	if !dryRun {
-		err := aladinoInterpreter.ExecProgram(reviewpadFile.Mode, program)
+		err := aladinoInterpreter.ExecProgram(program)
+		if err != nil {
+			engine.CollectError(evalEnv, err)
+			return err
+		}
+
+		err = aladinoInterpreter.Report(reviewpadFile.Mode)
 		if err != nil {
 			engine.CollectError(evalEnv, err)
 			return err
 		}
 	}
-
-	log.Println(fmtio.Sprintf("reviewpad", "executed program:\n%+q", program))
 
 	evalEnv.Collector.Collect("Completed Analysis", map[string]interface{}{
 		"pullRequestUrl": evalEnv.PullRequest.URL,

--- a/runner.go
+++ b/runner.go
@@ -43,15 +43,12 @@ func Run(
 	reviewpadFile *engine.ReviewpadFile,
 	dryRun bool,
 ) error {
-	interpreters := make(map[string]engine.Interpreter)
-
 	aladinoInterpreter, err := aladino.NewInterpreter(ctx, client, clientGQL, collector, ghPullRequest, plugins_aladino.PluginBuiltIns())
 	if err != nil {
 		return err
 	}
 
-	interpreters["aladino"] = aladinoInterpreter
-	evalEnv, err := engine.NewEvalEnv(ctx, client, clientGQL, collector, ghPullRequest, interpreters)
+	evalEnv, err := engine.NewEvalEnv(ctx, client, clientGQL, collector, ghPullRequest, aladinoInterpreter)
 	if err != nil {
 		return err
 	}

--- a/runner.go
+++ b/runner.go
@@ -68,7 +68,7 @@ func Run(
 
 	log.Println(fmtio.Sprintf("reviewpad", "executed program:\n%+q", program))
 
-	evalEnv.Collector.Collect("Completed Analysis", &map[string]interface{}{
+	evalEnv.Collector.Collect("Completed Analysis", map[string]interface{}{
 		"pullRequestUrl": evalEnv.PullRequest.URL,
 	})
 

--- a/runner.go
+++ b/runner.go
@@ -56,18 +56,13 @@ func Run(
 		return err
 	}
 
-	workflowsReport, program, err := engine.Eval(reviewpadFile, evalEnv)
+	program, err := engine.Eval(reviewpadFile, evalEnv)
 	if err != nil {
 		return err
 	}
 
 	if !dryRun {
-		if reviewpadFile.Mode == engine.VERBOSE_MODE {
-			// ignore error
-			engine.ReportProgram(evalEnv, workflowsReport)
-		}
-
-		err := aladinoInterpreter.ExecActions(program)
+		err := aladinoInterpreter.ExecProgram(reviewpadFile.Mode, program)
 		if err != nil {
 			engine.CollectError(evalEnv, err)
 			return err


### PR DESCRIPTION
This pull request decouples the reporting capabilities from the execution of aladino program that is synthesised by the evaluator. 

It also makes a series of isolated refactorings that can be identified by the commit messages.