### PR TITLE
Update reviewpad action to v3.x

### DIFF
--- a/.github/workflows/reviewpad.yml
+++ b/.github/workflows/reviewpad.yml
@@ -1,10 +1,15 @@
-name: Reviewpad Action
+name: Reviewpad
 
-on: pull_request
+on:
+  pull_request:
+  workflow_run:
+    workflows: ["*"]
+    types:
+      - completed
 
 jobs:
   reviewpad:
     runs-on: ubuntu-latest
     steps:
       - name: Reviewpad
-        uses: reviewpad/action@v2.x
+        uses: reviewpad/action@v3.x

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -59,10 +59,15 @@ rules:
     description: large-sized pull request
     spec: $size() > 100
 
+  - name: ci-is-green
+    kind: patch
+    description: Pipeline is green
+    spec: $workflowStatus("build") == "success"
+
   - name: shipPullRequestsAreAutomerged
     kind: patch
     description: owners of pull requests with ship in the title
-    spec: '$contains($title(), "[ship]: ") && $isElementOf($author(), $group("owners"))'
+    spec: '$contains($title(), "[ship]: ") && $isElementOf($author(), $group("owners")) && $rule("ci-is-green")'
 
   - name: is-first-time-contributor
     kind: patch
@@ -231,4 +236,3 @@ workflows:
       - rule: touchesPluginsFunctionsOrActionsAndNotBuiltins
     then:
       - '$info("If you have added a new function or action do not forget to include it in the built-in list!")'
-


### PR DESCRIPTION
In this pull request the version of reviewpad action is updated to v3.x. This version is still a WIP.

With this version comes the ability to listen to GitHub events and react to them.

The changes include:

- `.github/workflows/reviewpad.yml`
  - Rename action name to `Reviewpad` instead of `Reviewpad Action` 
  - Run lint
  - Use action v3.x
- `reviewpad.yml`
  - Add CI=green condition before merge. 