### PR TITLE
fix: :bug: fix incorrect error messages in cli

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -46,12 +46,12 @@ func main() {
 	}
 
 	if *pullRequestUrl == "" {
-		log.Printf("Missing argument reviewpad.")
+		log.Printf("Missing argument pull-request.")
 		usage()
 	}
 
 	if *gitHubToken == "" {
-		log.Printf("Missing argument reviewpad.")
+		log.Printf("Missing argument github-token.")
 		usage()
 	}
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
- fix incorrect error messages in cli
<!-- Also include relevant motivation and context. -->
As I was trying to do a dry run using the cli I was faced with a confusing error message saying `Missing argument reviewpad.` even though the `-reviewpad` flag was provided, turns out I was missing the `-pull-request` flag and the cli was printing out an incorrect error message.
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

<!-- Closes # (issue) -->

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
I did a manual test by running the cli with missing arguments and checked if the intended error message was printed
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues
