### PR TITLE
test: add unit tests for engine exec

### DIFF
--- a/engine/exec.go
+++ b/engine/exec.go
@@ -25,14 +25,14 @@ func execLog(val string) {
 }
 
 func CollectError(env *Env, err error) {
-    var errDetails string
+	var errDetails string
 	ghError, isGitHubError := err.(*github.ErrorResponse)
 
-    if isGitHubError {
-        errDetails = ghError.Message
-    } else {
-        errDetails = err.Error()
-    }
+	if isGitHubError {
+		errDetails = ghError.Message
+	} else {
+		errDetails = err.Error()
+	}
 
 	env.Collector.Collect("Error", map[string]interface{}{
 		"pullRequestUrl": env.PullRequest.URL,

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"regexp"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 	"github.com/reviewpad/reviewpad/v3/utils/fmtio"
 )
 

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -25,18 +25,18 @@ func execLog(val string) {
 }
 
 func CollectError(env *Env, err error) {
-	var errDetails string
+	var errMsg string
 	ghError, isGitHubError := err.(*github.ErrorResponse)
 
 	if isGitHubError {
-		errDetails = ghError.Message
+		errMsg = ghError.Message
 	} else {
-		errDetails = err.Error()
+		errMsg = err.Error()
 	}
 
 	env.Collector.Collect("Error", map[string]interface{}{
 		"pullRequestUrl": env.PullRequest.URL,
-		"details":        errDetails,
+		"details":        errMsg,
 	})
 }
 

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"regexp"
 
+	"github.com/google/go-github/v42/github"
 	"github.com/reviewpad/reviewpad/v3/utils/fmtio"
 )
 
@@ -24,9 +25,18 @@ func execLog(val string) {
 }
 
 func CollectError(env *Env, err error) {
+    var errDetails string
+	ghError, isGitHubError := err.(*github.ErrorResponse)
+
+    if isGitHubError {
+        errDetails = ghError.Message
+    } else {
+        errDetails = err.Error()
+    }
+
 	env.Collector.Collect("Error", map[string]interface{}{
 		"pullRequestUrl": env.PullRequest.URL,
-		"details":        err.Error(),
+		"details":        errDetails,
 	})
 }
 

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEval_WhenRequestFails(t *testing.T) {
+func TestEval_WhenGitHubRequestsFails(t *testing.T) {
 	tests := map[string]struct {
 		inputReviewpadFilePath string
 		clientOptions          []mock.MockBackendOption

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -1,0 +1,538 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package engine_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v42/github"
+	"github.com/jinzhu/copier"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v3/engine"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var mockedReviewpadFile = &engine.ReviewpadFile{
+	Version:      "reviewpad.com/v1alpha",
+	Edition:      "professional",
+	Mode:         "silent",
+	IgnoreErrors: false,
+	Imports: []engine.PadImport{
+		{Url: "https://foo.bar/draft-rule.yml"},
+	},
+	Groups: []engine.PadGroup{
+		{
+			Name:        "seniors",
+			Description: "Senior developers",
+			Kind:        "developers",
+			Spec:        "[\"john\"]",
+		},
+	},
+	Rules: []engine.PadRule{
+		{
+			Name:        "tautology",
+			Kind:        "patch",
+			Description: "testing rule",
+			Spec:        "true",
+		},
+	},
+	Labels: map[string]engine.PadLabel{
+		"bug": {
+			Name:        "bug",
+			Color:       "f29513",
+			Description: "Something isn't working",
+		},
+	},
+	Workflows: []engine.PadWorkflow{
+		{
+			Name:        "test",
+			Description: "Test process",
+			AlwaysRun:   true,
+			Rules: []engine.PadWorkflowRule{
+				{
+					Rule:         "tautology",
+					ExtraActions: []string{},
+				},
+			},
+			Actions: []string{
+				"$action()",
+			},
+		},
+	},
+}
+
+func TestEval_WhenDryModeIsNotSetAndGetLabelRequestFails(t *testing.T) {
+	dryRun := false
+	failMessage := "GetLabelRequestFailed"
+	mockedCtx := engine.DefaultMockCtx
+	mockedClient := engine.MockGithubClient(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposLabelsByOwnerByRepoByName,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write(mock.MustMarshal(github.ErrorResponse{
+						Response: &http.Response{
+							StatusCode: 500,
+						},
+						Message: failMessage,
+					}))
+				}),
+			),
+		},
+	)
+	mockedCollector := engine.DefaultMockCollector
+	mockedEvent := engine.DefaultMockEventPayload
+	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
+
+	mockedAladinoInterpreter, err := aladino.NewInterpreter(
+		mockedCtx,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		aladino.MockBuiltIns(),
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
+	}
+
+	mockedEnv, err := engine.NewEvalEnv(
+		mockedCtx,
+		dryRun,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		mockedAladinoInterpreter,
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
+	}
+
+	gotProgram, err := engine.Eval(mockedReviewpadFile, mockedEnv)
+
+	assert.Nil(t, gotProgram)
+	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
+}
+
+func TestEval_WhenDryModeIsNotSetAndCreateLabelFails(t *testing.T) {
+	dryRun := false
+	failMessage := "CreateLabelRequestFailed"
+	mockedCtx := engine.DefaultMockCtx
+	mockedClient := engine.MockGithubClient(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposLabelsByOwnerByRepoByName,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write(mock.MustMarshal(github.ErrorResponse{
+						Response: &http.Response{
+							StatusCode: 404,
+						},
+                        Message: "Resource not found",
+					}))
+				}),
+			),
+			mock.WithRequestMatchHandler(
+				mock.PostReposLabelsByOwnerByRepo,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mock.WriteError(
+						w,
+						http.StatusInternalServerError,
+						failMessage,
+					)
+				}),
+			),
+		},
+	)
+	mockedCollector := engine.DefaultMockCollector
+	mockedEvent := engine.DefaultMockEventPayload
+	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
+
+	mockedAladinoInterpreter, err := aladino.NewInterpreter(
+		mockedCtx,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		aladino.MockBuiltIns(),
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
+	}
+
+	mockedEnv, err := engine.NewEvalEnv(
+		mockedCtx,
+		dryRun,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		mockedAladinoInterpreter,
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
+	}
+
+	gotProgram, err := engine.Eval(mockedReviewpadFile, mockedEnv)
+
+	assert.Nil(t, gotProgram)
+	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
+}
+
+func TestEval_WhenWorkflowRuleEvalExprFails(t *testing.T) {
+	dryRun := false
+	mockedCtx := engine.DefaultMockCtx
+	mockedClient := engine.MockGithubClient(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatch(
+				mock.GetReposLabelsByOwnerByRepoByName,
+				&github.Label{
+					Name: github.String("bug"),
+				},
+			),
+		},
+	)
+	mockedCollector := engine.DefaultMockCollector
+	mockedEvent := engine.DefaultMockEventPayload
+	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
+
+	otherReviewpadFile := &engine.ReviewpadFile{}
+	copier.Copy(otherReviewpadFile, mockedReviewpadFile)
+
+	executedWorkflow := engine.PadWorkflow{
+		Name:        "test",
+		Description: "Test process",
+		AlwaysRun:   true,
+		Rules: []engine.PadWorkflowRule{
+			{
+				Rule:         "tautology",
+				ExtraActions: []string{},
+			},
+		},
+		Actions: []string{
+			"$action()",
+		},
+	}
+
+	wrongTypedRule := engine.PadRule{
+		Name:        "tautology",
+		Kind:        "patch",
+		Description: "testing rule",
+		Spec:        "\"notBoolType\"",
+	}
+
+	otherReviewpadFile.Rules = []engine.PadRule{wrongTypedRule}
+	otherReviewpadFile.Workflows = []engine.PadWorkflow{executedWorkflow}
+
+	mockedAladinoInterpreter, err := aladino.NewInterpreter(
+		mockedCtx,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		aladino.MockBuiltIns(),
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
+	}
+
+	mockedEnv, err := engine.NewEvalEnv(
+		mockedCtx,
+		dryRun,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		mockedAladinoInterpreter,
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
+	}
+
+	gotProgram, err := engine.Eval(otherReviewpadFile, mockedEnv)
+
+	assert.Nil(t, gotProgram)
+	assert.EqualError(t, err, "expression \"notBoolType\" is not a condition")
+}
+
+func TestEval_WhenWorkflowIsTriggered(t *testing.T) {
+	dryRun := false
+	mockedCtx := engine.DefaultMockCtx
+	mockedClient := engine.MockGithubClient(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatch(
+				mock.GetReposLabelsByOwnerByRepoByName,
+				&github.Label{
+					Name: github.String("bug"),
+				},
+			),
+		},
+	)
+	mockedCollector := engine.DefaultMockCollector
+	mockedEvent := engine.DefaultMockEventPayload
+	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
+
+	otherReviewpadFile := &engine.ReviewpadFile{}
+	copier.Copy(otherReviewpadFile, mockedReviewpadFile)
+
+	executedWorkflow := engine.PadWorkflow{
+		Name:        "test",
+		Description: "Test process",
+		AlwaysRun:   false,
+		Rules: []engine.PadWorkflowRule{
+			{
+				Rule:         "tautology",
+				ExtraActions: []string{},
+			},
+		},
+		Actions: []string{
+			"$action()",
+		},
+	}
+
+	otherReviewpadFile.Workflows = []engine.PadWorkflow{executedWorkflow}
+
+	mockedAladinoInterpreter, err := aladino.NewInterpreter(
+		mockedCtx,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		aladino.MockBuiltIns(),
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
+	}
+
+	mockedEnv, err := engine.NewEvalEnv(
+		mockedCtx,
+		dryRun,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		mockedAladinoInterpreter,
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
+	}
+
+	gotProgram, err := engine.Eval(otherReviewpadFile, mockedEnv)
+
+	wantProgram := &engine.Program{
+		Statements: []*engine.Statement{
+			{
+				Code: executedWorkflow.Actions[0],
+				Metadata: &engine.Metadata{
+					Workflow:    executedWorkflow,
+					TriggeredBy: executedWorkflow.Rules,
+				},
+			},
+		},
+	}
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantProgram, gotProgram)
+}
+
+func TestEval_WhenWorkflowIsSkipped(t *testing.T) {
+	dryRun := false
+	mockedCtx := engine.DefaultMockCtx
+	mockedClient := engine.MockGithubClient(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatch(
+				mock.GetReposLabelsByOwnerByRepoByName,
+				&github.Label{
+					Name: github.String("bug"),
+				},
+			),
+		},
+	)
+	mockedCollector := engine.DefaultMockCollector
+	mockedEvent := engine.DefaultMockEventPayload
+	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
+
+	otherReviewpadFile := &engine.ReviewpadFile{}
+	copier.Copy(otherReviewpadFile, mockedReviewpadFile)
+
+	executedWorkflow := engine.PadWorkflow{
+		Name:        "test",
+		Description: "Test process",
+		AlwaysRun:   false,
+		Rules: []engine.PadWorkflowRule{
+			{
+				Rule:         "tautology",
+				ExtraActions: []string{},
+			},
+		},
+		Actions: []string{
+			"$action()",
+		},
+	}
+
+	rule := engine.PadRule{
+		Name:        "dummy-rule",
+		Kind:        "patch",
+		Description: "testing rule",
+		Spec:        "true",
+	}
+
+    otherReviewpadFile.Rules = append(otherReviewpadFile.Rules, rule)
+
+	otherReviewpadFile.Workflows = []engine.PadWorkflow{
+		executedWorkflow,
+		{
+			Name:        "test#2",
+			Description: "Test process x2",
+			AlwaysRun:   false,
+			Rules: []engine.PadWorkflowRule{
+				{
+					Rule:         "dummy-rule",
+					ExtraActions: []string{},
+				},
+			},
+			Actions: []string{
+				"$action2()",
+			},
+		},
+	}
+
+	mockedAladinoInterpreter, err := aladino.NewInterpreter(
+		mockedCtx,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		aladino.MockBuiltIns(),
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
+	}
+
+	mockedEnv, err := engine.NewEvalEnv(
+		mockedCtx,
+		dryRun,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		mockedAladinoInterpreter,
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
+	}
+
+	gotProgram, err := engine.Eval(otherReviewpadFile, mockedEnv)
+
+	wantProgram := &engine.Program{
+		Statements: []*engine.Statement{
+			{
+				Code: executedWorkflow.Actions[0],
+				Metadata: &engine.Metadata{
+					Workflow:    executedWorkflow,
+					TriggeredBy: executedWorkflow.Rules,
+				},
+			},
+		},
+	}
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantProgram, gotProgram)
+}
+
+func TestEval_WhenNoWorkflowRulesAreActivated(t *testing.T) {
+	dryRun := false
+	mockedCtx := engine.DefaultMockCtx
+	mockedClient := engine.MockGithubClient(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatch(
+				mock.GetReposLabelsByOwnerByRepoByName,
+				&github.Label{
+					Name: github.String("bug"),
+				},
+			),
+		},
+	)
+	mockedCollector := engine.DefaultMockCollector
+	mockedEvent := engine.DefaultMockEventPayload
+	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
+
+	otherReviewpadFile := &engine.ReviewpadFile{}
+	copier.Copy(otherReviewpadFile, mockedReviewpadFile)
+
+    notTriggeredRule := engine.PadRule{
+		Name:        "dummy-rule",
+		Kind:        "patch",
+		Description: "testing rule",
+		Spec:        "false",
+	}
+
+	analyzedWorkflow := engine.PadWorkflow{
+		Name:        "test",
+		Description: "Test process",
+		AlwaysRun:   false,
+		Rules: []engine.PadWorkflowRule{
+			{
+				Rule:         "dummy-rule",
+				ExtraActions: []string{},
+			},
+		},
+		Actions: []string{
+			"$action()",
+		},
+	}
+
+    otherReviewpadFile.Rules = []engine.PadRule{notTriggeredRule}
+	otherReviewpadFile.Workflows = []engine.PadWorkflow{analyzedWorkflow}
+
+	mockedAladinoInterpreter, err := aladino.NewInterpreter(
+		mockedCtx,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		aladino.MockBuiltIns(),
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
+	}
+
+	mockedEnv, err := engine.NewEvalEnv(
+		mockedCtx,
+		dryRun,
+		mockedClient,
+		nil,
+		mockedCollector,
+		mockedPullRequest,
+		mockedEvent,
+		mockedAladinoInterpreter,
+	)
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
+	}
+
+	gotProgram, err := engine.Eval(otherReviewpadFile, mockedEnv)
+
+    wantProgram := &engine.Program{Statements:[]*engine.Statement{}}
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantProgram, gotProgram)
+}

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -119,17 +119,7 @@ func TestEval(t *testing.T) {
 			clientOptions:          []mock.MockBackendOption{getLabelRequest("bug")},
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
-					engine.BuildStatement(
-						"$addLabel(\"test-unnamed-label\")",
-						engine.BuildMetadata(
-							engine.PadWorkflow{
-								Name:    "test-workflow",
-								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
-								Actions: []string{"$addLabel(\"test-unnamed-label\")"},
-							},
-							[]engine.PadWorkflowRule{{Rule: "tautology"}},
-						),
-					),
+					engine.BuildStatement("$addLabel(\"test-unnamed-label\")"),
 				},
 			),
 		},
@@ -138,17 +128,7 @@ func TestEval(t *testing.T) {
 			clientOptions:          []mock.MockBackendOption{getLabelRequest("bug")},
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
-					engine.BuildStatement(
-						"$addLabel(\"test-valid-label\")",
-						engine.BuildMetadata(
-							engine.PadWorkflow{
-								Name:    "test-workflow",
-								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
-								Actions: []string{"$addLabel(\"test-valid-label\")"},
-							},
-							[]engine.PadWorkflowRule{{Rule: "tautology"}},
-						),
-					),
+					engine.BuildStatement("$addLabel(\"test-valid-label\")"),
 				},
 			),
 		},
@@ -160,17 +140,7 @@ func TestEval(t *testing.T) {
 			},
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
-					engine.BuildStatement(
-						"$addLabel(\"test-valid-label\")",
-						engine.BuildMetadata(
-							engine.PadWorkflow{
-								Name:    "test-workflow",
-								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
-								Actions: []string{"$addLabel(\"test-valid-label\")"},
-							},
-							[]engine.PadWorkflowRule{{Rule: "tautology"}},
-						),
-					),
+					engine.BuildStatement("$addLabel(\"test-valid-label\")"),
 				},
 			),
 		},
@@ -180,17 +150,7 @@ func TestEval(t *testing.T) {
 			clientOptions:          []mock.MockBackendOption{getLabelRequest("test-valid-group")},
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
-					engine.BuildStatement(
-						"$addLabel(\"test-valid-group\")",
-						engine.BuildMetadata(
-							engine.PadWorkflow{
-								Name:    "test-workflow",
-								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
-								Actions: []string{"$addLabel(\"test-valid-group\")"},
-							},
-							[]engine.PadWorkflowRule{{Rule: "tautology"}},
-						),
-					),
+					engine.BuildStatement("$addLabel(\"test-valid-group\")"),
 				},
 			),
 		},
@@ -214,17 +174,7 @@ func TestEval(t *testing.T) {
 			inputReviewpadFilePath: "testdata/exec/reviewpad_with_one_activated_workflow.yml",
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
-					engine.BuildStatement(
-						"$addLabel(\"activate-one-workflow\")",
-						engine.BuildMetadata(
-							engine.PadWorkflow{
-								Name:    "activated-workflow",
-								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
-								Actions: []string{"$addLabel(\"activate-one-workflow\")"},
-							},
-							[]engine.PadWorkflowRule{{Rule: "tautology"}},
-						),
-					),
+					engine.BuildStatement("$addLabel(\"activate-one-workflow\")"),
 				},
 			),
 		},
@@ -232,29 +182,8 @@ func TestEval(t *testing.T) {
 			inputReviewpadFilePath: "testdata/exec/reviewpad_with_multiple_activated_workflows.yml",
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
-					engine.BuildStatement(
-						"$addLabel(\"activated-workflow-a\")",
-						engine.BuildMetadata(
-							engine.PadWorkflow{
-								Name:    "activated-workflow-a",
-								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
-								Actions: []string{"$addLabel(\"activated-workflow-a\")"},
-							},
-							[]engine.PadWorkflowRule{{Rule: "tautology"}},
-						),
-					),
-					engine.BuildStatement(
-						"$addLabel(\"activated-workflow-b\")",
-						engine.BuildMetadata(
-							engine.PadWorkflow{
-								Name:      "activated-workflow-b",
-								AlwaysRun: true,
-								Rules:     []engine.PadWorkflowRule{{Rule: "tautology"}},
-								Actions:   []string{"$addLabel(\"activated-workflow-b\")"},
-							},
-							[]engine.PadWorkflowRule{{Rule: "tautology"}},
-						),
-					),
+					engine.BuildStatement("$addLabel(\"activated-workflow-a\")"),
+					engine.BuildStatement("$addLabel(\"activated-workflow-b\")"),
 				},
 			),
 		},
@@ -262,48 +191,8 @@ func TestEval(t *testing.T) {
 			inputReviewpadFilePath: "testdata/exec/reviewpad_with_activated_workflow_with_extra_actions.yml",
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
-					engine.BuildStatement(
-						"$addLabel(\"activated-workflow\")",
-						engine.BuildMetadata(
-							engine.PadWorkflow{
-								Name: "activated-workflow",
-								Rules: []engine.PadWorkflowRule{
-									{
-										Rule:         "tautology",
-										ExtraActions: []string{"$addLabel(\"workflow-with-extra-actions\")"},
-									},
-								},
-								Actions: []string{"$addLabel(\"activated-workflow\")"},
-							},
-							[]engine.PadWorkflowRule{
-								{
-									Rule:         "tautology",
-									ExtraActions: []string{"$addLabel(\"workflow-with-extra-actions\")"},
-								},
-							},
-						),
-					),
-					engine.BuildStatement(
-						"$addLabel(\"workflow-with-extra-actions\")",
-						engine.BuildMetadata(
-							engine.PadWorkflow{
-								Name: "activated-workflow",
-								Rules: []engine.PadWorkflowRule{
-									{
-										Rule:         "tautology",
-										ExtraActions: []string{"$addLabel(\"workflow-with-extra-actions\")"},
-									},
-								},
-								Actions: []string{"$addLabel(\"activated-workflow\")"},
-							},
-							[]engine.PadWorkflowRule{
-								{
-									Rule:         "tautology",
-									ExtraActions: []string{"$addLabel(\"workflow-with-extra-actions\")"},
-								},
-							},
-						),
-					),
+					engine.BuildStatement("$addLabel(\"activated-workflow\")"),
+					engine.BuildStatement("$addLabel(\"workflow-with-extra-actions\")"),
 				},
 			),
 		},
@@ -311,17 +200,7 @@ func TestEval(t *testing.T) {
 			inputReviewpadFilePath: "testdata/exec/reviewpad_with_skipped_workflow.yml",
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
-					engine.BuildStatement(
-						"$addLabel(\"activated-workflow\")",
-						engine.BuildMetadata(
-							engine.PadWorkflow{
-								Name:    "activated-workflow",
-								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
-								Actions: []string{"$addLabel(\"activated-workflow\")"},
-							},
-							[]engine.PadWorkflowRule{{Rule: "tautology"}},
-						),
-					),
+					engine.BuildStatement("$addLabel(\"activated-workflow\")"),
 				},
 			),
 		},

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -9,558 +9,404 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-github/v42/github"
-	"github.com/jinzhu/copier"
+	"github.com/google/go-github/v45/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/reviewpad/reviewpad/v3/engine"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	"github.com/reviewpad/reviewpad/v3/utils/file"
 	"github.com/stretchr/testify/assert"
 )
 
-// TODO: Move this to resources/test/engine once #174 is accepted
-var mockedReviewpadFile = &engine.ReviewpadFile{
-	Version:      "reviewpad.com/v1alpha",
-	Edition:      "professional",
-	Mode:         "silent",
-	IgnoreErrors: false,
-	Imports: []engine.PadImport{
-		{Url: "https://foo.bar/draft-rule.yml"},
-	},
-	Groups: []engine.PadGroup{
-		{
-			Name:        "seniors",
-			Description: "Senior developers",
-			Kind:        "developers",
-			Spec:        "[\"john\"]",
-		},
-	},
-	Rules: []engine.PadRule{
-		{
-			Name:        "tautology",
-			Kind:        "patch",
-			Description: "testing rule",
-			Spec:        "true",
-		},
-	},
-	Labels: map[string]engine.PadLabel{
-		"bug": {
-			Name:        "bug",
-			Color:       "f29513",
-			Description: "Something isn't working",
-		},
-	},
-	Workflows: []engine.PadWorkflow{
-		{
-			Name:        "test-workflow",
-			Description: "Test process",
-			AlwaysRun:   true,
-			Rules: []engine.PadWorkflowRule{
-				{
-					Rule:         "tautology",
-					ExtraActions: []string{},
-				},
+func TestEval_WhenRequestFails(t *testing.T) {
+	tests := map[string]struct {
+		inputReviewpadFilePath string
+		clientOptions          []mock.MockBackendOption
+		wantErr                string
+	}{
+		"when get label request fails": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_valid_label.yml",
+			clientOptions: []mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.GetReposLabelsByOwnerByRepoByName,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write(mock.MustMarshal(github.ErrorResponse{
+							// An error response may also consist of a 404 status code.
+							// However, in this context, such response is not an error since it only means a label does not exist.
+							// So we force an error by setting it to a status code different than 404.
+							Response: &http.Response{
+								StatusCode: 500,
+							},
+							Message: "GetLabelRequestFailed",
+						}))
+					}),
+				),
 			},
-			Actions: []string{
-				"$action()",
-			},
+			wantErr: "GetLabelRequestFailed",
 		},
-	},
+		"when create label request fails": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_valid_label.yml",
+			clientOptions: []mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.GetReposLabelsByOwnerByRepoByName,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write(mock.MustMarshal(github.ErrorResponse{
+							Response: &http.Response{
+								StatusCode: 404,
+							},
+							Message: "Resource not found",
+						}))
+					}),
+				),
+				mock.WithRequestMatchHandler(
+					mock.PostReposLabelsByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						mock.WriteError(
+							w,
+							http.StatusInternalServerError,
+							"CreateLabelRequestFailed",
+						)
+					}),
+				),
+			},
+			wantErr: "CreateLabelRequestFailed",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedClient := engine.MockGithubClient(test.clientOptions)
+
+			mockedAladinoInterpreter, err := mockDefaultAladinoInterpreterWith(mockedClient)
+			if err != nil {
+				assert.FailNow(t, "mockDefaultAladinoInterpreterWith: %v", err)
+			}
+
+			mockedEnv, err := engine.MockDefaultEnvWith(mockedClient, mockedAladinoInterpreter)
+			if err != nil {
+				assert.FailNow(t, "engine MockDefaultEnvWith: %v", err)
+			}
+
+			reviewpadFileData, err := file.LoadReviewpadFile(test.inputReviewpadFilePath)
+			if err != nil {
+				assert.FailNow(t, "Error reading reviewpad file: %v", err)
+			}
+
+			reviewpadFile, err := file.ParseReviewpadFile(reviewpadFileData)
+			if err != nil {
+				assert.FailNow(t, "Error parsing reviewpad file: %v", err)
+			}
+
+			gotProgram, err := engine.Eval(reviewpadFile, mockedEnv)
+
+			assert.Nil(t, gotProgram)
+			assert.Equal(t, err.(*github.ErrorResponse).Message, test.wantErr)
+		})
+	}
 }
 
-func TestEval_WhenDryModeIsNotSetAndGetLabelRequestFails(t *testing.T) {
-	failMessage := "GetLabelRequestFailed"
-	mockedClient := engine.MockGithubClient(
-		[]mock.MockBackendOption{
-			mock.WithRequestMatchHandler(
-				mock.GetReposLabelsByOwnerByRepoByName,
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusInternalServerError)
-					w.Write(mock.MustMarshal(github.ErrorResponse{
-						// An error response may also consist of a 404 status code.
-						// However, in this context, such response is not an error since it only means a label does not exist.
-						// So we force an error by setting it to a status code different than 404.
-						Response: &http.Response{
-							StatusCode: 500,
-						},
-						Message: failMessage,
-					}))
-				}),
+func TestEval(t *testing.T) {
+	tests := map[string]struct {
+		inputReviewpadFilePath string
+		clientOptions          []mock.MockBackendOption
+		wantProgram            *engine.Program
+		wantErr                string
+	}{
+		// Label use cases
+		"when label has no name": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_unnamed_label.yml",
+			clientOptions:          []mock.MockBackendOption{getLabelRequest("bug")},
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(
+						"$addLabel(\"test-unnamed-label\")",
+						engine.BuildMetadata(
+							engine.PadWorkflow{
+								Name:    "test-workflow",
+								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
+								Actions: []string{"$addLabel(\"test-unnamed-label\")"},
+							},
+							[]engine.PadWorkflowRule{{Rule: "tautology"}},
+						),
+					),
+				},
 			),
 		},
-	)
+		"when label exists": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_valid_label.yml",
+			clientOptions:          []mock.MockBackendOption{getLabelRequest("bug")},
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(
+						"$addLabel(\"test-valid-label\")",
+						engine.BuildMetadata(
+							engine.PadWorkflow{
+								Name:    "test-workflow",
+								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
+								Actions: []string{"$addLabel(\"test-valid-label\")"},
+							},
+							[]engine.PadWorkflowRule{{Rule: "tautology"}},
+						),
+					),
+				},
+			),
+		},
+		"when label does not exist": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_valid_label.yml",
+			clientOptions: []mock.MockBackendOption{
+				getLabelRequest(""),
+				createLabelRequest("bug", "f29513", ""),
+			},
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(
+						"$addLabel(\"test-valid-label\")",
+						engine.BuildMetadata(
+							engine.PadWorkflow{
+								Name:    "test-workflow",
+								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
+								Actions: []string{"$addLabel(\"test-valid-label\")"},
+							},
+							[]engine.PadWorkflowRule{{Rule: "tautology"}},
+						),
+					),
+				},
+			),
+		},
+		// Group use cases
+		"when group is valid": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_valid_group.yml",
+			clientOptions:          []mock.MockBackendOption{getLabelRequest("test-valid-group")},
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(
+						"$addLabel(\"test-valid-group\")",
+						engine.BuildMetadata(
+							engine.PadWorkflow{
+								Name:    "test-workflow",
+								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
+								Actions: []string{"$addLabel(\"test-valid-group\")"},
+							},
+							[]engine.PadWorkflowRule{{Rule: "tautology"}},
+						),
+					),
+				},
+			),
+		},
+		"when group is invalid": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_invalid_group.yml",
+			clientOptions:          []mock.MockBackendOption{getLabelRequest("test-invalid-group")},
+			wantErr:                "ProcessGroup:evalGroup expression is not a valid group",
+		},
+		// Workflow use cases
+		"when workflow is invalid": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_invalid_workflow.yml",
+			wantErr:                "expression 1 is not a condition",
+		},
+		"when no workflow is activated": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_no_activated_workflows.yml",
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{},
+			),
+		},
+		"when one workflow is activated": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_one_activated_workflow.yml",
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(
+						"$addLabel(\"activate-one-workflow\")",
+						engine.BuildMetadata(
+							engine.PadWorkflow{
+								Name:    "activated-workflow",
+								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
+								Actions: []string{"$addLabel(\"activate-one-workflow\")"},
+							},
+							[]engine.PadWorkflowRule{{Rule: "tautology"}},
+						),
+					),
+				},
+			),
+		},
+		"when multiple workflows are activated": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_multiple_activated_workflows.yml",
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(
+						"$addLabel(\"activated-workflow-a\")",
+						engine.BuildMetadata(
+							engine.PadWorkflow{
+								Name:    "activated-workflow-a",
+								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
+								Actions: []string{"$addLabel(\"activated-workflow-a\")"},
+							},
+							[]engine.PadWorkflowRule{{Rule: "tautology"}},
+						),
+					),
+					engine.BuildStatement(
+						"$addLabel(\"activated-workflow-b\")",
+						engine.BuildMetadata(
+							engine.PadWorkflow{
+								Name:      "activated-workflow-b",
+								AlwaysRun: true,
+								Rules:     []engine.PadWorkflowRule{{Rule: "tautology"}},
+								Actions:   []string{"$addLabel(\"activated-workflow-b\")"},
+							},
+							[]engine.PadWorkflowRule{{Rule: "tautology"}},
+						),
+					),
+				},
+			),
+		},
+		"when workflow is activated and has extra actions": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_activated_workflow_with_extra_actions.yml",
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(
+						"$addLabel(\"activated-workflow\")",
+						engine.BuildMetadata(
+							engine.PadWorkflow{
+								Name: "activated-workflow",
+								Rules: []engine.PadWorkflowRule{
+									{
+										Rule:         "tautology",
+										ExtraActions: []string{"$addLabel(\"workflow-with-extra-actions\")"},
+									},
+								},
+								Actions: []string{"$addLabel(\"activated-workflow\")"},
+							},
+							[]engine.PadWorkflowRule{
+								{
+									Rule:         "tautology",
+									ExtraActions: []string{"$addLabel(\"workflow-with-extra-actions\")"},
+								},
+							},
+						),
+					),
+					engine.BuildStatement(
+						"$addLabel(\"workflow-with-extra-actions\")",
+						engine.BuildMetadata(
+							engine.PadWorkflow{
+								Name: "activated-workflow",
+								Rules: []engine.PadWorkflowRule{
+									{
+										Rule:         "tautology",
+										ExtraActions: []string{"$addLabel(\"workflow-with-extra-actions\")"},
+									},
+								},
+								Actions: []string{"$addLabel(\"activated-workflow\")"},
+							},
+							[]engine.PadWorkflowRule{
+								{
+									Rule:         "tautology",
+									ExtraActions: []string{"$addLabel(\"workflow-with-extra-actions\")"},
+								},
+							},
+						),
+					),
+				},
+			),
+		},
+		"when workflow is skipped": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_skipped_workflow.yml",
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(
+						"$addLabel(\"activated-workflow\")",
+						engine.BuildMetadata(
+							engine.PadWorkflow{
+								Name:    "activated-workflow",
+								Rules:   []engine.PadWorkflowRule{{Rule: "tautology"}},
+								Actions: []string{"$addLabel(\"activated-workflow\")"},
+							},
+							[]engine.PadWorkflowRule{{Rule: "tautology"}},
+						),
+					),
+				},
+			),
+		},
+	}
 
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedClient := engine.MockGithubClient(test.clientOptions)
+
+			mockedAladinoInterpreter, err := mockDefaultAladinoInterpreterWith(mockedClient)
+			if err != nil {
+				assert.FailNow(t, "mockDefaultAladinoInterpreterWith: %v", err)
+			}
+
+			mockedEnv, err := engine.MockDefaultEnvWith(mockedClient, mockedAladinoInterpreter)
+			if err != nil {
+				assert.FailNow(t, "engine MockDefaultEnvWith: %v", err)
+			}
+
+			reviewpadFileData, err := file.LoadReviewpadFile(test.inputReviewpadFilePath)
+			if err != nil {
+				assert.FailNow(t, "Error reading reviewpad file: %v", err)
+			}
+
+			reviewpadFile, err := file.ParseReviewpadFile(reviewpadFileData)
+			if err != nil {
+				assert.FailNow(t, "Error parsing reviewpad file: %v", err)
+			}
+
+			gotProgram, gotErr := engine.Eval(reviewpadFile, mockedEnv)
+
+			if gotErr != nil && gotErr.Error() != test.wantErr {
+				assert.FailNow(t, "Load() error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+			assert.Equal(t, test.wantProgram, gotProgram)
+		})
+	}
+}
+
+func mockDefaultAladinoInterpreterWith(client *github.Client) (engine.Interpreter, error) {
 	dryRun := false
-	mockedCtx := engine.DefaultMockCtx
-	mockedCollector := engine.DefaultMockCollector
-	mockedEvent := engine.DefaultMockEventPayload
-	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
-
 	mockedAladinoInterpreter, err := aladino.NewInterpreter(
-		mockedCtx,
+		engine.DefaultMockCtx,
 		dryRun,
-		mockedClient,
+		client,
 		// TODO: add mocked github GQL client
 		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
+		engine.DefaultMockCollector,
+		engine.GetDefaultMockPullRequestDetails(),
+		engine.DefaultMockEventPayload,
 		aladino.MockBuiltIns(),
 	)
 	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
+		return nil, fmt.Errorf("aladino NewInterpreter returned unexpected error: %v", err)
 	}
 
-	mockedEnv, err := engine.NewEvalEnv(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		mockedAladinoInterpreter,
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
-	}
-
-	gotProgram, err := engine.Eval(mockedReviewpadFile, mockedEnv)
-
-	assert.Nil(t, gotProgram)
-	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
+	return mockedAladinoInterpreter, nil
 }
 
-func TestEval_WhenDryModeIsNotSetAndCreateLabelRequestFails(t *testing.T) {
-	failMessage := "CreateLabelRequestFailed"
-	mockedClient := engine.MockGithubClient(
-		[]mock.MockBackendOption{
-			mock.WithRequestMatchHandler(
-				mock.GetReposLabelsByOwnerByRepoByName,
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusInternalServerError)
-					w.Write(mock.MustMarshal(github.ErrorResponse{
-						Response: &http.Response{
-							StatusCode: 404,
-						},
-						Message: "Resource not found",
-					}))
-				}),
-			),
-			mock.WithRequestMatchHandler(
-				mock.PostReposLabelsByOwnerByRepo,
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					mock.WriteError(
-						w,
-						http.StatusInternalServerError,
-						failMessage,
-					)
-				}),
-			),
-		},
-	)
+func getLabelRequest(label string) mock.MockBackendOption {
+	var labelsMockedResponse *github.Label
 
-	dryRun := false
-	mockedCtx := engine.DefaultMockCtx
-	mockedCollector := engine.DefaultMockCollector
-	mockedEvent := engine.DefaultMockEventPayload
-	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
-
-	mockedAladinoInterpreter, err := aladino.NewInterpreter(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		aladino.MockBuiltIns(),
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
+	if label != "" {
+		labelsMockedResponse = &github.Label{
+			Name: github.String(label),
+		}
+	} else {
+		labelsMockedResponse = &github.Label{}
 	}
 
-	mockedEnv, err := engine.NewEvalEnv(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		mockedAladinoInterpreter,
+	return mock.WithRequestMatch(
+		mock.GetReposLabelsByOwnerByRepoByName,
+		labelsMockedResponse,
 	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
-	}
-
-	gotProgram, err := engine.Eval(mockedReviewpadFile, mockedEnv)
-
-	assert.Nil(t, gotProgram)
-	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
 }
 
-func TestEval_WhenWorkflowRuleEvalExprFails(t *testing.T) {
-	mockedClient := engine.MockGithubClient(
-		[]mock.MockBackendOption{
-			mock.WithRequestMatch(
-				mock.GetReposLabelsByOwnerByRepoByName,
-				&github.Label{
-					Name: github.String("bug"),
-				},
-			),
-		},
+func createLabelRequest(name, color, description string) mock.MockBackendOption {
+	labelsMockedResponse := &github.Label{
+		Name:        github.String(name),
+		Color:       github.String(color),
+		Description: github.String(description),
+	}
+
+	return mock.WithRequestMatch(
+		mock.PostReposLabelsByOwnerByRepo,
+		labelsMockedResponse,
 	)
-
-	dryRun := false
-	mockedCtx := engine.DefaultMockCtx
-	mockedCollector := engine.DefaultMockCollector
-	mockedEvent := engine.DefaultMockEventPayload
-	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
-
-	otherReviewpadFile := &engine.ReviewpadFile{}
-	copier.Copy(otherReviewpadFile, mockedReviewpadFile)
-
-	executedWorkflow := engine.PadWorkflow{
-		Name:        "test-workflow",
-		Description: "Test process",
-		AlwaysRun:   true,
-		Rules: []engine.PadWorkflowRule{
-			{
-				Rule:         "wrong-typed-rule",
-				ExtraActions: []string{},
-			},
-		},
-		Actions: []string{
-			"$action()",
-		},
-	}
-
-	wrongTypedRule := engine.PadRule{
-		Name:        "wrong-typed-rule",
-		Kind:        "patch",
-		Description: "Rule with non boolean spec",
-		Spec:        "\"notBoolType\"",
-	}
-
-	otherReviewpadFile.Rules = []engine.PadRule{wrongTypedRule}
-	otherReviewpadFile.Workflows = []engine.PadWorkflow{executedWorkflow}
-
-	mockedAladinoInterpreter, err := aladino.NewInterpreter(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		aladino.MockBuiltIns(),
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
-	}
-
-	mockedEnv, err := engine.NewEvalEnv(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		mockedAladinoInterpreter,
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
-	}
-
-	gotProgram, err := engine.Eval(otherReviewpadFile, mockedEnv)
-
-	assert.Nil(t, gotProgram)
-	assert.EqualError(t, err, "expression \"notBoolType\" is not a condition")
-}
-
-func TestEval_WhenWorkflowIsTriggered(t *testing.T) {
-	mockedClient := engine.MockGithubClient(
-		[]mock.MockBackendOption{
-			mock.WithRequestMatch(
-				mock.GetReposLabelsByOwnerByRepoByName,
-				&github.Label{
-					Name: github.String("bug"),
-				},
-			),
-		},
-	)
-
-	dryRun := false
-	mockedCtx := engine.DefaultMockCtx
-	mockedCollector := engine.DefaultMockCollector
-	mockedEvent := engine.DefaultMockEventPayload
-	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
-
-	otherReviewpadFile := &engine.ReviewpadFile{}
-	copier.Copy(otherReviewpadFile, mockedReviewpadFile)
-
-	executedWorkflow := engine.PadWorkflow{
-		Name:        "test-workflow",
-		Description: "Test process",
-		AlwaysRun:   false,
-		Rules: []engine.PadWorkflowRule{
-			{
-				Rule:         "tautology",
-				ExtraActions: []string{},
-			},
-		},
-		Actions: []string{
-			"$action()",
-		},
-	}
-
-	otherReviewpadFile.Workflows = []engine.PadWorkflow{executedWorkflow}
-
-	mockedAladinoInterpreter, err := aladino.NewInterpreter(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		aladino.MockBuiltIns(),
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
-	}
-
-	mockedEnv, err := engine.NewEvalEnv(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		mockedAladinoInterpreter,
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
-	}
-
-	gotProgram, err := engine.Eval(otherReviewpadFile, mockedEnv)
-
-	wantProgram := &engine.Program{
-		Statements: []*engine.Statement{
-			{
-				Code: executedWorkflow.Actions[0],
-				Metadata: &engine.Metadata{
-					Workflow:    executedWorkflow,
-					TriggeredBy: executedWorkflow.Rules,
-				},
-			},
-		},
-	}
-
-	assert.Nil(t, err)
-	assert.Equal(t, wantProgram, gotProgram)
-}
-
-func TestEval_WhenWorkflowIsSkipped(t *testing.T) {
-	mockedClient := engine.MockGithubClient(
-		[]mock.MockBackendOption{
-			mock.WithRequestMatch(
-				mock.GetReposLabelsByOwnerByRepoByName,
-				&github.Label{
-					Name: github.String("bug"),
-				},
-			),
-		},
-	)
-
-	dryRun := false
-	mockedCtx := engine.DefaultMockCtx
-	mockedCollector := engine.DefaultMockCollector
-	mockedEvent := engine.DefaultMockEventPayload
-	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
-
-	otherReviewpadFile := &engine.ReviewpadFile{}
-	copier.Copy(otherReviewpadFile, mockedReviewpadFile)
-
-	executedWorkflow := engine.PadWorkflow{
-		Name:        "test-workflow-A",
-		Description: "Test process A",
-		AlwaysRun:   false,
-		Rules: []engine.PadWorkflowRule{
-			{
-				Rule:         "tautology",
-				ExtraActions: []string{},
-			},
-		},
-		Actions: []string{
-			"$actionA()",
-		},
-	}
-
-	rule := engine.PadRule{
-		Name:        "dummy-rule",
-		Kind:        "patch",
-		Description: "testing rule",
-		Spec:        "true",
-	}
-
-	otherReviewpadFile.Rules = append(otherReviewpadFile.Rules, rule)
-
-	otherReviewpadFile.Workflows = []engine.PadWorkflow{
-		executedWorkflow,
-		{
-			Name:        "test-workflow-B",
-			Description: "Test process B",
-			AlwaysRun:   false,
-			Rules: []engine.PadWorkflowRule{
-				{
-					Rule:         "dummy-rule",
-					ExtraActions: []string{},
-				},
-			},
-			Actions: []string{
-				"$actionB()",
-			},
-		},
-	}
-
-	mockedAladinoInterpreter, err := aladino.NewInterpreter(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		aladino.MockBuiltIns(),
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
-	}
-
-	mockedEnv, err := engine.NewEvalEnv(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		mockedAladinoInterpreter,
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
-	}
-
-	gotProgram, err := engine.Eval(otherReviewpadFile, mockedEnv)
-
-	wantProgram := &engine.Program{
-		Statements: []*engine.Statement{
-			{
-				Code: executedWorkflow.Actions[0],
-				Metadata: &engine.Metadata{
-					Workflow:    executedWorkflow,
-					TriggeredBy: executedWorkflow.Rules,
-				},
-			},
-		},
-	}
-
-	assert.Nil(t, err)
-	assert.Equal(t, wantProgram, gotProgram)
-}
-
-func TestEval_WhenNoWorkflowRulesAreActivated(t *testing.T) {
-	mockedClient := engine.MockGithubClient(
-		[]mock.MockBackendOption{
-			mock.WithRequestMatch(
-				mock.GetReposLabelsByOwnerByRepoByName,
-				&github.Label{
-					Name: github.String("bug"),
-				},
-			),
-		},
-	)
-
-	dryRun := false
-	mockedCtx := engine.DefaultMockCtx
-	mockedCollector := engine.DefaultMockCollector
-	mockedEvent := engine.DefaultMockEventPayload
-	mockedPullRequest := engine.GetDefaultMockPullRequestDetails()
-
-	otherReviewpadFile := &engine.ReviewpadFile{}
-	copier.Copy(otherReviewpadFile, mockedReviewpadFile)
-
-	notTriggeredRule := engine.PadRule{
-		Name:        "dummy-rule",
-		Kind:        "patch",
-		Description: "testing rule",
-		Spec:        "false",
-	}
-
-	analyzedWorkflow := engine.PadWorkflow{
-		Name:        "test-workflow",
-		Description: "Test process",
-		AlwaysRun:   false,
-		Rules: []engine.PadWorkflowRule{
-			{
-				Rule:         "dummy-rule",
-				ExtraActions: []string{},
-			},
-		},
-		Actions: []string{
-			"$action()",
-		},
-	}
-
-	otherReviewpadFile.Rules = []engine.PadRule{notTriggeredRule}
-	otherReviewpadFile.Workflows = []engine.PadWorkflow{analyzedWorkflow}
-
-	mockedAladinoInterpreter, err := aladino.NewInterpreter(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		aladino.MockBuiltIns(),
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("aladino NewInterpreter returned unexpected error: %v", err))
-	}
-
-	mockedEnv, err := engine.NewEvalEnv(
-		mockedCtx,
-		dryRun,
-		mockedClient,
-		// TODO: add mocked github GQL client
-		nil,
-		mockedCollector,
-		mockedPullRequest,
-		mockedEvent,
-		mockedAladinoInterpreter,
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("NewEvalEnv returned unexpected error: %v", err))
-	}
-
-	gotProgram, err := engine.Eval(otherReviewpadFile, mockedEnv)
-
-	wantProgram := &engine.Program{Statements: []*engine.Statement{}}
-
-	assert.Nil(t, err)
-	assert.Equal(t, wantProgram, gotProgram)
 }

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -92,6 +92,7 @@ func TestEval_WhenDryModeIsNotSetAndGetLabelRequestFails(t *testing.T) {
 
 	mockedAladinoInterpreter, err := aladino.NewInterpreter(
 		mockedCtx,
+		dryRun,
 		mockedClient,
 		nil,
 		mockedCollector,
@@ -137,7 +138,7 @@ func TestEval_WhenDryModeIsNotSetAndCreateLabelFails(t *testing.T) {
 						Response: &http.Response{
 							StatusCode: 404,
 						},
-                        Message: "Resource not found",
+						Message: "Resource not found",
 					}))
 				}),
 			),
@@ -159,6 +160,7 @@ func TestEval_WhenDryModeIsNotSetAndCreateLabelFails(t *testing.T) {
 
 	mockedAladinoInterpreter, err := aladino.NewInterpreter(
 		mockedCtx,
+		dryRun,
 		mockedClient,
 		nil,
 		mockedCollector,
@@ -237,6 +239,7 @@ func TestEval_WhenWorkflowRuleEvalExprFails(t *testing.T) {
 
 	mockedAladinoInterpreter, err := aladino.NewInterpreter(
 		mockedCtx,
+		dryRun,
 		mockedClient,
 		nil,
 		mockedCollector,
@@ -307,6 +310,7 @@ func TestEval_WhenWorkflowIsTriggered(t *testing.T) {
 
 	mockedAladinoInterpreter, err := aladino.NewInterpreter(
 		mockedCtx,
+		dryRun,
 		mockedClient,
 		nil,
 		mockedCollector,
@@ -392,7 +396,7 @@ func TestEval_WhenWorkflowIsSkipped(t *testing.T) {
 		Spec:        "true",
 	}
 
-    otherReviewpadFile.Rules = append(otherReviewpadFile.Rules, rule)
+	otherReviewpadFile.Rules = append(otherReviewpadFile.Rules, rule)
 
 	otherReviewpadFile.Workflows = []engine.PadWorkflow{
 		executedWorkflow,
@@ -414,6 +418,7 @@ func TestEval_WhenWorkflowIsSkipped(t *testing.T) {
 
 	mockedAladinoInterpreter, err := aladino.NewInterpreter(
 		mockedCtx,
+		dryRun,
 		mockedClient,
 		nil,
 		mockedCollector,
@@ -477,7 +482,7 @@ func TestEval_WhenNoWorkflowRulesAreActivated(t *testing.T) {
 	otherReviewpadFile := &engine.ReviewpadFile{}
 	copier.Copy(otherReviewpadFile, mockedReviewpadFile)
 
-    notTriggeredRule := engine.PadRule{
+	notTriggeredRule := engine.PadRule{
 		Name:        "dummy-rule",
 		Kind:        "patch",
 		Description: "testing rule",
@@ -499,11 +504,12 @@ func TestEval_WhenNoWorkflowRulesAreActivated(t *testing.T) {
 		},
 	}
 
-    otherReviewpadFile.Rules = []engine.PadRule{notTriggeredRule}
+	otherReviewpadFile.Rules = []engine.PadRule{notTriggeredRule}
 	otherReviewpadFile.Workflows = []engine.PadWorkflow{analyzedWorkflow}
 
 	mockedAladinoInterpreter, err := aladino.NewInterpreter(
 		mockedCtx,
+		dryRun,
 		mockedClient,
 		nil,
 		mockedCollector,
@@ -531,7 +537,7 @@ func TestEval_WhenNoWorkflowRulesAreActivated(t *testing.T) {
 
 	gotProgram, err := engine.Eval(otherReviewpadFile, mockedEnv)
 
-    wantProgram := &engine.Program{Statements:[]*engine.Statement{}}
+	wantProgram := &engine.Program{Statements: []*engine.Statement{}}
 
 	assert.Nil(t, err)
 	assert.Equal(t, wantProgram, gotProgram)

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/google/go-github/v45/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/reviewpad/reviewpad/v3/engine"
+	"github.com/reviewpad/reviewpad/v3/engine/testutils"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
-	"github.com/reviewpad/reviewpad/v3/utils/file"
+	"github.com/reviewpad/reviewpad/v3/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -82,17 +83,17 @@ func TestEval_WhenGitHubRequestsFail(t *testing.T) {
 				assert.FailNow(t, "mockDefaultAladinoInterpreterWith: %v", err)
 			}
 
-			mockedEnv, err := engine.MockDefaultEnvWith(mockedClient, mockedAladinoInterpreter)
+			mockedEnv, err := engine.MockEnvWith(mockedClient, mockedAladinoInterpreter)
 			if err != nil {
 				assert.FailNow(t, "engine MockDefaultEnvWith: %v", err)
 			}
 
-			reviewpadFileData, err := file.LoadReviewpadFile(test.inputReviewpadFilePath)
+			reviewpadFileData, err := utils.LoadFile(test.inputReviewpadFilePath)
 			if err != nil {
 				assert.FailNow(t, "Error reading reviewpad file: %v", err)
 			}
 
-			reviewpadFile, err := file.ParseReviewpadFile(reviewpadFileData)
+			reviewpadFile, err := testutils.ParseReviewpadFile(reviewpadFileData)
 			if err != nil {
 				assert.FailNow(t, "Error parsing reviewpad file: %v", err)
 			}
@@ -211,17 +212,17 @@ func TestEval(t *testing.T) {
 				assert.FailNow(t, "mockDefaultAladinoInterpreterWith: %v", err)
 			}
 
-			mockedEnv, err := engine.MockDefaultEnvWith(mockedClient, mockedAladinoInterpreter)
+			mockedEnv, err := engine.MockEnvWith(mockedClient, mockedAladinoInterpreter)
 			if err != nil {
 				assert.FailNow(t, "engine MockDefaultEnvWith: %v", err)
 			}
 
-			reviewpadFileData, err := file.LoadReviewpadFile(test.inputReviewpadFilePath)
+			reviewpadFileData, err := utils.LoadFile(test.inputReviewpadFilePath)
 			if err != nil {
 				assert.FailNow(t, "Error reading reviewpad file: %v", err)
 			}
 
-			reviewpadFile, err := file.ParseReviewpadFile(reviewpadFileData)
+			reviewpadFile, err := testutils.ParseReviewpadFile(reviewpadFileData)
 			if err != nil {
 				assert.FailNow(t, "Error parsing reviewpad file: %v", err)
 			}

--- a/engine/mocks.go
+++ b/engine/mocks.go
@@ -66,15 +66,16 @@ func GetDefaultMockPullRequestDetails() *github.PullRequest {
 }
 
 func getDefaultMockPullRequestFileList() *[]*github.CommitFile {
-	prRepoName := defaultMockPrRepoName
 	return &[]*github.CommitFile{
 		{
-			Filename: github.String(fmt.Sprintf("%v/file1.ts", prRepoName)),
-			Patch: github.String(`@@ -2,9 +2,11 @@ package main
+			Filename: github.String(fmt.Sprintf("%v/file1.ts", defaultMockPrRepoName)),
+			Patch: github.String(
+				`@@ -2,9 +2,11 @@ package main
 - func previous1() {
 + func new1() {
 +
-return`),
+return`,
+			),
 		},
 	}
 }
@@ -100,7 +101,7 @@ func MockGithubClient(clientOptions []mock.MockBackendOption) *github.Client {
 	return github.NewClient(mock.NewMockedHTTPClient(mocks...))
 }
 
-func MockDefaultEnvWith(client *github.Client, mockedAladinoInterpreter Interpreter) (*Env, error) {
+func MockEnvWith(client *github.Client, interpreter Interpreter) (*Env, error) {
 	dryRun := false
 	mockedEnv, err := NewEvalEnv(
 		DefaultMockCtx,
@@ -111,7 +112,7 @@ func MockDefaultEnvWith(client *github.Client, mockedAladinoInterpreter Interpre
 		DefaultMockCollector,
 		GetDefaultMockPullRequestDetails(),
 		DefaultMockEventPayload,
-		mockedAladinoInterpreter,
+		interpreter,
 	)
 
 	if err != nil {

--- a/engine/mocks.go
+++ b/engine/mocks.go
@@ -99,3 +99,24 @@ func MockGithubClient(clientOptions []mock.MockBackendOption) *github.Client {
 
 	return github.NewClient(mock.NewMockedHTTPClient(mocks...))
 }
+
+func MockDefaultEnvWith(client *github.Client, mockedAladinoInterpreter Interpreter) (*Env, error) {
+	dryRun := false
+	mockedEnv, err := NewEvalEnv(
+		DefaultMockCtx,
+		dryRun,
+		client,
+		// TODO: add mocked github GQL client
+		nil,
+		DefaultMockCollector,
+		GetDefaultMockPullRequestDetails(),
+		DefaultMockEventPayload,
+		mockedAladinoInterpreter,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("NewEvalEnv returned unexpected error: %v", err)
+	}
+
+	return mockedEnv, nil
+}

--- a/engine/mocks.go
+++ b/engine/mocks.go
@@ -79,14 +79,6 @@ return`),
 	}
 }
 
-func mockDefaultHttpClient(clientOptions []mock.MockBackendOption) *http.Client {
-	return mockHttpClientWith(clientOptions...)
-}
-
-func mockHttpClientWith(clientOptions ...mock.MockBackendOption) *http.Client {
-	return mock.NewMockedHTTPClient(clientOptions...)
-}
-
 func MockGithubClient(clientOptions []mock.MockBackendOption) *github.Client {
 	defaultMocks := []mock.MockBackendOption{
 		mock.WithRequestMatchHandler(
@@ -105,5 +97,5 @@ func MockGithubClient(clientOptions []mock.MockBackendOption) *github.Client {
 
 	mocks := append(clientOptions, defaultMocks...)
 
-	return github.NewClient(mockDefaultHttpClient(mocks))
+	return github.NewClient(mock.NewMockedHTTPClient(mocks...))
 }

--- a/engine/mocks.go
+++ b/engine/mocks.go
@@ -42,7 +42,7 @@ func GetDefaultMockPullRequestDetails() *github.PullRequest {
 		CreatedAt: &prDate,
 		Number:    github.Int(prNum),
 		URL:       github.String(prUrl),
-        Head: &github.PullRequestBranch{
+		Head: &github.PullRequestBranch{
 			Repo: &github.Repository{
 				Owner: &github.User{
 					Login: github.String("john"),
@@ -88,22 +88,22 @@ func mockHttpClientWith(clientOptions ...mock.MockBackendOption) *http.Client {
 }
 
 func MockGithubClient(clientOptions []mock.MockBackendOption) *github.Client {
-    defaultMocks := []mock.MockBackendOption{
-        mock.WithRequestMatchHandler(
-				mock.GetReposPullsByOwnerByRepoByPullNumber,
-				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.Write(mock.MustMarshal(GetDefaultMockPullRequestDetails()))
-				}),
-			),
-			mock.WithRequestMatchHandler(
-				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
-				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.Write(mock.MustMarshal(getDefaultMockPullRequestFileList()))
-				}),
-			),
-    }
+	defaultMocks := []mock.MockBackendOption{
+		mock.WithRequestMatchHandler(
+			mock.GetReposPullsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Write(mock.MustMarshal(GetDefaultMockPullRequestDetails()))
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Write(mock.MustMarshal(getDefaultMockPullRequestFileList()))
+			}),
+		),
+	}
 
-    mocks := append(clientOptions, defaultMocks...)
+	mocks := append(clientOptions, defaultMocks...)
 
 	return github.NewClient(mockDefaultHttpClient(mocks))
 }

--- a/engine/mocks.go
+++ b/engine/mocks.go
@@ -6,6 +6,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -17,6 +18,8 @@ import (
 // Use only for tests
 const defaultMockPrID = 1234
 const defaultMockPrNum = 6
+const defaultMockPrOwner = "foobar"
+const defaultMockPrRepoName = "default-mock-repo"
 
 // Use only for tests
 var DefaultMockCtx = context.Background()
@@ -26,7 +29,10 @@ var DefaultMockEventPayload = &github.CheckRunEvent{}
 func GetDefaultMockPullRequestDetails() *github.PullRequest {
 	prNum := defaultMockPrNum
 	prId := int64(defaultMockPrID)
+	prOwner := defaultMockPrOwner
+	prRepoName := defaultMockPrRepoName
 	prDate := time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
+	prUrl := fmt.Sprintf("https://api.github.com/repos/%v/%v/pulls/%v", prOwner, prRepoName, prNum)
 
 	return &github.PullRequest{
 		ID:        &prId,
@@ -35,6 +41,41 @@ func GetDefaultMockPullRequestDetails() *github.PullRequest {
 		Body:      github.String("Please pull these awesome changes in!"),
 		CreatedAt: &prDate,
 		Number:    github.Int(prNum),
+		URL:       github.String(prUrl),
+        Head: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				Owner: &github.User{
+					Login: github.String("john"),
+				},
+				URL:  github.String(prUrl),
+				Name: github.String(prRepoName),
+			},
+			Ref: github.String("new-topic"),
+		},
+		Base: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				Owner: &github.User{
+					Login: github.String("john"),
+				},
+				URL:  github.String(prUrl),
+				Name: github.String(prRepoName),
+			},
+			Ref: github.String("master"),
+		},
+	}
+}
+
+func getDefaultMockPullRequestFileList() *[]*github.CommitFile {
+	prRepoName := defaultMockPrRepoName
+	return &[]*github.CommitFile{
+		{
+			Filename: github.String(fmt.Sprintf("%v/file1.ts", prRepoName)),
+			Patch: github.String(`@@ -2,9 +2,11 @@ package main
+- func previous1() {
++ func new1() {
++
+return`),
+		},
 	}
 }
 
@@ -47,5 +88,22 @@ func mockHttpClientWith(clientOptions ...mock.MockBackendOption) *http.Client {
 }
 
 func MockGithubClient(clientOptions []mock.MockBackendOption) *github.Client {
-	return github.NewClient(mockDefaultHttpClient(clientOptions))
+    defaultMocks := []mock.MockBackendOption{
+        mock.WithRequestMatchHandler(
+				mock.GetReposPullsByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Write(mock.MustMarshal(GetDefaultMockPullRequestDetails()))
+				}),
+			),
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Write(mock.MustMarshal(getDefaultMockPullRequestFileList()))
+				}),
+			),
+    }
+
+    mocks := append(clientOptions, defaultMocks...)
+
+	return github.NewClient(mockDefaultHttpClient(mocks))
 }

--- a/engine/testdata/exec/reviewpad_with_activated_workflow_with_extra_actions.yml
+++ b/engine/testdata/exec/reviewpad_with_activated_workflow_with_extra_actions.yml
@@ -1,0 +1,19 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+api-version: reviewpad.com/v1alpha
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+
+workflows:
+  - name: activated-workflow
+    if:
+      - rule: tautology
+        extra-actions:
+          - $addLabel("workflow-with-extra-actions")
+    then:
+      - $addLabel("activated-workflow")

--- a/engine/testdata/exec/reviewpad_with_invalid_group.yml
+++ b/engine/testdata/exec/reviewpad_with_invalid_group.yml
@@ -1,0 +1,24 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+# Reviewpad file with the use case of an invalid group which is invalid because its spec is not an array type value.
+
+api-version: reviewpad.com/v1alpha
+
+groups:
+  - name: owners
+    kind: developers
+    spec: 2
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+
+workflows:
+  - name: test-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("test-invalid-group")

--- a/engine/testdata/exec/reviewpad_with_invalid_workflow.yml
+++ b/engine/testdata/exec/reviewpad_with_invalid_workflow.yml
@@ -1,0 +1,19 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+# Reviewpad file with the use case of an invalid workflow due to an invalid rule which is invalid because its spec is not a condition (boolean).
+
+api-version: reviewpad.com/v1alpha
+
+rules:
+  - name: invalid-rule
+    kind: patch
+    spec: 1
+
+workflows:
+  - name: invalid-workflow
+    if:
+      - rule: invalid-rule
+    then:
+      - $addLabel("invalid-workflow")

--- a/engine/testdata/exec/reviewpad_with_multiple_activated_workflows.yml
+++ b/engine/testdata/exec/reviewpad_with_multiple_activated_workflows.yml
@@ -1,0 +1,23 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+api-version: reviewpad.com/v1alpha
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+
+workflows:
+  - name: activated-workflow-a
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("activated-workflow-a")
+  - name: activated-workflow-b
+    always-run: true
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("activated-workflow-b")

--- a/engine/testdata/exec/reviewpad_with_no_activated_workflows.yml
+++ b/engine/testdata/exec/reviewpad_with_no_activated_workflows.yml
@@ -1,0 +1,22 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+api-version: reviewpad.com/v1alpha
+
+rules:
+  - name: non-tautology
+    kind: patch
+    spec: false
+
+workflows:
+  - name: not-activated-workflow-a
+    if:
+      - rule: non-tautology
+    then:
+      - $addLabel("workflow-a-not-activated")
+  - name: not-activated-workflow-b
+    if:
+      - rule: non-tautology
+    then:
+      - $addLabel("workflow-b-not-activated")

--- a/engine/testdata/exec/reviewpad_with_one_activated_workflow.yml
+++ b/engine/testdata/exec/reviewpad_with_one_activated_workflow.yml
@@ -1,0 +1,25 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+api-version: reviewpad.com/v1alpha
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+  - name: non-tautology
+    kind: patch
+    spec: false
+
+workflows:
+  - name: not-activated-workflow
+    if:
+      - rule: non-tautology
+    then:
+      - $addLabel("activated-wrong-workflow")
+  - name: activated-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("activate-one-workflow")

--- a/engine/testdata/exec/reviewpad_with_skipped_workflow.yml
+++ b/engine/testdata/exec/reviewpad_with_skipped_workflow.yml
@@ -1,0 +1,25 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+# Reviewpad file with use case of a skipped workflow: since the workflow 'activated-workflow' is triggered and has `always-run: false`,
+# the next workflow 'non-activated-workflow' will be skipped because it doesn't have the flag `always-run: true`.
+
+api-version: reviewpad.com/v1alpha
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+
+workflows:
+  - name: activated-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("activated-workflow")
+  - name: non-activated-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("non-activated-workflow")

--- a/engine/testdata/exec/reviewpad_with_unnamed_label.yml
+++ b/engine/testdata/exec/reviewpad_with_unnamed_label.yml
@@ -1,0 +1,24 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+# Reviewpad file with use case of an unnamed label.
+# A label is unnamed if it doesn't have the `name` field set.
+
+api-version: reviewpad.com/v1alpha
+
+labels:
+  bug:
+    color: f29513
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+
+workflows:
+  - name: test-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("test-unnamed-label")

--- a/engine/testdata/exec/reviewpad_with_valid_group.yml
+++ b/engine/testdata/exec/reviewpad_with_valid_group.yml
@@ -1,0 +1,22 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+api-version: reviewpad.com/v1alpha
+
+groups:
+  - name: owners
+    kind: developers
+    spec: '["jane", "john"]'
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+
+workflows:
+  - name: test-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("test-valid-group")

--- a/engine/testdata/exec/reviewpad_with_valid_label.yml
+++ b/engine/testdata/exec/reviewpad_with_valid_label.yml
@@ -1,0 +1,22 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+api-version: reviewpad.com/v1alpha
+
+labels:
+  bug:
+    name: bug
+    color: f29513
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+
+workflows:
+  - name: test-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("test-valid-label")

--- a/engine/testutils/parse.go
+++ b/engine/testutils/parse.go
@@ -18,7 +18,9 @@ func ParseReviewpadFile(data []byte) (*engine.ReviewpadFile, error) {
 
 	// At the end of loading all imports from the file, its imports are reset to []engine.PadImport{}.
 	// However, the parsing of the wanted reviewpad file, sets the imports to []engine.PadImport(nil).
-	reviewpadFile.Imports = []engine.PadImport{}
+	if reviewpadFile.Imports == nil {
+		reviewpadFile.Imports = []engine.PadImport{}
+	}
 
 	return reviewpadFile, nil
 }

--- a/engine/testutils/parse.go
+++ b/engine/testutils/parse.go
@@ -2,23 +2,12 @@
 // Use of this source code is governed by a license that can be
 // found in the LICENSE file.
 
-package file
+package testutils
 
 import (
-	"os"
-
 	"github.com/reviewpad/reviewpad/v3/engine"
 	"gopkg.in/yaml.v3"
 )
-
-func LoadReviewpadFile(filepath string) ([]byte, error) {
-	reviewpadFileData, err := os.ReadFile(filepath)
-	if err != nil {
-		return nil, err
-	}
-
-	return reviewpadFileData, nil
-}
 
 func ParseReviewpadFile(data []byte) (*engine.ReviewpadFile, error) {
 	reviewpadFile := &engine.ReviewpadFile{}

--- a/utils/file/file.go
+++ b/utils/file/file.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package file
+
+import (
+	"os"
+
+	"github.com/reviewpad/reviewpad/v3/engine"
+	"gopkg.in/yaml.v3"
+)
+
+func LoadReviewpadFile(filepath string) ([]byte, error) {
+	reviewpadFileData, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	return reviewpadFileData, nil
+}
+
+func ParseReviewpadFile(data []byte) (*engine.ReviewpadFile, error) {
+	reviewpadFile := &engine.ReviewpadFile{}
+	err := yaml.Unmarshal(data, &reviewpadFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// At the end of loading all imports from the file, its imports are reset to []engine.PadImport{}.
+	// However, the parsing of the wanted reviewpad file, sets the imports to []engine.PadImport(nil).
+	reviewpadFile.Imports = []engine.PadImport{}
+
+	return reviewpadFile, nil
+}

--- a/utils/load.go
+++ b/utils/load.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package utils
+
+import "os"
+
+func LoadFile(filepath string) ([]byte, error) {
+	fileData, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	return fileData, nil
+}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request introduces the unit tests for engine exec and some extra mocks related to the pull request data.
During the development of the unit tests, it was encountered an error in the `CollectError` function where it wasn't being taken into account the `*github.ErrorResponse` error type and this would cause an nil pointer dereference because the `Error()` method would be applied to this object which doesn't support such thing and so we need to manually get the error string in this case.

## Related issue

<!-- Closes # (issue) -->
Closes #176

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran `task test` cmd.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues
