### PR TITLE
feat: remove mocks files from code coverage

### DIFF
--- a/scripts/resources/exclude-from-code-coverage.txt
+++ b/scripts/resources/exclude-from-code-coverage.txt
@@ -1,1 +1,1 @@
-\/parser\.go\|\/mocks\.go
+\/\(parser\|mocks\)\.go

--- a/scripts/resources/exclude-from-code-coverage.txt
+++ b/scripts/resources/exclude-from-code-coverage.txt
@@ -1,1 +1,1 @@
-lang/aladino/parser.go
+\/parser\.go\|\/mocks\.go


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request introduces the removal of mock files in the code coverage by adding the file path pattern that matches `/mocks.go` to `exclude-from-code-coverage.txt` which is a file containing the file patterns regex which will be consumed by the `exclude-from-code-coverage.sh` script that removes from the code coverage the files that match the file patterns mentioned before.

## Related issue

<!-- Closes # (issue) -->
Closes #191

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran the `go tool cover -func coverage.out` that lists the files part of the code coverage with the covered percentage and it also presents at the end the total coverage percentage - with this it was verified that the parser and mock files didn't belong to this listing and the total coverage increased.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues
