### PR TITLE
fix: yaml multiline, issue #89

### DIFF
--- a/lang/aladino/parse.go
+++ b/lang/aladino/parse.go
@@ -6,9 +6,11 @@ package aladino
 
 import (
 	"fmt"
+	"strings"
 )
 
 func Parse(input string) (Expr, error) {
+	input = strings.TrimRight(input, "\n")
 	lex := &AladinoLex{input: input}
 	res := AladinoParse(lex)
 

--- a/lang/aladino/parse_test.go
+++ b/lang/aladino/parse_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package aladino
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParse_WhenSingleLine(t *testing.T) {
+	input := `$addLabel("small")`
+	wantExpr := BuildFunctionCall(
+		BuildVariable("addLabel"),
+		[]Expr{BuildStringConst("small")},
+	)
+
+	gotExpr, err := Parse(input)
+	assert.Nil(t, err)
+	assert.Equal(t, wantExpr, gotExpr)
+}
+
+func TestParse_WhenMultilineLine(t *testing.T) {
+	input := `$addLabel("medium multiline")
+
+`
+	wantExpr := BuildFunctionCall(
+		BuildVariable("addLabel"),
+		[]Expr{BuildStringConst("medium multiline")},
+	)
+
+	gotExpr, err := Parse(input)
+	assert.Nil(t, err)
+	assert.Equal(t, wantExpr, gotExpr)
+}


### PR DESCRIPTION
## Description

Fix adds support multiline strings in yaml config

## Related issue

Closes [issue #89](https://github.com/reviewpad/reviewpad/issues/89)

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Ran `task test` command.
Use rewiewpad as CLI with this config part
```yaml
workflows:
  - name: label-pull-request-with-size
    description: Label pull request with size
    if:
      - rule: isSmall
         extra-actions:
         - >
            $addLabel("small
             multiline")
      - rule: isMedium
         extra-actions:
           - >
             $addLabel("medium
              multiline")
       - rule: isLarge
          extra-actions:
          - >
             $addLabel("large
              multiline")
```

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues
