### PR TITLE
[ship]: add GetPullRequests to utils/github

### DIFF
--- a/plugins/aladino/functions/reviewerStatus.go
+++ b/plugins/aladino/functions/reviewerStatus.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions
 
 import (
-	"github.com/google/go-github/v42/github"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
 	"github.com/reviewpad/reviewpad/v3/utils"
 )
@@ -24,7 +23,7 @@ func reviewerStatusCode(e aladino.Env, args []aladino.Value) (aladino.Value, err
 	owner := utils.GetPullRequestBaseOwnerName(e.GetPullRequest())
 	repo := utils.GetPullRequestBaseRepoName(e.GetPullRequest())
 
-	reviews, err := utils.GetPullRequestReviews(e.GetCtx(), e.GetClient(), owner, repo, prNum, &github.ListOptions{})
+	reviews, err := utils.GetPullRequestReviews(e.GetCtx(), e.GetClient(), owner, repo, prNum)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This pull request introduces the following changes:
- Moves functionality from the host-event-handler to utils/github.com
- Minor improvement to `GetPullRequestReviews`

## Related issue

None.

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues
