### PR TITLE
fix: only exclude reviewers that have approved the pull request

### DIFF
--- a/plugins/aladino/actions/assignReviewer.go
+++ b/plugins/aladino/actions/assignReviewer.go
@@ -56,20 +56,15 @@ func assignReviewerCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
-	// Skip current requested reviewers if pull request already reviewed
-	for _, review := range reviews {
-		if review.State != nil && *review.State == "APPROVED" {
-			log.Printf("assignReviewer: skipping request reviewers. the pull request already reviewed")
-			return nil
-		}
-	}
-
 	// Re-request current reviewers if mention on the provided reviewers list
 	for _, review := range reviews {
 		for index, availableReviewer := range availableReviewers {
 			if availableReviewer.(*aladino.StringValue).Val == *review.User.Login {
 				totalRequiredReviewers--
-				reviewers = append(reviewers, *review.User.Login)
+				// Skip reviewer if pull request is already reviewed
+				if *review.State != "APPROVED" {
+					reviewers = append(reviewers, *review.User.Login)
+				}
 				availableReviewers = append(availableReviewers[:index], availableReviewers[index+1:]...)
 				break
 			}
@@ -88,6 +83,7 @@ func assignReviewerCode(e aladino.Env, args []aladino.Value) error {
 		}
 	}
 
+	// TODO: #164 - Improve reviewer selection
 	// Select random reviewers from the list of all provided reviewers
 	for i := 0; i < totalRequiredReviewers; i++ {
 		selectedElementIndex := utils.GenerateRandom(len(availableReviewers))

--- a/plugins/aladino/actions/assignReviewer.go
+++ b/plugins/aladino/actions/assignReviewer.go
@@ -61,7 +61,6 @@ func assignReviewerCode(e aladino.Env, args []aladino.Value) error {
 		for index, availableReviewer := range availableReviewers {
 			if availableReviewer.(*aladino.StringValue).Val == *review.User.Login {
 				totalRequiredReviewers--
-				// Skip reviewer if pull request is already reviewed
 				if *review.State != "APPROVED" {
 					reviewers = append(reviewers, *review.User.Login)
 				}

--- a/plugins/aladino/actions/assignReviewer_test.go
+++ b/plugins/aladino/actions/assignReviewer_test.go
@@ -223,6 +223,7 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasReviews(t *testing.T) {
 						User: &github.User{
 							Login: github.String(reviewerLogin),
 						},
+						State: github.String("COMMENTED"),
 					},
 				},
 			),
@@ -255,7 +256,7 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasReviews(t *testing.T) {
 	err = assignReviewer(mockedEnv, args)
 
 	assert.Nil(t, err)
-	assert.ElementsMatch(t, wantReviewers, gotReviewers, "when a provided reviewer already has review then a review needs to be re-requested")
+	assert.ElementsMatch(t, wantReviewers, gotReviewers)
 }
 
 func TestAssignReviewer_WhenPullRequestAlreadyHasRequestedReviewers(t *testing.T) {


### PR DESCRIPTION
## Description

This pull request fixes a previous implementation of #118 in which only reviewers are excluded from the review assignment if they have previously approved the pull request

## Related issue

Fixes #118 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues
