### PR TITLE
Request the review of a set of teams

### DIFF
--- a/plugins/aladino/actions.go
+++ b/plugins/aladino/actions.go
@@ -216,6 +216,10 @@ func assignTeamReviewerCode(e aladino.Env, args []aladino.Value) error {
 
 	teamReviewers := arg.(*aladino.ArrayValue).Vals
 
+	if len(teamReviewers) < 1 {
+		return fmt.Errorf("assignTeamReviewer: requires at least 1 team to request for review")
+	}
+
 	teamReviewersSlugs := []string{}
 
 	for _, team := range teamReviewers {

--- a/plugins/aladino/actions.go
+++ b/plugins/aladino/actions.go
@@ -218,16 +218,16 @@ func assignTeamReviewerCode(e aladino.Env, args []aladino.Value) error {
 		return fmt.Errorf("assignTeamReviewer: requires array argument, got %v", arg.Kind())
 	}
 
-	teamsToReview := arg.(*aladino.ArrayValue).Vals
+	teamReviewers := arg.(*aladino.ArrayValue).Vals
 
-	teamReviewers := []string{}
+	teamReviewersSlugs := []string{}
 
-	for _, team := range teamsToReview {
+	for _, team := range teamReviewers {
 		if !team.HasKindOf(aladino.STRING_VALUE) {
 			return fmt.Errorf("assignTeamReviewer: requires array of strings, got array with value of %v", team.Kind())
 		}
 		
-		teamReviewers = append(teamReviewers, team.(*aladino.StringValue).Val)
+		teamReviewersSlugs = append(teamReviewersSlugs, team.(*aladino.StringValue).Val)
 	}
 
 	prNum := utils.GetPullRequestNumber(e.GetPullRequest())
@@ -235,7 +235,7 @@ func assignTeamReviewerCode(e aladino.Env, args []aladino.Value) error {
 	repo := utils.GetPullRequestRepoName(e.GetPullRequest())
 
 	_, _, err := e.GetClient().PullRequests.RequestReviewers(e.GetCtx(), owner, repo, prNum, github.ReviewersRequest{
-		TeamReviewers: teamReviewers,
+		TeamReviewers: teamReviewersSlugs,
 	})
 
 	return err

--- a/plugins/aladino/actions.go
+++ b/plugins/aladino/actions.go
@@ -209,12 +209,7 @@ func assignTeamReviewer() *aladino.BuiltInAction {
 }
 
 func assignTeamReviewerCode(e aladino.Env, args []aladino.Value) error {
-	arg := args[0]
-	if !arg.HasKindOf(aladino.ARRAY_VALUE) {
-		return fmt.Errorf("assignTeamReviewer: requires array argument, got %v", arg.Kind())
-	}
-
-	teamReviewers := arg.(*aladino.ArrayValue).Vals
+	teamReviewers := args[0].(*aladino.ArrayValue).Vals
 
 	if len(teamReviewers) < 1 {
 		return fmt.Errorf("assignTeamReviewer: requires at least 1 team to request for review")

--- a/plugins/aladino/actions.go
+++ b/plugins/aladino/actions.go
@@ -220,15 +220,16 @@ func assignTeamReviewerCode(e aladino.Env, args []aladino.Value) error {
 		return fmt.Errorf("assignTeamReviewer: requires at least 1 team to request for review")
 	}
 
-	teamReviewersSlugs := []string{}
+	teamReviewersSlugs := make([]string, len(teamReviewers))
 
 	for _, team := range teamReviewers {
 		teamReviewersSlugs = append(teamReviewersSlugs, team.(*aladino.StringValue).Val)
 	}
 
-	prNum := utils.GetPullRequestNumber(e.GetPullRequest())
-	owner := utils.GetPullRequestOwnerName(e.GetPullRequest())
-	repo := utils.GetPullRequestRepoName(e.GetPullRequest())
+	pullRequest := e.GetPullRequest()
+	prNum := utils.GetPullRequestNumber(pullRequest)
+	owner := utils.GetPullRequestOwnerName(pullRequest)
+	repo := utils.GetPullRequestRepoName(pullRequest)
 
 	_, _, err := e.GetClient().PullRequests.RequestReviewers(e.GetCtx(), owner, repo, prNum, github.ReviewersRequest{
 		TeamReviewers: teamReviewersSlugs,

--- a/plugins/aladino/actions.go
+++ b/plugins/aladino/actions.go
@@ -209,10 +209,6 @@ func assignTeamReviewer() *aladino.BuiltInAction {
 }
 
 func assignTeamReviewerCode(e aladino.Env, args []aladino.Value) error {
-	if len(args) < 1 {
-		return fmt.Errorf("assignTeamReviewer: expecting at least 1 argument")
-	}
-
 	arg := args[0]
 	if !arg.HasKindOf(aladino.ARRAY_VALUE) {
 		return fmt.Errorf("assignTeamReviewer: requires array argument, got %v", arg.Kind())
@@ -223,10 +219,6 @@ func assignTeamReviewerCode(e aladino.Env, args []aladino.Value) error {
 	teamReviewersSlugs := []string{}
 
 	for _, team := range teamReviewers {
-		if !team.HasKindOf(aladino.STRING_VALUE) {
-			return fmt.Errorf("assignTeamReviewer: requires array of strings, got array with value of %v", team.Kind())
-		}
-		
 		teamReviewersSlugs = append(teamReviewersSlugs, team.(*aladino.StringValue).Val)
 	}
 

--- a/plugins/aladino/actions.go
+++ b/plugins/aladino/actions.go
@@ -222,8 +222,8 @@ func assignTeamReviewerCode(e aladino.Env, args []aladino.Value) error {
 
 	teamReviewersSlugs := make([]string, len(teamReviewers))
 
-	for _, team := range teamReviewers {
-		teamReviewersSlugs = append(teamReviewersSlugs, team.(*aladino.StringValue).Val)
+	for i, team := range teamReviewers {
+		teamReviewersSlugs[i] = team.(*aladino.StringValue).Val
 	}
 
 	pullRequest := e.GetPullRequest()

--- a/plugins/aladino/actions_test.go
+++ b/plugins/aladino/actions_test.go
@@ -35,10 +35,9 @@ func TestAssignTeamReviewer_WhenNoTeamSlugsAreProvided(t *testing.T) {
 }
 
 func TestAssignTeamReviewer(t *testing.T) {
-	wantTeamReviewers := []string{
-		"core",
-		"reviewpad-project",
-	}
+	teamA := "core"
+	teamB := "reviewpad-project"
+	wantTeamReviewers := []string{teamA, teamB}	
 	gotTeamReviewers := []string{}
 	mockedEnv, err := mockDefaultEnv(
 		mock.WithRequestMatchHandler(
@@ -57,7 +56,7 @@ func TestAssignTeamReviewer(t *testing.T) {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
 	}
 
-	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("core"), aladino.BuildStringValue("reviewpad-project")})}
+	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue(teamA), aladino.BuildStringValue(teamB)})}
 	err = assignTeamReviewerCode(mockedEnv, args)
 
 	assert.Nil(t, err)

--- a/plugins/aladino/actions_test.go
+++ b/plugins/aladino/actions_test.go
@@ -22,18 +22,6 @@ type TeamReviewersRequestPostBody struct {
 	TeamReviewers []string `json:"team_reviewers"`
 }
 
-func TestAssignTeamReviewers_WhenArgIsNotArray(t *testing.T) {
-	mockedEnv, err := mockDefaultEnv()
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
-
-	args := []aladino.Value{aladino.BuildIntValue(1)}
-	err = assignTeamReviewerCode(mockedEnv, args)
-
-	assert.EqualError(t, err, "assignTeamReviewer: requires array argument, got IntValue")
-}
-
 func TestAssignTeamReviewers_WhenNoTeamSlugsAreProvided(t *testing.T) {
 	mockedEnv, err := mockDefaultEnv()
 	if err != nil {

--- a/plugins/aladino/actions_test.go
+++ b/plugins/aladino/actions_test.go
@@ -22,7 +22,7 @@ type TeamReviewersRequestPostBody struct {
 	TeamReviewers []string `json:"team_reviewers"`
 }
 
-func TestAssignTeamReviewers_WhenNoTeamSlugsAreProvided(t *testing.T) {
+func TestAssignTeamReviewer_WhenNoTeamSlugsAreProvided(t *testing.T) {
 	mockedEnv, err := mockDefaultEnv()
 	if err != nil {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
@@ -34,7 +34,7 @@ func TestAssignTeamReviewers_WhenNoTeamSlugsAreProvided(t *testing.T) {
 	assert.EqualError(t, err, "assignTeamReviewer: requires at least 1 team to request for review")
 }
 
-func TestAssignTeamReviewers(t *testing.T) {
+func TestAssignTeamReviewer(t *testing.T) {
 	wantTeamReviewers := []string{
 		"core",
 		"reviewpad-project",

--- a/plugins/aladino/actions_test.go
+++ b/plugins/aladino/actions_test.go
@@ -34,6 +34,18 @@ func TestAssignTeamReviewers_WhenArgIsNotArray(t *testing.T) {
 	assert.EqualError(t, err, "assignTeamReviewer: requires array argument, got IntValue")
 }
 
+func TestAssignTeamReviewers_WhenNoTeamSlugsAreProvided(t *testing.T) {
+	mockedEnv, err := mockDefaultEnv()
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{})}
+	err = assignTeamReviewerCode(mockedEnv, args)
+
+	assert.EqualError(t, err, "assignTeamReviewer: requires at least 1 team to request for review")
+}
+
 func TestAssignTeamReviewers(t *testing.T) {
 	wantTeamReviewers := []string{
 		"core",

--- a/plugins/aladino/actions_test.go
+++ b/plugins/aladino/actions_test.go
@@ -22,18 +22,6 @@ type TeamReviewersRequestPostBody struct {
 	TeamReviewers []string `json:"team_reviewers"`
 }
 
-func TestAssignTeamReviewers_WhenNoArgsAreProvided(t *testing.T) {
-	mockedEnv, err := mockDefaultEnv()
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
-
-	args := []aladino.Value{}
-	err = assignTeamReviewerCode(mockedEnv, args)
-
-	assert.EqualError(t, err, "assignTeamReviewer: expecting at least 1 argument")
-}
-
 func TestAssignTeamReviewers_WhenArgIsNotArray(t *testing.T) {
 	mockedEnv, err := mockDefaultEnv()
 	if err != nil {
@@ -46,24 +34,12 @@ func TestAssignTeamReviewers_WhenArgIsNotArray(t *testing.T) {
 	assert.EqualError(t, err, "assignTeamReviewer: requires array argument, got IntValue")
 }
 
-func TestAssignTeamReviewers_WhenArgHasANonStringElem(t *testing.T) {
-	mockedEnv, err := mockDefaultEnv()
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
-
-	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("team"), aladino.BuildFalseValue()})}
-	err = assignTeamReviewerCode(mockedEnv, args)
-
-	assert.EqualError(t, err, "assignTeamReviewer: requires array of strings, got array with value of BoolValue")
-}
-
 func TestAssignTeamReviewers(t *testing.T) {
-	teamsToRequestForReview := []string{
+	wantTeamReviewers := []string{
 		"core",
 		"reviewpad-project",
 	}
-	requestedTeamReviewers := []string{}
+	gotTeamReviewers := []string{}
 	mockedEnv, err := mockDefaultEnv(
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
@@ -73,7 +49,7 @@ func TestAssignTeamReviewers(t *testing.T) {
 
 				json.Unmarshal(rawBody, &body)
 
-				requestedTeamReviewers = body.TeamReviewers
+				gotTeamReviewers = body.TeamReviewers
 			}),
 		),
 	)
@@ -85,7 +61,7 @@ func TestAssignTeamReviewers(t *testing.T) {
 	err = assignTeamReviewerCode(mockedEnv, args)
 
 	assert.Nil(t, err)
-	assert.Equal(t, teamsToRequestForReview, requestedTeamReviewers)
+	assert.Equal(t, wantTeamReviewers, gotTeamReviewers)
 }
 
 func TestCommentOnce_WhenGetCommentsRequestFails(t *testing.T) {

--- a/plugins/aladino/actions_test.go
+++ b/plugins/aladino/actions_test.go
@@ -46,7 +46,7 @@ func TestAssignTeamReviewers_WhenArgIsNotArray(t *testing.T) {
 	assert.EqualError(t, err, "assignTeamReviewer: requires array argument, got IntValue")
 }
 
-func TestAssignTeamReviewers_WhenArgHasANoStringElem(t *testing.T) {
+func TestAssignTeamReviewers_WhenArgHasANonStringElem(t *testing.T) {
 	mockedEnv, err := mockDefaultEnv()
 	if err != nil {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
@@ -60,8 +60,8 @@ func TestAssignTeamReviewers_WhenArgHasANoStringElem(t *testing.T) {
 
 func TestAssignTeamReviewers(t *testing.T) {
 	teamsToRequestForReview := []string{
-		"justice-league",
-		"avengers",
+		"core",
+		"reviewpad-project",
 	}
 	requestedTeamReviewers := []string{}
 	mockedEnv, err := mockDefaultEnv(
@@ -81,7 +81,7 @@ func TestAssignTeamReviewers(t *testing.T) {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
 	}
 
-	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("justice-league"), aladino.BuildStringValue("avengers")})}
+	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("core"), aladino.BuildStringValue("reviewpad-project")})}
 	err = assignTeamReviewerCode(mockedEnv, args)
 
 	assert.Nil(t, err)

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -54,6 +54,7 @@ func PluginBuiltIns() *aladino.BuiltIns {
 			"addLabel":             addLabel(),
 			"assignRandomReviewer": assignRandomReviewer(),
 			"assignReviewer":       assignReviewer(),
+			"assignTeamReviewer":   assignTeamReviewer(),
 			"close":                close(),
 			"comment":              comment(),
 			"commentOnce":          commentOnce(),


### PR DESCRIPTION
This pull request introduces a new action called $assignTeamReviewer() that requests the review of a given set of team slugs.

It was also added unit tests for this action.

Documentation: https://github.com/reviewpad/docs/pull/3

Closes #26.