### PR TITLE
Add  built-in utility function `$reviewerStatus`

### DIFF
--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -42,6 +42,7 @@ func PluginBuiltIns() *aladino.BuiltIns {
 			"size":              functions.Size(),
 			"title":             functions.Title(),
 			"workflowStatus":    functions.WorkflowStatus(),
+			"reviewerStatus":    functions.ReviewerStatus(),
 			// Organization
 			"organization": functions.Organization(),
 			"team":         functions.Team(),

--- a/plugins/aladino/functions/reviewerStatus.go
+++ b/plugins/aladino/functions/reviewerStatus.go
@@ -1,0 +1,67 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"fmt"
+
+	"github.com/google/go-github/v42/github"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	"github.com/reviewpad/reviewpad/v3/utils"
+)
+
+// contain all the available reviewer status states
+const (
+	ReviewerStatusStateCommented       string = "COMMENTED"
+	ReviewerStatusStateRequestChanges  string = "CHANGES_REQUESTED"
+	ReviewerStatusStateRequestApproved string = "APPROVED"
+)
+
+// ReviewerStatus return the lastest review status of reviewer on a pull request
+func ReviewerStatus() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type: aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType()}, aladino.BuildStringType()),
+		Code: reviewerStatusCdoe,
+	}
+}
+
+// reviewerStatusCdoe return the lastest review status (neutral, requested_changes, approved) of the reviewerLogin on a pull request
+func reviewerStatusCdoe(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
+	reviewerLogin := args[0].(*aladino.StringValue)
+
+	prNum := utils.GetPullRequestNumber(e.GetPullRequest())
+	owner := utils.GetPullRequestBaseOwnerName(e.GetPullRequest())
+	repo := utils.GetPullRequestBaseRepoName(e.GetPullRequest())
+
+	reviews, err := utils.GetPullRequestReviews(e.GetCtx(), e.GetClient(), owner, repo, prNum, &github.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	status := "neutral"
+	// iterate over the reviewersLogin and update the status for the reviewerLogin
+	for _, r := range reviews {
+		if *r.User.Login != *&reviewerLogin.Val {
+			continue
+		}
+
+		switch *r.State {
+
+		case ReviewerStatusStateCommented:
+			status = "neutral"
+
+		case ReviewerStatusStateRequestChanges:
+			status = "requested_changes"
+
+		case ReviewerStatusStateRequestApproved:
+			status = "approved"
+
+		}
+	}
+
+	fmt.Println("Hello", status)
+
+	return aladino.BuildStringValue(status), nil
+}

--- a/plugins/aladino/functions/reviewerStatus.go
+++ b/plugins/aladino/functions/reviewerStatus.go
@@ -47,21 +47,19 @@ func reviewerStatusCdoe(e aladino.Env, args []aladino.Value) (aladino.Value, err
 			continue
 		}
 
+		fmt.Println("State:", *r.State)
+
 		switch *r.State {
-
-		case ReviewerStatusStateCommented:
-			status = "neutral"
-
 		case ReviewerStatusStateRequestChanges:
 			status = "requested_changes"
-
 		case ReviewerStatusStateRequestApproved:
 			status = "approved"
 
 		}
+
 	}
 
-	fmt.Println("Hello", status)
+	fmt.Println("Status:", status)
 
 	return aladino.BuildStringValue(status), nil
 }

--- a/plugins/aladino/functions/reviewerStatus.go
+++ b/plugins/aladino/functions/reviewerStatus.go
@@ -30,9 +30,10 @@ func reviewerStatusCode(e aladino.Env, args []aladino.Value) (aladino.Value, err
 	}
 
 	status := ""
+	reviewerHasDecision := false
 
 	for _, review := range reviews {
-		if review.User == nil {
+		if review.User == nil || review.State == nil {
 			continue
 		}
 
@@ -40,13 +41,16 @@ func reviewerStatusCode(e aladino.Env, args []aladino.Value) (aladino.Value, err
 			continue
 		}
 
-		switch *review.State {
-		case "COMMENTED":
-			status = "commented"
-		case "CHANGES_REQUESTED":
-			status = "requested_changes"
-		case "APPROVED":
-			status = "approved"
+		reviewState := *review.State
+		if reviewState == "COMMENTED" {
+			if reviewerHasDecision {
+				continue
+			} else {
+				status = reviewState
+			}
+		} else {
+			status = reviewState
+			reviewerHasDecision = true
 		}
 	}
 

--- a/plugins/aladino/functions/reviewerStatus.go
+++ b/plugins/aladino/functions/reviewerStatus.go
@@ -39,7 +39,7 @@ func reviewerStatusCdoe(e aladino.Env, args []aladino.Value) (aladino.Value, err
 	}
 
 	status := "neutral"
-	// iterate over the reviewersLogin and update the status for the reviewerLogin
+
 	for _, r := range reviews {
 		if *r.User.Login != *&reviewerLogin.Val {
 			continue

--- a/plugins/aladino/functions/reviewerStatus.go
+++ b/plugins/aladino/functions/reviewerStatus.go
@@ -5,8 +5,6 @@
 package plugins_aladino_functions
 
 import (
-	"fmt"
-
 	"github.com/google/go-github/v42/github"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
 	"github.com/reviewpad/reviewpad/v3/utils"
@@ -47,8 +45,6 @@ func reviewerStatusCdoe(e aladino.Env, args []aladino.Value) (aladino.Value, err
 			continue
 		}
 
-		fmt.Println("State:", *r.State)
-
 		switch *r.State {
 		case ReviewerStatusStateRequestChanges:
 			status = "requested_changes"
@@ -58,8 +54,6 @@ func reviewerStatusCdoe(e aladino.Env, args []aladino.Value) (aladino.Value, err
 		}
 
 	}
-
-	fmt.Println("Status:", status)
 
 	return aladino.BuildStringValue(status), nil
 }

--- a/plugins/aladino/functions/reviewerStatus_test.go
+++ b/plugins/aladino/functions/reviewerStatus_test.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"testing"
+
+	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+)
+
+var reviewersTemp = plugins_aladino.PluginBuiltIns().Functions["reviewers"].Code
+
+func TestReviewerStatus(t *testing.T) {
+
+}

--- a/plugins/aladino/functions/reviewerStatus_test.go
+++ b/plugins/aladino/functions/reviewerStatus_test.go
@@ -18,7 +18,7 @@ import (
 
 var reviewerStatus = plugins_aladino.PluginBuiltIns().Functions["reviewerStatus"].Code
 
-func TestReviewerStatus_whenRequestFails(t *testing.T) {
+func TestReviewerStatus_WhenRequestFails(t *testing.T) {
 	failMessage := "ReviewerStatusRequestFail"
 	mockedEnv, err := aladino.MockDefaultEnv(
 		[]mock.MockBackendOption{

--- a/plugins/aladino/functions/reviewerStatus_test.go
+++ b/plugins/aladino/functions/reviewerStatus_test.go
@@ -74,6 +74,36 @@ func TestReviewerStatus_WhenUserIsNil(t *testing.T) {
 	assert.Equal(t, wantReviewState, gotReviewState)
 }
 
+func TestReviewerStatus_WhenStateIsNil(t *testing.T) {
+	reviews := []*github.PullRequestReview{
+		{
+			User: &github.User{
+				Login: github.String("john"),
+			},
+		},
+	}
+	mockedEnv, err := aladino.MockDefaultEnv(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatch(
+				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+				reviews,
+			),
+		},
+		nil,
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	wantReviewState := aladino.BuildStringValue("")
+
+	args := []aladino.Value{aladino.BuildStringValue("mary")}
+	gotReviewState, err := reviewerStatus(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantReviewState, gotReviewState)
+}
+
 func TestReviewerStatus_WhenStateUnknown(t *testing.T) {
 	reviews := []*github.PullRequestReview{
 		{
@@ -133,7 +163,7 @@ func TestReviewerStatus_WhenStateCommented(t *testing.T) {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
 	}
 
-	wantReviewState := aladino.BuildStringValue("commented")
+	wantReviewState := aladino.BuildStringValue("COMMENTED")
 
 	args := []aladino.Value{aladino.BuildStringValue("mary")}
 	gotReviewState, err := reviewerStatus(mockedEnv, args)
@@ -168,6 +198,12 @@ func TestReviewerStatus_WhenStateApproved(t *testing.T) {
 				Login: github.String("mary"),
 			},
 		},
+		{
+			State: github.String("COMMENTED"),
+			User: &github.User{
+				Login: github.String("mary"),
+			},
+		},
 	}
 	mockedEnv, err := aladino.MockDefaultEnv(
 		[]mock.MockBackendOption{
@@ -182,7 +218,7 @@ func TestReviewerStatus_WhenStateApproved(t *testing.T) {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
 	}
 
-	wantReviewState := aladino.BuildStringValue("approved")
+	wantReviewState := aladino.BuildStringValue("APPROVED")
 
 	args := []aladino.Value{aladino.BuildStringValue("mary")}
 	gotReviewState, err := reviewerStatus(mockedEnv, args)
@@ -191,7 +227,7 @@ func TestReviewerStatus_WhenStateApproved(t *testing.T) {
 	assert.Equal(t, wantReviewState, gotReviewState)
 }
 
-func TestReviewerStatus_whenStateRequestedChanges(t *testing.T) {
+func TestReviewerStatus_WhenStateRequestedChanges(t *testing.T) {
 	reviews := []*github.PullRequestReview{
 		{
 			State: github.String("COMMENTED"),
@@ -211,6 +247,12 @@ func TestReviewerStatus_whenStateRequestedChanges(t *testing.T) {
 				Login: github.String("mary"),
 			},
 		},
+		{
+			State: github.String("COMMENTED"),
+			User: &github.User{
+				Login: github.String("mary"),
+			},
+		},
 	}
 	mockedEnv, err := aladino.MockDefaultEnv(
 		[]mock.MockBackendOption{
@@ -225,7 +267,7 @@ func TestReviewerStatus_whenStateRequestedChanges(t *testing.T) {
 		log.Fatalf("mockDefaultEnv failed: %v", err)
 	}
 
-	wantReviewState := aladino.BuildStringValue("requested_changes")
+	wantReviewState := aladino.BuildStringValue("CHANGES_REQUESTED")
 
 	args := []aladino.Value{aladino.BuildStringValue("mary")}
 	gotReviewState, err := reviewerStatus(mockedEnv, args)

--- a/plugins/aladino/functions/reviewerStatus_test.go
+++ b/plugins/aladino/functions/reviewerStatus_test.go
@@ -5,13 +5,170 @@
 package plugins_aladino_functions_test
 
 import (
+	"log"
+	"net/http"
 	"testing"
 
+	"github.com/google/go-github/v42/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
 	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+	"github.com/stretchr/testify/assert"
 )
 
-var reviewersTemp = plugins_aladino.PluginBuiltIns().Functions["reviewers"].Code
+var reviewerStatus = plugins_aladino.PluginBuiltIns().Functions["reviewerStatus"].Code
 
-func TestReviewerStatus(t *testing.T) {
+func TestReviewerStatusRequestFails(t *testing.T) {
+	failMessage := "ReviewerStatusRequestFail"
+	mockedEnv, err := aladino.MockDefaultEnv(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mock.WriteError(
+						w,
+						http.StatusInternalServerError,
+						failMessage,
+					)
+				}),
+			),
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mock.WriteError(
+						w,
+						http.StatusInternalServerError,
+						failMessage,
+					)
+				}),
+			),
+		},
+		nil,
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
 
+	args := []aladino.Value{aladino.BuildStringValue("mary")}
+	gotReviewState, err := reviewerStatus(mockedEnv, args)
+
+	assert.Nil(t, gotReviewState)
+	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
+}
+
+func TestReviewerStatusNeutral(t *testing.T) {
+	reviews := []*github.PullRequestReview{
+		{
+			State: github.String("COMMENTED"),
+			User: &github.User{
+				Login: github.String("john"),
+			},
+		},
+	}
+	mockedEnv, err := aladino.MockDefaultEnv(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatch(
+				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+				reviews,
+			),
+		},
+		nil,
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	wantReviewState := aladino.BuildStringValue("neutral")
+
+	args := []aladino.Value{aladino.BuildStringValue("mary")}
+	gotReviewState, err := reviewerStatus(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantReviewState, gotReviewState)
+}
+
+func TestReviewerStatusApproved(t *testing.T) {
+	reviews := []*github.PullRequestReview{
+		{
+			State: github.String("COMMENTED"),
+			User: &github.User{
+				Login: github.String("john"),
+			},
+		},
+		{
+			State: github.String("APPROVED"),
+			User: &github.User{
+				Login: github.String("mary"),
+			},
+		},
+		{
+			State: github.String("COMMENTED"),
+			User: &github.User{
+				Login: github.String("mary"),
+			},
+		},
+	}
+	mockedEnv, err := aladino.MockDefaultEnv(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatch(
+				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+				reviews,
+			),
+		},
+		nil,
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	wantReviewState := aladino.BuildStringValue("approved")
+
+	args := []aladino.Value{aladino.BuildStringValue("mary")}
+	gotReviewState, err := reviewerStatus(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantReviewState, gotReviewState)
+}
+
+func TestReviewerStatusRequestedChanges(t *testing.T) {
+	reviews := []*github.PullRequestReview{
+		{
+			State: github.String("COMMENTED"),
+			User: &github.User{
+				Login: github.String("john"),
+			},
+		},
+		{
+			State: github.String("APPROVED"),
+			User: &github.User{
+				Login: github.String("mary"),
+			},
+		},
+		{
+			State: github.String("CHANGES_REQUESTED"),
+			User: &github.User{
+				Login: github.String("mary"),
+			},
+		},
+	}
+	mockedEnv, err := aladino.MockDefaultEnv(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatch(
+				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+				reviews,
+			),
+		},
+		nil,
+	)
+	if err != nil {
+		log.Fatalf("mockDefaultEnv failed: %v", err)
+	}
+
+	wantReviewState := aladino.BuildStringValue("requested_changes")
+
+	args := []aladino.Value{aladino.BuildStringValue("mary")}
+	gotReviewState, err := reviewerStatus(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantReviewState, gotReviewState)
 }

--- a/utils/github.go
+++ b/utils/github.go
@@ -249,3 +249,29 @@ func GetPullRequestCommits(ctx context.Context, client *github.Client, owner str
 
 	return commits.([]*github.RepositoryCommit), nil
 }
+
+// GetPullRequestReviews fetch pull request reviews
+func GetPullRequestReviews(ctx context.Context, client *github.Client, owner string, repo string, number int, opts *github.ListOptions) ([]*github.PullRequestReview, error) {
+	reviews, err := PaginatedRequest(
+		func() interface{} {
+			return []*github.PullRequestReview{}
+		},
+		func(i interface{}, page int) (interface{}, *github.Response, error) {
+			currentReviews := i.([]*github.PullRequestReview)
+			reviews, resp, err := client.PullRequests.ListReviews(ctx, owner, repo, number, &github.ListOptions{
+				Page:    page,
+				PerPage: maxPerPage,
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+			currentReviews = append(currentReviews, reviews...)
+			return currentReviews, resp, nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return reviews.([]*github.PullRequestReview), nil
+}

--- a/utils/github.go
+++ b/utils/github.go
@@ -250,7 +250,6 @@ func GetPullRequestCommits(ctx context.Context, client *github.Client, owner str
 	return commits.([]*github.RepositoryCommit), nil
 }
 
-// GetPullRequestReviews fetch pull request reviews
 func GetPullRequestReviews(ctx context.Context, client *github.Client, owner string, repo string, number int, opts *github.ListOptions) ([]*github.PullRequestReview, error) {
 	reviews, err := PaginatedRequest(
 		func() interface{} {

--- a/utils/github_test.go
+++ b/utils/github_test.go
@@ -617,7 +617,7 @@ func TestGetPullRequestCommits(t *testing.T) {
 	assert.Equal(t, wantCommits, gotCommits)
 }
 
-func TestGetPullRequestReviewsWithCommentedState(t *testing.T) {
+func TestGetPullRequestReviews(t *testing.T) {
 	wantReviews := []*github.PullRequestReview{
 		{
 			State: github.String("COMMENTED"),
@@ -653,7 +653,7 @@ func TestGetPullRequestReviewsWithCommentedState(t *testing.T) {
 	assert.Equal(t, wantReviews, gotReviews)
 }
 
-func TestGetPullRequestReviewsFails(t *testing.T) {
+func TestGetPullRequestReviews_WhenRequestFails(t *testing.T) {
 	failMessage := "ListPullRequestReviewsFail"
 	mockedEnv, err := aladino.MockDefaultEnv(
 		[]mock.MockBackendOption{


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes. -->
This pull request introduces a built-in utility function `$reviewerStatus`.

<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #160

## Type of change

Improvements (non-breaking change without functionality)

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Ran `task test` command and also checked  coverage using `task coverage`

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues
