### PR TITLE
Add unit tests for `$merge` action builtin

### DIFF
--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -40,16 +40,11 @@ func parseMergeMethod(args []aladino.Value) (string, error) {
 		return "merge", nil
 	}
 
-	arg := args[0]
-	if arg.HasKindOf(aladino.STRING_VALUE) {
-		mergeMethod := arg.(*aladino.StringValue).Val
-		switch mergeMethod {
-		case "merge", "rebase", "squash":
-			return mergeMethod, nil
-		default:
-			return "", fmt.Errorf("merge: unexpected argument %v", mergeMethod)
-		}
-	} else {
-		return "", fmt.Errorf("merge: expects string argument")
+	mergeMethod := args[0].(*aladino.StringValue).Val
+	switch mergeMethod {
+	case "merge", "rebase", "squash":
+		return mergeMethod, nil
+	default:
+		return "", fmt.Errorf("merge: unexpected argument %v", mergeMethod)
 	}
 }

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -45,6 +45,6 @@ func parseMergeMethod(args []aladino.Value) (string, error) {
 	case "merge", "rebase", "squash":
 		return mergeMethod, nil
 	default:
-		return "", fmt.Errorf("merge: unexpected argument %v", mergeMethod)
+		return "", fmt.Errorf("merge: unsupported merge method %v", mergeMethod)
 	}
 }

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -36,10 +36,6 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 }
 
 func parseMergeMethod(args []aladino.Value) (string, error) {
-	if len(args) > 1 {
-		return "", fmt.Errorf("merge: received two arguments")
-	}
-
 	if len(args) == 0 {
 		return "merge", nil
 	}

--- a/plugins/aladino/actions/merge_test.go
+++ b/plugins/aladino/actions/merge_test.go
@@ -1,0 +1,92 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_actions_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v2/lang/aladino"
+	mocks_aladino "github.com/reviewpad/reviewpad/v2/mocks/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v2/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var merge = plugins_aladino.PluginBuiltIns().Actions["merge"].Code
+
+type MergeRequestPostBody struct {
+	MergeMethod string `json:"merge_method"`
+}
+
+func TestMerge_WhenMergeMethodIsInvalid(t *testing.T) {
+	mockedEnv, err := mocks_aladino.MockDefaultEnv()
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	args := []aladino.Value{aladino.BuildStringValue("INVALID")}
+	err = merge(mockedEnv, args)
+
+	assert.EqualError(t, err, "merge: unexpected argument INVALID")
+}
+
+func TestMerge_WhenNoMergeMethodIsProvided(t *testing.T) {
+	wantMergeMethod := "merge"
+	var gotMergeMethod string
+	mockedEnv, err := mocks_aladino.MockDefaultEnv(
+		mock.WithRequestMatchHandler(
+			mock.PutReposPullsMergeByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				rawBody, _ := ioutil.ReadAll(r.Body)
+				body := MergeRequestPostBody{}
+
+				json.Unmarshal(rawBody, &body)
+
+				gotMergeMethod = body.MergeMethod
+			}),
+		),
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	args := []aladino.Value{}
+	err = merge(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantMergeMethod, gotMergeMethod)
+}
+
+func TestMerge_WhenMergeMethodIsProvided(t *testing.T) {
+	wantMergeMethod := "rebase"
+	var gotMergeMethod string
+	mockedEnv, err := mocks_aladino.MockDefaultEnv(
+		mock.WithRequestMatchHandler(
+			mock.PutReposPullsMergeByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				rawBody, _ := ioutil.ReadAll(r.Body)
+				body := MergeRequestPostBody{}
+
+				json.Unmarshal(rawBody, &body)
+
+				gotMergeMethod = body.MergeMethod
+			}),
+		),
+	)
+
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	args := []aladino.Value{aladino.BuildStringValue(wantMergeMethod)}
+	err = merge(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantMergeMethod, gotMergeMethod)
+}

--- a/plugins/aladino/actions/merge_test.go
+++ b/plugins/aladino/actions/merge_test.go
@@ -33,7 +33,7 @@ func TestMerge_WhenMergeMethodIsInvalid(t *testing.T) {
 	args := []aladino.Value{aladino.BuildStringValue("INVALID")}
 	err = merge(mockedEnv, args)
 
-	assert.EqualError(t, err, "merge: unexpected argument INVALID")
+	assert.EqualError(t, err, "merge: unsupported merge method INVALID")
 }
 
 func TestMerge_WhenNoMergeMethodIsProvided(t *testing.T) {

--- a/plugins/aladino/actions/merge_test.go
+++ b/plugins/aladino/actions/merge_test.go
@@ -24,7 +24,7 @@ type MergeRequestPostBody struct {
 	MergeMethod string `json:"merge_method"`
 }
 
-func TestMerge_WhenMergeMethodIsInvalid(t *testing.T) {
+func TestMerge_WhenMergeMethodIsUnsupported(t *testing.T) {
 	mockedEnv, err := mocks_aladino.MockDefaultEnv()
 	if err != nil {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
@@ -79,7 +79,6 @@ func TestMerge_WhenMergeMethodIsProvided(t *testing.T) {
 			}),
 		),
 	)
-
 	if err != nil {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
 	}


### PR DESCRIPTION
This pull request introduces unit tests for the merge action builtin.
Besides this, it was removed from the merge action builtin code the checks that are made to the provided args len and type since this is done before the execution of the builtin.