### PR TITLE
Paginate list comments request in aladino report

### DIFF
--- a/lang/aladino/report.go
+++ b/lang/aladino/report.go
@@ -180,7 +180,7 @@ func FindReportComment(env Env) (*github.IssueComment, error) {
 	repo := utils.GetPullRequestRepoName(pullRequest)
 	prNum := utils.GetPullRequestNumber(pullRequest)
 
-	comments, _, err := env.GetClient().Issues.ListComments(env.GetCtx(), owner, repo, prNum, &github.IssueListCommentsOptions{
+	comments, err := utils.GetPullRequestComments(env.GetCtx(), env.GetClient(), owner, repo, prNum, &github.IssueListCommentsOptions{
 		Sort:      github.String("created"),
 		Direction: github.String("asc"),
 	})

--- a/plugins/aladino/actions.go
+++ b/plugins/aladino/actions.go
@@ -295,7 +295,7 @@ func commentOnceCode(e aladino.Env, args []aladino.Value) error {
 	commentBodyWithReviewpadAnnotation := fmt.Sprintf("%v%v", ReviewpadCommentAnnotation, commentBody)
 	commentBodyWithReviewpadAnnotationHash := sha256.Sum256([]byte(commentBodyWithReviewpadAnnotation))
 
-	comments, err := utils.GetPullRequestComments(e.GetCtx(), e.GetClient(), owner, repo, prNum)
+	comments, err := utils.GetPullRequestComments(e.GetCtx(), e.GetClient(), owner, repo, prNum, &github.IssueListCommentsOptions{})
 	if err != nil {
 		return err
 	}

--- a/utils/github.go
+++ b/utils/github.go
@@ -84,7 +84,7 @@ func ParseNumPages(resp *github.Response) int {
 	return ParseNumPagesFromLink(link)
 }
 
-func GetPullRequestComments(ctx context.Context, client *github.Client, owner string, repo string, number int) ([]*github.IssueComment, error) {
+func GetPullRequestComments(ctx context.Context, client *github.Client, owner string, repo string, number int, opts *github.IssueListCommentsOptions) ([]*github.IssueComment, error) {
 	fs, err := PaginatedRequest(
 		func() interface{} {
 			return []*github.IssueComment{}
@@ -92,6 +92,9 @@ func GetPullRequestComments(ctx context.Context, client *github.Client, owner st
 		func(i interface{}, page int) (interface{}, *github.Response, error) {
 			fls := i.([]*github.IssueComment)
 			fs, resp, err := client.Issues.ListComments(ctx, owner, repo, number, &github.IssueListCommentsOptions{
+				Sort: opts.Sort,
+				Direction: opts.Direction,
+				Since: opts.Since,
 				ListOptions: github.ListOptions{
 					Page:    page,
 					PerPage: int(maxPerPage),


### PR DESCRIPTION
This pull request includes the following changes:
- Paginate list comments request made in `FindReportComment` function present in `lang/aladino/report.go`
- Added the `opts` argument in `GetPullRequestComments` function present in `utils/github.go`. This was added because when we want to make a request to list the comments of pull request we may want to add a set of options for this listing and this options may vary according to the context of the `GetPullRequestComments` function call. For example, the call made in `FindReportComment` in `lang/aladino/report.go` and the call made in `plugins/aladino/actions.go` differ.

Closes #9