### PR TITLE
Add YAML property to define failure mode

### DIFF
--- a/engine/lang.go
+++ b/engine/lang.go
@@ -141,15 +141,15 @@ func (p PadGroup) equals(o PadGroup) bool {
 }
 
 type ReviewpadFile struct {
-	Version         string              `yaml:"api-version"`
-	Edition         string              `yaml:"edition"`
-	Mode            string              `yaml:"mode"`
-	SkipFailOnError bool                `yaml:"skip-fail-on-error"`
-	Imports         []PadImport         `yaml:"imports"`
-	Groups          []PadGroup          `yaml:"groups"`
-	Rules           []PadRule           `yaml:"rules"`
-	Labels          map[string]PadLabel `yaml:"labels"`
-	Workflows       []PadWorkflow       `yaml:"workflows"`
+	Version      string              `yaml:"api-version"`
+	Edition      string              `yaml:"edition"`
+	Mode         string              `yaml:"mode"`
+	IgnoreErrors bool                `yaml:"ignore-errors"`
+	Imports      []PadImport         `yaml:"imports"`
+	Groups       []PadGroup          `yaml:"groups"`
+	Rules        []PadRule           `yaml:"rules"`
+	Labels       map[string]PadLabel `yaml:"labels"`
+	Workflows    []PadWorkflow       `yaml:"workflows"`
 }
 
 func (r *ReviewpadFile) equals(o *ReviewpadFile) bool {
@@ -165,7 +165,7 @@ func (r *ReviewpadFile) equals(o *ReviewpadFile) bool {
 		return false
 	}
 
-	if r.SkipFailOnError != o.SkipFailOnError {
+	if r.IgnoreErrors != o.IgnoreErrors {
 		return false
 	}
 

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -141,14 +141,15 @@ func (p PadGroup) equals(o PadGroup) bool {
 }
 
 type ReviewpadFile struct {
-	Version   string              `yaml:"api-version"`
-	Edition   string              `yaml:"edition"`
-	Mode      string              `yaml:"mode"`
-	Imports   []PadImport         `yaml:"imports"`
-	Groups    []PadGroup          `yaml:"groups"`
-	Rules     []PadRule           `yaml:"rules"`
-	Labels    map[string]PadLabel `yaml:"labels"`
-	Workflows []PadWorkflow       `yaml:"workflows"`
+	Version         string              `yaml:"api-version"`
+	Edition         string              `yaml:"edition"`
+	Mode            string              `yaml:"mode"`
+	SkipFailOnError bool                `yaml:"skip-fail-on-error"`
+	Imports         []PadImport         `yaml:"imports"`
+	Groups          []PadGroup          `yaml:"groups"`
+	Rules           []PadRule           `yaml:"rules"`
+	Labels          map[string]PadLabel `yaml:"labels"`
+	Workflows       []PadWorkflow       `yaml:"workflows"`
 }
 
 func (r *ReviewpadFile) equals(o *ReviewpadFile) bool {
@@ -161,6 +162,10 @@ func (r *ReviewpadFile) equals(o *ReviewpadFile) bool {
 	}
 
 	if r.Mode != o.Mode {
+		return false
+	}
+
+	if r.SkipFailOnError != o.SkipFailOnError {
 		return false
 	}
 

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -88,15 +88,15 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 	}
 
 	return &ReviewpadFile{
-		Version:         file.Version,
-		Edition:         file.Edition,
-		Mode:            file.Mode,
-		SkipFailOnError: file.SkipFailOnError,
-		Imports:         file.Imports,
-		Groups:          file.Groups,
-		Rules:           file.Rules,
-		Labels:          file.Labels,
-		Workflows:       transformedWorkflows,
+		Version:      file.Version,
+		Edition:      file.Edition,
+		Mode:         file.Mode,
+		IgnoreErrors: file.IgnoreErrors,
+		Imports:      file.Imports,
+		Groups:       file.Groups,
+		Rules:        file.Rules,
+		Labels:       file.Labels,
+		Workflows:    transformedWorkflows,
 	}
 }
 

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -88,14 +88,15 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 	}
 
 	return &ReviewpadFile{
-		Version:   file.Version,
-		Edition:   file.Edition,
-		Mode:      file.Mode,
-		Imports:   file.Imports,
-		Groups:    file.Groups,
-		Rules:     file.Rules,
-		Labels:    file.Labels,
-		Workflows: transformedWorkflows,
+		Version:         file.Version,
+		Edition:         file.Edition,
+		Mode:            file.Mode,
+		SkipFailOnError: file.SkipFailOnError,
+		Imports:         file.Imports,
+		Groups:          file.Groups,
+		Rules:           file.Rules,
+		Labels:          file.Labels,
+		Workflows:       transformedWorkflows,
 	}
 }
 


### PR DESCRIPTION
This pull request adds a new YAML property to define failure mode called "skip-fail-on-error" which by default is `false`.

Closes #28.