### PR TITLE
feat: assign reviewer when pr is not in draft

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -2,7 +2,12 @@ name: Pull Request Build
 
 on:
   pull_request:
-    types: [ labeled, opened, synchronize, reopened ]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - ready_for_review
 
 jobs:
   pr-build:

--- a/plugins/aladino/actions/assignRandomReviewer.go
+++ b/plugins/aladino/actions/assignRandomReviewer.go
@@ -20,6 +20,10 @@ func AssignRandomReviewer() *aladino.BuiltInAction {
 }
 
 func assignRandomReviewerCode(e aladino.Env, _ []aladino.Value) error {
+	if e.GetPullRequest().GetDraft() {
+		return nil
+	}
+
 	prNum := utils.GetPullRequestNumber(e.GetPullRequest())
 	owner := utils.GetPullRequestBaseOwnerName(e.GetPullRequest())
 	repo := utils.GetPullRequestBaseRepoName(e.GetPullRequest())

--- a/plugins/aladino/actions/assignReviewer.go
+++ b/plugins/aladino/actions/assignReviewer.go
@@ -21,6 +21,10 @@ func AssignReviewer() *aladino.BuiltInAction {
 }
 
 func assignReviewerCode(e aladino.Env, args []aladino.Value) error {
+    if e.GetPullRequest().GetDraft() {
+        return nil
+    }
+
 	totalRequiredReviewers := args[1].(*aladino.IntValue).Val
 	if totalRequiredReviewers == 0 {
 		return fmt.Errorf("assignReviewer: total required reviewers can't be 0")


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request introduces the following changes:
- reviewer assignment (`$assignReviewer` and `$assignRandomReviewer`) only happens if the pull request is not in draft;
- add unit tests for the previous scenario;
- add the trigger event `ready_for_review` because this will re-run the action on pull requests that become ready for review (reverse draft mode) and perform the reviewer assignment if stipulated;
- reorder the type events sequence presenting first the default one (opened, reopened, synchronize) - this change is only for logic purposes, it doesn't affect execution.

## Related issue

<!-- Closes # (issue) -->
Closes #129

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Developed unit tests and tested implementation with `task test` cmd.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues
