### PR TITLE
fix: not request review already approved pr

### DIFF
--- a/plugins/aladino/actions/assignReviewer.go
+++ b/plugins/aladino/actions/assignReviewer.go
@@ -56,6 +56,14 @@ func assignReviewerCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
+	// Skip current requested reviewers if pull request already reviewed
+	for _, review := range reviews {
+		if review.State != nil && *review.State == "APPROVED" {
+			log.Printf("assignReviewer: skipping request reviewers. the pull request already reviewed")
+			return nil
+		}
+	}
+
 	// Re-request current reviewers if mention on the provided reviewers list
 	for _, review := range reviews {
 		for index, availableReviewer := range availableReviewers {


### PR DESCRIPTION
## Description

Fix don't re-request review if pr already approved

## Related issue

Closes [issue #89](https://github.com/reviewpad/reviewpad/issues/118)

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Ran `task test` command.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues
