### PR TITLE
refactor: rename lang/aladino type unit tests

### DIFF
--- a/lang/aladino/type_internal_test.go
+++ b/lang/aladino/type_internal_test.go
@@ -10,231 +10,231 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildStringType_ExpectStringType(t *testing.T) {
+func TestBuildStringType(t *testing.T) {
 	wantVal := &StringType{}
 	gotVal := BuildStringType()
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestBuildIntType_ExpectIntType(t *testing.T) {
+func TestBuildIntType(t *testing.T) {
 	wantVal := &IntType{}
 	gotVal := BuildIntType()
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestBuildBoolType_ExpectBoolType(t *testing.T) {
+func TestBuildBoolType(t *testing.T) {
 	wantVal := &BoolType{}
 	gotVal := BuildBoolType()
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestBuildFunctionType_ExpectFunctionType(t *testing.T) {
+func TestBuildFunctionType(t *testing.T) {
 	wantVal := &FunctionType{[]Type{&StringType{}}, &StringType{}}
 	gotVal := BuildFunctionType([]Type{&StringType{}}, &StringType{})
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestBuildArrayOfType_ExpectArrayOfType(t *testing.T) {
+func TestBuildArrayOfType(t *testing.T) {
 	wantVal := &ArrayOfType{&StringType{}}
 	gotVal := BuildArrayOfType(&StringType{})
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestBuildArrayType_ExpectArrayType(t *testing.T) {
+func TestBuildArrayType(t *testing.T) {
 	wantVal := &ArrayType{[]Type{&StringType{}, &IntType{}}}
 	gotVal := BuildArrayType([]Type{&StringType{}, &IntType{}})
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestKind_WhenBoolType_ExpectBoolKind(t *testing.T) {
+func TestKind_WhenBoolType(t *testing.T) {
 	wantVal := BOOL_TYPE
 	gotVal := BuildBoolType().Kind()
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestKind_WhenIntType_ExpectIntKind(t *testing.T) {
+func TestKind_WhenIntType(t *testing.T) {
 	wantVal := INT_TYPE
 	gotVal := BuildIntType().Kind()
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestKind_WhenStringType_ExpectStringKind(t *testing.T) {
+func TestKind_WhenStringType(t *testing.T) {
 	wantVal := STRING_TYPE
 	gotVal := BuildStringType().Kind()
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestKind_WhenFunctionType_ExpectFunctionKind(t *testing.T) {
+func TestKind_WhenFunctionType(t *testing.T) {
 	wantVal := FUNCTION_TYPE
 	gotVal := BuildFunctionType([]Type{&StringType{}}, &StringType{}).Kind()
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestKind_WhenArrayType_ExpectArrayKind(t *testing.T) {
+func TestKind_WhenArrayType(t *testing.T) {
 	wantVal := ARRAY_TYPE
 	gotVal := BuildArrayType([]Type{&StringType{}, &IntType{}}).Kind()
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestKind_WhenArrayOfType_ExpectArrayOfKind(t *testing.T) {
+func TestKind_WhenArrayOfType(t *testing.T) {
 	wantVal := ARRAY_OF_TYPE
 	gotVal := BuildArrayOfType(&StringType{}).Kind()
 
 	assert.Equal(t, wantVal, gotVal)
 }
 
-func TestEquals_WhenArraysOfDiffSizes_ExpectFalse(t *testing.T) {
+func TestEquals_WhenArraysOfDiffSizes(t *testing.T) {
 	leftTys := []Type{BuildBoolType(), BuildIntType()}
 	rightTys := []Type{BuildBoolType()}
 
 	assert.False(t, equals(leftTys, rightTys))
 }
 
-func TestEquals_WhenArraysContainDiffValues_ExpectFalse(t *testing.T) {
+func TestEquals_WhenArraysContainDiffValues(t *testing.T) {
 	leftTys := []Type{BuildIntType()}
 	rightTys := []Type{BuildBoolType()}
 
 	assert.False(t, equals(leftTys, rightTys))
 }
 
-func TestEquals_ExpectTrue(t *testing.T) {
+func TestEquals_WhenEqualTypes(t *testing.T) {
 	leftTys := []Type{BuildBoolType()}
 	rightTys := []Type{BuildBoolType()}
 
 	assert.True(t, equals(leftTys, rightTys))
 }
 
-func TestEquals_WhenBoolType_ExpectFalse(t *testing.T) {
+func TestEquals_WhenBoolTypeComparedToStringType(t *testing.T) {
 	boolType := BuildBoolType()
 	otherType := BuildStringType()
 
 	assert.False(t, boolType.equals(otherType))
 }
 
-func TestEquals_WhenBoolType_ExpectTrue(t *testing.T) {
+func TestEquals_WhenBoolTypeComparedToSameType(t *testing.T) {
 	boolType := BuildBoolType()
 	otherType := BuildBoolType()
 
 	assert.True(t, boolType.equals(otherType))
 }
 
-func TestEquals_WhenStringType_ExpectFalse(t *testing.T) {
+func TestEquals_WhenStringTypeComparedToBoolType(t *testing.T) {
 	stringType := BuildStringType()
 	otherType := BuildBoolType()
 
 	assert.False(t, stringType.equals(otherType))
 }
 
-func TestEquals_WhenStringType_ExpectTrue(t *testing.T) {
+func TestEquals_WhenStringTypeComparedToSameType(t *testing.T) {
 	stringType := BuildStringType()
 	otherType := BuildStringType()
 
 	assert.True(t, stringType.equals(otherType))
 }
 
-func TestEquals_WhenIntType_ExpectFalse(t *testing.T) {
+func TestEquals_WhenIntTypeComparedToStringType(t *testing.T) {
 	intType := BuildIntType()
 	otherType := BuildStringType()
 
 	assert.False(t, intType.equals(otherType))
 }
 
-func TestEquals_WhenIntType_ExpectTrue(t *testing.T) {
+func TestEquals_WhenIntTypeComparedToSameType(t *testing.T) {
 	intType := BuildIntType()
 	otherType := BuildIntType()
 
 	assert.True(t, intType.equals(otherType))
 }
 
-func TestEquals_WhenFunctionType_ExpectFalse(t *testing.T) {
+func TestEquals_WhenFunctionTypeComparedToIntType(t *testing.T) {
 	functionType := BuildFunctionType([]Type{BuildStringType()}, BuildIntType())
 	otherType := BuildIntType()
 
 	assert.False(t, functionType.equals(otherType))
 }
 
-func TestEquals_WhenFunctionType_ExpectTrue(t *testing.T) {
+func TestEquals_WhenFunctionTypeComparedToSameType(t *testing.T) {
 	functionType := BuildFunctionType([]Type{BuildStringType()}, BuildIntType())
 	otherType := BuildFunctionType([]Type{BuildStringType()}, BuildIntType())
 
 	assert.True(t, functionType.equals(otherType))
 }
 
-func TestEquals_WhenArraysTypesHaveDiffSizes_ExpectFalse(t *testing.T) {
+func TestEquals_WhenArraysTypesHaveDiffSizes(t *testing.T) {
 	arrayType := BuildArrayType([]Type{BuildStringType()})
 	otherArrayType := BuildArrayType([]Type{BuildStringType(), BuildIntType()})
 
 	assert.False(t, arrayType.equals(otherArrayType))
 }
 
-func TestEquals_WhenArraysTypesAreEqual_ExpectTrue(t *testing.T) {
+func TestEquals_WhenArraysTypesAreEqual(t *testing.T) {
 	arrayType := BuildArrayType([]Type{BuildStringType()})
 	otherArrayType := BuildArrayType([]Type{BuildStringType()})
 
 	assert.True(t, arrayType.equals(otherArrayType))
 }
 
-func TestEquals_WhenArrayTypeAndArrayOfTypeHaveDiffKind_ExpectFalse(t *testing.T) {
+func TestEquals_WhenArrayTypeAndArrayOfTypeHaveDiffKind(t *testing.T) {
 	arrayType := BuildArrayType([]Type{BuildStringType()})
 	arrayOfType := BuildArrayOfType(BuildIntType())
 
 	assert.False(t, arrayType.equals(arrayOfType))
 }
 
-func TestEquals_WhenArrayTypeAndArrayOfTypeHaveSameKind_ExpectTrue(t *testing.T) {
+func TestEquals_WhenArrayTypeAndArrayOfTypeHaveSameKind(t *testing.T) {
 	arrayType := BuildArrayType([]Type{BuildStringType()})
 	arrayOfType := BuildArrayOfType(BuildStringType())
 
 	assert.True(t, arrayType.equals(arrayOfType))
 }
 
-func TestEquals_WhenArrayType_ExpectFalse(t *testing.T) {
+func TestEquals_WhenArrayTypeComparedToStringType(t *testing.T) {
 	arrayType := BuildArrayType([]Type{BuildStringType()})
 	otherType := BuildStringType()
 
 	assert.False(t, arrayType.equals(otherType))
 }
 
-func TestEquals_WhenArrayOfTypeAndArrayTypeHaveDiffKinds_ExpectFalse(t *testing.T) {
+func TestEquals_WhenArrayOfTypeAndArrayTypeHaveDiffKinds(t *testing.T) {
 	arrayOfType := BuildArrayOfType(BuildIntType())
     arrayType := BuildArrayType([]Type{BuildStringType()})
 
     assert.False(t, arrayOfType.equals(arrayType))
 }
 
-func TestEquals_WhenArrayOfTypeAndArrayTypeHaveSameKind_ExpectTrue(t *testing.T) {
+func TestEquals_WhenArrayOfTypeAndArrayTypeHaveSameKind(t *testing.T) {
 	arrayOfType := BuildArrayOfType(BuildIntType())
     arrayType := BuildArrayType([]Type{BuildIntType()})
 
     assert.True(t, arrayOfType.equals(arrayType))
 }
 
-func TestEquals_WhenArraysOfTypesHaveDiffKind_ExpectFalse(t *testing.T) {
+func TestEquals_WhenArraysOfTypesHaveDiffKind(t *testing.T) {
 	arrayOfType := BuildArrayOfType(BuildIntType())
 	otherArrayOfType := BuildArrayOfType(BuildStringType())
 
 	assert.False(t, arrayOfType.equals(otherArrayOfType))
 }
 
-func TestEquals_WhenArraysOfTypesAreEqual_ExpectTrue(t *testing.T) {
+func TestEquals_WhenArraysOfTypesAreEqual(t *testing.T) {
 	arrayOfType := BuildArrayOfType(BuildIntType())
 	otherArrayOfType := BuildArrayOfType(BuildIntType())
 
 	assert.True(t, arrayOfType.equals(otherArrayOfType))
 }
 
-func TestEquals_WhenArrayOfType_ExpectFalse(t *testing.T) {
+func TestEquals_WhenArrayOfTypeComparedToStringType(t *testing.T) {
 	arrayOfType := BuildArrayOfType(BuildIntType())
 	otherType := BuildStringType()
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request renames the `lang/aladino` type unit tests for the agreed format: `Test[MethodName](_When[StateUnderTest])()`.

## Related issue

<!-- Closes # (issue) -->
*None*

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran `task test`.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues
