### PR TITLE
Add unit tests for `$removeLabel` action builtin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dukex/mixpanel v0.0.0-20220410140740-e82251311162
 	github.com/google/go-github/v42 v42.0.0
 	github.com/google/uuid v1.3.0
+	github.com/gorilla/mux v1.8.0
 	github.com/migueleliasweb/go-github-mock v0.0.8
 	github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00
 	github.com/stretchr/testify v1.7.4
@@ -20,7 +21,6 @@ require (
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-github/v41 v41.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect

--- a/mocks/aladino/mocks.go
+++ b/mocks/aladino/mocks.go
@@ -43,6 +43,11 @@ func getDefaultMockPullRequestDetails() *github.PullRequest {
 		Milestone: &github.Milestone{
 			Title: github.String("v1.0"),
 		},
+		Labels: []*github.Label{
+			{
+				Name: github.String("enhancement"),
+			},
+		},
 		Head: &github.PullRequestBranch{
 			Repo: &github.Repository{
 				Owner: &github.User{

--- a/plugins/aladino/actions/removeLabel.go
+++ b/plugins/aladino/actions/removeLabel.go
@@ -5,8 +5,6 @@
 package plugins_aladino_actions
 
 import (
-	"fmt"
-
 	"github.com/reviewpad/reviewpad/v2/lang/aladino"
 	"github.com/reviewpad/reviewpad/v2/utils"
 )
@@ -19,16 +17,7 @@ func RemoveLabel() *aladino.BuiltInAction {
 }
 
 func removeLabelCode(e aladino.Env, args []aladino.Value) error {
-	if len(args) != 1 {
-		return fmt.Errorf("removeLabel: expecting 1 argument, got %v", len(args))
-	}
-
-	labelVal := args[0]
-	if !labelVal.HasKindOf(aladino.STRING_VALUE) {
-		return fmt.Errorf("removeLabel: expecting string argument, got %v", labelVal.Kind())
-	}
-
-	label := labelVal.(*aladino.StringValue).Val
+	label := args[0].(*aladino.StringValue).Val
 
 	prNum := utils.GetPullRequestNumber(e.GetPullRequest())
 	owner := utils.GetPullRequestOwnerName(e.GetPullRequest())

--- a/plugins/aladino/actions/removeLabel_test.go
+++ b/plugins/aladino/actions/removeLabel_test.go
@@ -1,0 +1,103 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_actions_test
+
+import (
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v42/github"
+	"github.com/gorilla/mux"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v2/lang/aladino"
+	mocks_aladino "github.com/reviewpad/reviewpad/v2/mocks/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v2/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var removeLabel = plugins_aladino.PluginBuiltIns().Actions["removeLabel"].Code
+
+func TestRemoveLabel_WhenGetLabelRequestFails(t *testing.T) {
+	failMessage := "GetLabelRequestFail"
+	mockedEnv, err := mocks_aladino.MockDefaultEnv(
+		mock.WithRequestMatchHandler(
+			mock.GetReposLabelsByOwnerByRepoByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mock.WriteError(
+					w,
+					http.StatusInternalServerError,
+					failMessage,
+				)
+			}),
+		),
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	args := []aladino.Value{aladino.BuildStringValue("test")}
+	err = removeLabel(mockedEnv, args)
+
+	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
+}
+
+func TestRemoveLabel_WhenLabelIsNotAppliedToPullRequest(t *testing.T) {
+	label := "bug"
+	var labelRemoved bool
+	mockedEnv, err := mocks_aladino.MockDefaultEnv(
+		mock.WithRequestMatch(
+			mock.GetReposLabelsByOwnerByRepoByName,
+			github.Label{
+				Name: github.String("bug"),
+			},
+		),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// If the remove label request was performed then the label was removed
+				labelRemoved = true
+			}),
+		),
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	args := []aladino.Value{aladino.BuildStringValue(label)}
+	err = removeLabel(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.False(t, labelRemoved, "The label should not be removed")
+}
+
+func TestRemoveLabel_WhenLabelIsAppliedToPullRequest(t *testing.T) {
+	label := "enhancement"
+	var gotLabel string
+	mockedEnv, err := mocks_aladino.MockDefaultEnv(
+		mock.WithRequestMatch(
+			mock.GetReposLabelsByOwnerByRepoByName,
+			github.Label{
+				Name: github.String("enhancement"),
+			},
+		),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				vars := mux.Vars(r)
+				gotLabel = vars["name"]
+			}),
+		),
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	args := []aladino.Value{aladino.BuildStringValue(label)}
+	err = removeLabel(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, label, gotLabel)
+}

--- a/plugins/aladino/actions/removeLabel_test.go
+++ b/plugins/aladino/actions/removeLabel_test.go
@@ -45,20 +45,20 @@ func TestRemoveLabel_WhenGetLabelRequestFails(t *testing.T) {
 }
 
 func TestRemoveLabel_WhenLabelIsNotAppliedToPullRequest(t *testing.T) {
-	label := "bug"
-	var labelRemoved bool
+	wantLabel := "bug"
+	var isLabelRemoved bool
 	mockedEnv, err := mocks_aladino.MockDefaultEnv(
 		mock.WithRequestMatch(
 			mock.GetReposLabelsByOwnerByRepoByName,
 			github.Label{
-				Name: github.String("bug"),
+				Name: github.String(wantLabel),
 			},
 		),
 		mock.WithRequestMatchHandler(
 			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				// If the remove label request was performed then the label was removed
-				labelRemoved = true
+				isLabelRemoved = true
 			}),
 		),
 	)
@@ -66,21 +66,21 @@ func TestRemoveLabel_WhenLabelIsNotAppliedToPullRequest(t *testing.T) {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
 	}
 
-	args := []aladino.Value{aladino.BuildStringValue(label)}
+	args := []aladino.Value{aladino.BuildStringValue(wantLabel)}
 	err = removeLabel(mockedEnv, args)
 
 	assert.Nil(t, err)
-	assert.False(t, labelRemoved, "The label should not be removed")
+	assert.False(t, isLabelRemoved, "The label should not be removed")
 }
 
 func TestRemoveLabel_WhenLabelIsAppliedToPullRequest(t *testing.T) {
-	label := "enhancement"
+	wantLabel := "enhancement"
 	var gotLabel string
 	mockedEnv, err := mocks_aladino.MockDefaultEnv(
 		mock.WithRequestMatch(
 			mock.GetReposLabelsByOwnerByRepoByName,
 			github.Label{
-				Name: github.String("enhancement"),
+				Name: github.String(wantLabel),
 			},
 		),
 		mock.WithRequestMatchHandler(
@@ -95,9 +95,9 @@ func TestRemoveLabel_WhenLabelIsAppliedToPullRequest(t *testing.T) {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
 	}
 
-	args := []aladino.Value{aladino.BuildStringValue(label)}
+	args := []aladino.Value{aladino.BuildStringValue(wantLabel)}
 	err = removeLabel(mockedEnv, args)
 
 	assert.Nil(t, err)
-	assert.Equal(t, label, gotLabel)
+	assert.Equal(t, wantLabel, gotLabel)
 }


### PR DESCRIPTION
This pull requests introduces the following:
- removal of args length and type check in removeLabel action builtin since these checks are already made before the action execution;
- add labels to the pull request mocks;
- add unit tests for the `removeLabel` action builtin.