### PR TITLE
Add unit tests for `$commits` function builtin

### DIFF
--- a/plugins/aladino/functions/commits.go
+++ b/plugins/aladino/functions/commits.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions
 
 import (
-	"github.com/google/go-github/v42/github"
 	"github.com/reviewpad/reviewpad/v2/lang/aladino"
 	"github.com/reviewpad/reviewpad/v2/utils"
 )
@@ -22,7 +21,7 @@ func commitsCode(e aladino.Env, _ []aladino.Value) (aladino.Value, error) {
 	owner := utils.GetPullRequestOwnerName(e.GetPullRequest())
 	repo := utils.GetPullRequestRepoName(e.GetPullRequest())
 
-	ghCommits, _, err := e.GetClient().PullRequests.ListCommits(e.GetCtx(), owner, repo, prNum, &github.ListOptions{})
+	ghCommits, err := utils.GetPullRequestCommits(e.GetCtx(), e.GetClient(), owner, repo, prNum)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/aladino/functions/commits_test.go
+++ b/plugins/aladino/functions/commits_test.go
@@ -1,0 +1,76 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v42/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v2/lang/aladino"
+	mocks_aladino "github.com/reviewpad/reviewpad/v2/mocks/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v2/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var commits = plugins_aladino.PluginBuiltIns().Functions["commits"].Code
+
+func TestCommits_WhenListCommitsRequestFails(t *testing.T) {
+	failMessage := "ListCommitsRequestFail"
+	mockedEnv, err := mocks_aladino.MockDefaultEnv(
+		mock.WithRequestMatchHandler(
+			mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mock.WriteError(
+					w,
+					http.StatusInternalServerError,
+					failMessage,
+				)
+			}),
+		),
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	args := []aladino.Value{}
+	gotCommits, err := commits(mockedEnv, args)
+
+	assert.Nil(t, gotCommits)
+	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
+}
+
+func TestCommits(t *testing.T) {
+	repoCommits := []*github.RepositoryCommit{
+		{
+			Commit: &github.Commit{
+				Message: github.String("Lorem Ipsum"),
+			},
+		},
+	}
+	mockedEnv, err := mocks_aladino.MockDefaultEnv(
+		mock.WithRequestMatch(
+			mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
+			repoCommits,
+		),
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	wantCommitsMessages := make([]aladino.Value, len(repoCommits))
+	for i, repoCommit := range repoCommits {
+		wantCommitsMessages[i] = aladino.BuildStringValue(repoCommit.Commit.GetMessage())
+	}
+  wantCommits := aladino.BuildArrayValue(wantCommitsMessages)
+
+	args := []aladino.Value{}
+	gotCommits, err := commits(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantCommits, gotCommits)
+}

--- a/plugins/aladino/functions/commits_test.go
+++ b/plugins/aladino/functions/commits_test.go
@@ -45,12 +45,6 @@ func TestCommits_WhenListCommitsRequestFails(t *testing.T) {
 }
 
 func TestCommits(t *testing.T) {
-  defaultPullRequestDetails := mocks_aladino.GetDefaultMockPullRequestDetails()
-  defaultPullRequestDetails.Number = github.Int(6)
-  defaultPullRequestDetails.Base.Repo.Owner = &github.User{
-    Login: github.String("john"),
-  }
-  defaultPullRequestDetails.Base.Repo.Name = github.String("default-mock-repo")
 	repoCommits := []*github.RepositoryCommit{
 		{
 			Commit: &github.Commit{
@@ -59,13 +53,6 @@ func TestCommits(t *testing.T) {
 		},
 	}
 	mockedEnv, err := mocks_aladino.MockDefaultEnv(
-    mock.WithRequestMatchHandler(
-			// Overwrite default mock to pull request request details
-			mock.GetReposPullsByOwnerByRepoByPullNumber,
-			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.Write(mock.MustMarshal(defaultPullRequestDetails))
-			}),
-		),
 		mock.WithRequestMatch(
 			mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
 			repoCommits,
@@ -79,7 +66,7 @@ func TestCommits(t *testing.T) {
 	for i, repoCommit := range repoCommits {
 		wantCommitsMessages[i] = aladino.BuildStringValue(repoCommit.Commit.GetMessage())
 	}
-  wantCommits := aladino.BuildArrayValue(wantCommitsMessages)
+	wantCommits := aladino.BuildArrayValue(wantCommitsMessages)
 
 	args := []aladino.Value{}
 	gotCommits, err := commits(mockedEnv, args)

--- a/plugins/aladino/functions/commits_test.go
+++ b/plugins/aladino/functions/commits_test.go
@@ -45,6 +45,12 @@ func TestCommits_WhenListCommitsRequestFails(t *testing.T) {
 }
 
 func TestCommits(t *testing.T) {
+  defaultPullRequestDetails := mocks_aladino.GetDefaultMockPullRequestDetails()
+  defaultPullRequestDetails.Number = github.Int(6)
+  defaultPullRequestDetails.Base.Repo.Owner = &github.User{
+    Login: github.String("john"),
+  }
+  defaultPullRequestDetails.Base.Repo.Name = github.String("default-mock-repo")
 	repoCommits := []*github.RepositoryCommit{
 		{
 			Commit: &github.Commit{
@@ -53,6 +59,13 @@ func TestCommits(t *testing.T) {
 		},
 	}
 	mockedEnv, err := mocks_aladino.MockDefaultEnv(
+    mock.WithRequestMatchHandler(
+			// Overwrite default mock to pull request request details
+			mock.GetReposPullsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Write(mock.MustMarshal(defaultPullRequestDetails))
+			}),
+		),
 		mock.WithRequestMatch(
 			mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
 			repoCommits,


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request adds unit tests for the `$commits` function builtin and it paginates the `ListCommits` github request.

## Related issue

<!-- Closes # (issue) -->
Closes #46

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran the command `task test`.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

