### PR TITLE
fix: use empty event when not provided on cli

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -61,36 +61,35 @@ func main() {
 	}
 
 	if *reviewpadFile == "" {
-		log.Printf("Missing argument reviewpad.")
+		log.Printf("[ERROR] Missing argument reviewpad.")
 		usage()
 	}
 
 	if *pullRequestUrl == "" {
-		log.Printf("Missing argument pull-request.")
+		log.Printf("[ERROR] Missing argument pull-request.")
 		usage()
 	}
 
 	if *gitHubToken == "" {
-		log.Printf("Missing argument github-token.")
+		log.Printf("[ERROR] Missing argument github-token.")
 		usage()
 	}
 
-	var rawEvent string
+	var ev interface{}
 
 	if *eventFilePath == "" {
-		rawEvent = "{}"
+		log.Print("[WARN] No event payload provided. Assuming empty event.")
 	} else {
 		content, err := ioutil.ReadFile(*eventFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		rawEvent = string(content)
-	}
-
-	ev, err := parseEvent(rawEvent)
-	if err != nil {
-		log.Fatal(err)
+		rawEvent := string(content)
+		ev, err = parseEvent(rawEvent)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	pullRequestDetailsRegex := regexp.MustCompile(`github\.com\/(.+)\/(.+)\/pull\/(\d+)`)


### PR DESCRIPTION
## Description

Right now when the event payload is not provided when running reviewpad cli, the cli fails.

This is because the cli tries to parse an empty event.

The proposed solution is to assume the event as empty, warn the user, and procced without the event.

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Close #178
<!-- Closes # (issue) -->

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

The cli was ran without a playload event.
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues
