### PR TITLE
Add unit tests for `$createdAt` function builtin

### DIFF
--- a/plugins/aladino/functions/createdAt_test.go
+++ b/plugins/aladino/functions/createdAt_test.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/reviewpad/reviewpad/v2/lang/aladino"
+	mocks_aladino "github.com/reviewpad/reviewpad/v2/mocks/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v2/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var createdAt = plugins_aladino.PluginBuiltIns().Functions["createdAt"].Code
+
+func TestCreatedAt(t *testing.T) {
+	mockedEnv, err := mocks_aladino.MockDefaultEnv()
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	wantCreatedAtTime, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", mockedEnv.GetPullRequest().GetCreatedAt().String())
+	if err != nil {
+		log.Fatalf("time.Parse failed: %v", err)
+	}
+	wantCreatedAt := aladino.BuildIntValue(int(wantCreatedAtTime.Unix()))
+
+	args := []aladino.Value{}
+	gotCreatedAt, err := createdAt(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantCreatedAt, gotCreatedAt)
+}

--- a/plugins/aladino/functions/createdAt_test.go
+++ b/plugins/aladino/functions/createdAt_test.go
@@ -26,12 +26,15 @@ func TestCreatedAt(t *testing.T) {
 		CreatedAt: &date,
 	})
 	mockedEnv, err := mocks_aladino.MockDefaultEnv(
-		mock.WithRequestMatchHandler(
-			mock.GetReposPullsByOwnerByRepoByPullNumber,
-			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.Write(mock.MustMarshal(mockedPullRequest))
-			}),
-		),
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Write(mock.MustMarshal(mockedPullRequest))
+				}),
+			),
+		},
+		nil,
 	)
 	if err != nil {
 		log.Fatalf("mockDefaultEnv failed: %v", err)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request adds unit tests for the `$createdAt` function builtin.
It wasn't possible to develop a unit test for the case of when the `time.Parse` throws an error since the `createdAt` parameter returned by GitHub is assumed to be valid at all times and so the parse will be successful at all times supposedly.

## Related issue

<!-- Closes # (issue) -->
*None*

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran `task test` command.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues
