### PR TITLE
refactor: fail on mockEnvWith function instead of returning error

### DIFF
--- a/lang/aladino/env_test.go
+++ b/lang/aladino/env_test.go
@@ -18,10 +18,7 @@ import (
 )
 
 func TestGetCtx_WithDefaultEnv(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantCtx := aladino.DefaultMockContext
 
@@ -31,10 +28,7 @@ func TestGetCtx_WithDefaultEnv(t *testing.T) {
 }
 
 func TestGetCollector_WithDefaultEnv(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantCollector := aladino.DefaultMockCollector
 
@@ -44,10 +38,7 @@ func TestGetCollector_WithDefaultEnv(t *testing.T) {
 }
 
 func TestGetPullRequest_WithDefaultEnv(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantPullRequest := aladino.GetDefaultMockPullRequestDetails()
 
@@ -65,7 +56,8 @@ func TestGetPatch_WithDefaultEnv(t *testing.T) {
 			Patch:    github.String(patch),
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -76,9 +68,6 @@ func TestGetPatch_WithDefaultEnv(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedFile1 := &aladino.File{
 		Repr: &github.CommitFile{
@@ -98,10 +87,7 @@ func TestGetPatch_WithDefaultEnv(t *testing.T) {
 }
 
 func TestGetRegisterMap_WithDefaultEnv(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantRegisterMap := make(aladino.RegisterMap)
 
@@ -111,10 +97,7 @@ func TestGetRegisterMap_WithDefaultEnv(t *testing.T) {
 }
 
 func TestGetBuiltIns_WithDefaultEnv(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantBuiltIns := aladino.MockBuiltIns()
 
@@ -136,10 +119,7 @@ func TestGetBuiltIns_WithDefaultEnv(t *testing.T) {
 }
 
 func TestGetReport_WithDefaultEnv(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantReport := &aladino.Report{
 		WorkflowDetails: make(map[string]aladino.ReportWorkflowDetails),
@@ -151,10 +131,7 @@ func TestGetReport_WithDefaultEnv(t *testing.T) {
 }
 
 func TestNewTypeEnv_WithDefaultEnv(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantTypeEnv := aladino.TypeEnv(map[string]aladino.Type{
 		"emptyFunction": aladino.BuildFunctionType([]aladino.Type{}, nil),

--- a/lang/aladino/eval_test.go
+++ b/lang/aladino/eval_test.go
@@ -13,10 +13,7 @@ import (
 )
 
 func TestEval_OnUnaryOp_WhenExprEvalFails(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	unaryOp, err := aladino.Parse("!$nonBuiltIn")
 	if err != nil {
@@ -30,10 +27,7 @@ func TestEval_OnUnaryOp_WhenExprEvalFails(t *testing.T) {
 }
 
 func TestEval_OnUnaryOp(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	unaryOp, err := aladino.Parse("!true")
 	if err != nil {
@@ -49,10 +43,7 @@ func TestEval_OnUnaryOp(t *testing.T) {
 }
 
 func TestEval_OnBinaryOp_WhenLeftOperandEvalFails(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	binaryOp, err := aladino.Parse("$nonBuiltIn() == 1")
 	if err != nil {
@@ -66,10 +57,7 @@ func TestEval_OnBinaryOp_WhenLeftOperandEvalFails(t *testing.T) {
 }
 
 func TestEval_OnBinaryOp_WhenRightOperandEvalFails(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	binaryOp, err := aladino.Parse("1 == $nonBuiltIn()")
 	if err != nil {
@@ -83,10 +71,7 @@ func TestEval_OnBinaryOp_WhenRightOperandEvalFails(t *testing.T) {
 }
 
 func TestEval_OnBinaryOp_WhenDiffKinds(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	binaryOp, err := aladino.Parse("1 == \"a\"")
 	if err != nil {
@@ -100,10 +85,7 @@ func TestEval_OnBinaryOp_WhenDiffKinds(t *testing.T) {
 }
 
 func TestEval_OnBinaryOp_WhenTrue(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	binaryOp, err := aladino.Parse("1 == 1")
 	if err != nil {
@@ -119,10 +101,7 @@ func TestEval_OnBinaryOp_WhenTrue(t *testing.T) {
 }
 
 func TestEval_OnBinaryOp_WhenFalse(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	binaryOp, err := aladino.Parse("1 == 2")
 	if err != nil {
@@ -138,10 +117,7 @@ func TestEval_OnBinaryOp_WhenFalse(t *testing.T) {
 }
 
 func TestEval_OnVariable_WhenVariableIsRegistered(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	variable, err := aladino.Parse("$size")
 	if err != nil {
@@ -163,10 +139,7 @@ func TestEval_OnVariable_WhenVariableIsRegistered(t *testing.T) {
 }
 
 func TestEval_OnVariable_WhenVariableIsNotABuiltIn(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	variable, err := aladino.Parse("$nonBuiltIn")
 	if err != nil {
@@ -180,10 +153,7 @@ func TestEval_OnVariable_WhenVariableIsNotABuiltIn(t *testing.T) {
 }
 
 func TestEval_OnVariable_WhenVariableIsABuiltIn(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	variable, err := aladino.Parse("$zeroConst")
 	if err != nil {
@@ -199,10 +169,7 @@ func TestEval_OnVariable_WhenVariableIsABuiltIn(t *testing.T) {
 }
 
 func TestEval_OnBoolConst(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	boolConst, err := aladino.Parse("true")
 	if err != nil {
@@ -218,10 +185,7 @@ func TestEval_OnBoolConst(t *testing.T) {
 }
 
 func TestEval_OnStringConst(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	str := "test string"
 	strConst, err := aladino.Parse("\"" + str + "\"")
@@ -238,10 +202,7 @@ func TestEval_OnStringConst(t *testing.T) {
 }
 
 func TestEval_OnIntConst(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	intConst, err := aladino.Parse("1")
 	if err != nil {
@@ -257,10 +218,7 @@ func TestEval_OnIntConst(t *testing.T) {
 }
 
 func TestEval_OnFunctionCall_WhenArgEvalFails(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	fc, err := aladino.Parse("$addLabel($nonBuiltIn)")
 	if err != nil {
@@ -274,10 +232,7 @@ func TestEval_OnFunctionCall_WhenArgEvalFails(t *testing.T) {
 }
 
 func TestEval_OnFunctionCall_WhenFunctionIsNotABuiltIn(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	fc, err := aladino.Parse("$nonBuiltIn()")
 	if err != nil {
@@ -291,10 +246,7 @@ func TestEval_OnFunctionCall_WhenFunctionIsNotABuiltIn(t *testing.T) {
 }
 
 func TestEval_OnFunctionCall_WhenFunctionIsABuiltIn(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	fc, err := aladino.Parse("$returnStr(\"hello\")")
 	if err != nil {
@@ -310,10 +262,7 @@ func TestEval_OnFunctionCall_WhenFunctionIsABuiltIn(t *testing.T) {
 }
 
 func TestEval_OnLambda_WhenLambdaBodyEvalFails(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	lambdaBody, err := aladino.Parse("1 == $nonBuiltIn")
 	if err != nil {
@@ -331,10 +280,7 @@ func TestEval_OnLambda_WhenLambdaBodyEvalFails(t *testing.T) {
 }
 
 func TestEval_OnLambda(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	variable, err := aladino.Parse("$size")
 	if err != nil {
@@ -358,10 +304,7 @@ func TestEval_OnLambda(t *testing.T) {
 }
 
 func TestEval_OnTypedExpr(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	expr, err := aladino.Parse("1 == 1")
 	if err != nil {
@@ -379,10 +322,7 @@ func TestEval_OnTypedExpr(t *testing.T) {
 }
 
 func TestEval_OnArray_WhenElemEvalFails(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	array, err := aladino.Parse("[$nonBuiltIn()]")
 	if err != nil {
@@ -396,10 +336,7 @@ func TestEval_OnArray_WhenElemEvalFails(t *testing.T) {
 }
 
 func TestEval_OnArray(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	array, err := aladino.Parse("[\"a\"]")
 	if err != nil {
@@ -415,10 +352,7 @@ func TestEval_OnArray(t *testing.T) {
 }
 
 func TestEval_WhenExprEvalFails(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	expr, err := aladino.Parse("1 == \"a\"")
 	if err != nil {
@@ -432,10 +366,7 @@ func TestEval_WhenExprEvalFails(t *testing.T) {
 }
 
 func TestEval(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	expr, err := aladino.Parse("1 == 1")
 	if err != nil {
@@ -451,10 +382,7 @@ func TestEval(t *testing.T) {
 }
 
 func TestEvalCondition_WhenExprEvalFails(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	expr, err := aladino.Parse("1 == \"a\"")
 	if err != nil {
@@ -468,10 +396,7 @@ func TestEvalCondition_WhenExprEvalFails(t *testing.T) {
 }
 
 func TestEvalCondition_WhenConditionIsTrue(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	expr, err := aladino.Parse("1 == 1")
 	if err != nil {
@@ -485,10 +410,7 @@ func TestEvalCondition_WhenConditionIsTrue(t *testing.T) {
 }
 
 func TestEvalCondition_WhenConditionIsFalse(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	expr, err := aladino.Parse("1 == 2")
 	if err != nil {

--- a/lang/aladino/exec_internal_test.go
+++ b/lang/aladino/exec_internal_test.go
@@ -12,10 +12,7 @@ import (
 )
 
 func TestTypeCheckExec_WhenTypeInferenceFails(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	expr, err := Parse("$emptyAction(1)")
 	if err != nil {
@@ -29,10 +26,7 @@ func TestTypeCheckExec_WhenTypeInferenceFails(t *testing.T) {
 }
 
 func TestTypeCheck(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	expr, err := Parse("$emptyAction()")
 	if err != nil {
@@ -48,10 +42,7 @@ func TestTypeCheck(t *testing.T) {
 }
 
 func TestTypeCheck_WhenExprIsNotFunctionCall(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	expr, err := Parse("\"not a function call\"")
 	if err != nil {
@@ -65,10 +56,7 @@ func TestTypeCheck_WhenExprIsNotFunctionCall(t *testing.T) {
 }
 
 func TestExec_WhenFunctionArgsEvalFails(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	fc := &FunctionCall{
 		name: BuildVariable("invalidCmpOp"),
@@ -77,16 +65,13 @@ func TestExec_WhenFunctionArgsEvalFails(t *testing.T) {
 		},
 	}
 
-	err = fc.exec(mockedEnv)
+	err := fc.exec(mockedEnv)
 
 	assert.EqualError(t, err, "eval: left and right operand have different kinds")
 }
 
 func TestExec_WhenActionBuiltInNonExisting(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	delete(mockedEnv.GetBuiltIns().Actions, "tautology")
 
@@ -97,16 +82,13 @@ func TestExec_WhenActionBuiltInNonExisting(t *testing.T) {
 		},
 	}
 
-	err = fc.exec(mockedEnv)
+	err := fc.exec(mockedEnv)
 
 	assert.EqualError(t, err, "exec: tautology not found. are you sure this is a built-in function?")
 }
 
 func TestExec(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	fcName := "emptyAction"
 
@@ -122,7 +104,7 @@ func TestExec(t *testing.T) {
 		arguments: []Expr{},
 	}
 
-	err = fc.exec(mockedEnv)
+	err := fc.exec(mockedEnv)
 
 	assert.Nil(t, err)
 }

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -82,10 +82,7 @@ func TestBuildGroupAST_WhenGroupTypeFilterIsNotSet(t *testing.T) {
 }
 
 func TestEvalGroup_WhenTypeInferenceFails(t *testing.T) {
-	mockedEnv, err := MockDefaultEnvWithBuiltIns(nil, nil, &BuiltIns{})
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnvWithBuiltIns failed %v", err))
-	}
+	mockedEnv := MockDefaultEnvBuiltIns(t, nil, nil, &BuiltIns{})
 
 	expr, err := Parse("1 == \"a\"")
 	if err != nil {
@@ -98,10 +95,7 @@ func TestEvalGroup_WhenTypeInferenceFails(t *testing.T) {
 }
 
 func TestEvalGroup_WhenExpressionIsNotValidGroup(t *testing.T) {
-	mockedEnv, err := MockDefaultEnvWithBuiltIns(nil, nil, &BuiltIns{})
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnvWithBuiltIns failed %v", err))
-	}
+	mockedEnv := MockDefaultEnvBuiltIns(t, nil, nil, &BuiltIns{})
 
 	expr, err := Parse("true")
 	if err != nil {
@@ -127,10 +121,7 @@ func TestEvalGroup(t *testing.T) {
 		},
 	}
 
-	mockedEnv, err := MockDefaultEnvWithBuiltIns(nil, nil, builtIns)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnvWithBuiltIns failed %v", err))
-	}
+	mockedEnv := MockDefaultEnvBuiltIns(t, nil, nil, builtIns)
 
 	expr, err := Parse("$group(\"\")")
 	if err != nil {
@@ -146,10 +137,7 @@ func TestEvalGroup(t *testing.T) {
 }
 
 func TestProcessGroup_WhenBuildGroupASTFails(t *testing.T) {
-	mockedEnv, err := MockDefaultEnvWithBuiltIns(nil, nil, &BuiltIns{})
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnvWithBuiltIns failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnvBuiltIns(t, nil, nil, &BuiltIns{})
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -158,7 +146,7 @@ func TestProcessGroup_WhenBuildGroupASTFails(t *testing.T) {
 	groupName := "senior-developers"
 
 	errExpr := "$group("
-	err = mockedInterpreter.ProcessGroup(
+	err := mockedInterpreter.ProcessGroup(
 		groupName,
 		engine.GroupKindDeveloper,
 		engine.GroupTypeStatic,
@@ -171,10 +159,7 @@ func TestProcessGroup_WhenBuildGroupASTFails(t *testing.T) {
 }
 
 func TestProcessGroup_WhenEvalGroupFails(t *testing.T) {
-	mockedEnv, err := MockDefaultEnvWithBuiltIns(nil, nil, &BuiltIns{})
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnvWithBuiltIns failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnvBuiltIns(t, nil, nil, &BuiltIns{})
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -183,7 +168,7 @@ func TestProcessGroup_WhenEvalGroupFails(t *testing.T) {
 	groupName := "senior-developers"
 
 	errExpr := "true"
-	err = mockedInterpreter.ProcessGroup(
+	err := mockedInterpreter.ProcessGroup(
 		groupName,
 		engine.GroupKindDeveloper,
 		engine.GroupTypeStatic,
@@ -196,10 +181,7 @@ func TestProcessGroup_WhenEvalGroupFails(t *testing.T) {
 }
 
 func TestProcessGroup_WhenGroupTypeFilterIsNotSet(t *testing.T) {
-	mockedEnv, err := MockDefaultEnvWithBuiltIns(nil, nil, &BuiltIns{})
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnvWithBuiltIns failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnvBuiltIns(t, nil, nil, &BuiltIns{})
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -208,7 +190,7 @@ func TestProcessGroup_WhenGroupTypeFilterIsNotSet(t *testing.T) {
 	groupName := "senior-developers"
 	devName := "jane"
 
-	err = mockedInterpreter.ProcessGroup(
+	err := mockedInterpreter.ProcessGroup(
 		groupName,
 		engine.GroupKindDeveloper,
 		engine.GroupTypeStatic,
@@ -238,10 +220,7 @@ func TestBuildInternalLabelID(t *testing.T) {
 }
 
 func TestProcessLabel(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -249,7 +228,7 @@ func TestProcessLabel(t *testing.T) {
 
 	labelID := "label_id"
 	labelName := "label_name"
-	err = mockedInterpreter.ProcessLabel(labelID, labelName)
+	err := mockedInterpreter.ProcessLabel(labelID, labelName)
 
 	internalLabelID := fmt.Sprintf("@label:%v", labelID)
 	gotVal := mockedEnv.GetRegisterMap()[internalLabelID]
@@ -271,10 +250,7 @@ func TestBuildInternalRuleName(t *testing.T) {
 }
 
 func TestProcessRule(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -282,7 +258,7 @@ func TestProcessRule(t *testing.T) {
 
 	ruleName := "rule_name"
 	spec := "1 == 1"
-	err = mockedInterpreter.ProcessRule(ruleName, spec)
+	err := mockedInterpreter.ProcessRule(ruleName, spec)
 
 	internalRuleName := fmt.Sprintf("@rule:%v", ruleName)
 	gotVal := mockedEnv.GetRegisterMap()[internalRuleName]
@@ -294,10 +270,7 @@ func TestProcessRule(t *testing.T) {
 }
 
 func TestEvalExpr_WhenParseFails(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	gotVal, err := EvalExpr(mockedEnv, "", "1 ==")
 
@@ -306,10 +279,7 @@ func TestEvalExpr_WhenParseFails(t *testing.T) {
 }
 
 func TestEvalExpr_WhenTypeInferenceFails(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	gotVal, err := EvalExpr(mockedEnv, "", "1 == \"a\"")
 
@@ -318,10 +288,7 @@ func TestEvalExpr_WhenTypeInferenceFails(t *testing.T) {
 }
 
 func TestEvalExpr_WhenExprIsNotBoolType(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	gotVal, err := EvalExpr(mockedEnv, "", "1")
 
@@ -330,10 +297,7 @@ func TestEvalExpr_WhenExprIsNotBoolType(t *testing.T) {
 }
 
 func TestEvalExpr(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	gotVal, err := EvalExpr(mockedEnv, "", "1 == 1")
 
@@ -342,10 +306,7 @@ func TestEvalExpr(t *testing.T) {
 }
 
 func TestEvalExpr_OnInterpreter(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -358,10 +319,7 @@ func TestEvalExpr_OnInterpreter(t *testing.T) {
 }
 
 func TestExecProgram_WhenExecStatementFails(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -376,7 +334,7 @@ func TestExecProgram_WhenExecStatementFails(t *testing.T) {
 		},
 	}
 
-	err = mockedInterpreter.ExecProgram(program)
+	err := mockedInterpreter.ExecProgram(program)
 
 	assert.EqualError(t, err, "no type for built-in action. Please check if the mode in the reviewpad.yml file supports it")
 }
@@ -393,7 +351,8 @@ func TestExecProgram(t *testing.T) {
 		},
 	}
 
-	mockedEnv, err := MockDefaultEnvWithBuiltIns(
+	mockedEnv := MockDefaultEnvBuiltIns(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposLabelsByOwnerByRepoByName,
@@ -409,9 +368,6 @@ func TestExecProgram(t *testing.T) {
 		nil,
 		builtIns,
 	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnvWithBuiltIns failed: %v", err))
-	}
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -438,7 +394,7 @@ func TestExecProgram(t *testing.T) {
 		},
 	}
 
-	err = mockedInterpreter.ExecProgram(program)
+	err := mockedInterpreter.ExecProgram(program)
 
 	gotVal := mockedEnv.GetReport().WorkflowDetails[statementWorkflowName]
 
@@ -455,10 +411,7 @@ func TestExecProgram(t *testing.T) {
 }
 
 func TestExecStatement_WhenParseFails(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -476,7 +429,7 @@ func TestExecStatement_WhenParseFails(t *testing.T) {
 		},
 	}
 
-	err = mockedInterpreter.ExecStatement(statement)
+	err := mockedInterpreter.ExecStatement(statement)
 
 	assert.EqualError(t, err, "parse error: failed to build AST on input $addLabel(")
 }
@@ -493,10 +446,7 @@ func TestExecStatement_WhenTypeCheckExecFails(t *testing.T) {
 		},
 	}
 
-	mockedEnv, err := MockDefaultEnvWithBuiltIns(nil, nil, builtIns)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnvWithBuiltIns failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnvBuiltIns(t, nil, nil, builtIns)
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -514,7 +464,7 @@ func TestExecStatement_WhenTypeCheckExecFails(t *testing.T) {
 		},
 	}
 
-	err = mockedInterpreter.ExecStatement(statement)
+	err := mockedInterpreter.ExecStatement(statement)
 
 	assert.EqualError(t, err, "type inference failed: mismatch in arg types on addLabel")
 }
@@ -532,10 +482,7 @@ func TestExecStatement_WhenActionExecFails(t *testing.T) {
 		},
 	}
 
-	mockedEnv, err := MockDefaultEnvWithBuiltIns(nil, nil, builtIns)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnvWithBuiltIns failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnvBuiltIns(t, nil, nil, builtIns)
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -553,7 +500,7 @@ func TestExecStatement_WhenActionExecFails(t *testing.T) {
 		},
 	}
 
-	err = mockedInterpreter.ExecStatement(statement)
+	err := mockedInterpreter.ExecStatement(statement)
 
 	assert.EqualError(t, err, "exec: author not found. are you sure this is a built-in function?")
 }
@@ -570,7 +517,8 @@ func TestExecStatement(t *testing.T) {
 		},
 	}
 
-	mockedEnv, err := MockDefaultEnvWithBuiltIns(
+	mockedEnv := MockDefaultEnvBuiltIns(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposLabelsByOwnerByRepoByName,
@@ -586,9 +534,6 @@ func TestExecStatement(t *testing.T) {
 		nil,
 		builtIns,
 	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnvWithBuiltIns failed: %v", err))
-	}
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -609,7 +554,7 @@ func TestExecStatement(t *testing.T) {
 		},
 	}
 
-	err = mockedInterpreter.ExecStatement(statement)
+	err := mockedInterpreter.ExecStatement(statement)
 
 	gotVal := mockedEnv.GetReport().WorkflowDetails[statementWorkflowName]
 
@@ -638,7 +583,8 @@ func TestReport_WhenFindReportCommentFails(t *testing.T) {
 			Ref: github.String("master"),
 		},
 	})
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -649,22 +595,20 @@ func TestReport_WhenFindReportCommentFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
 	}
 
-	err = mockedInterpreter.Report(engine.SILENT_MODE, false)
+	err := mockedInterpreter.Report(engine.SILENT_MODE, false)
 
 	assert.EqualError(t, err, "[report] error getting issues mock response not found for /repos/john/default-mock-repo/issues/6/comments")
 }
 
 func TestReport_OnSilentMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 	var isDeletedCommentRequested bool
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -685,15 +629,12 @@ func TestReport_OnSilentMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
 	}
 
-	err = mockedInterpreter.Report(engine.SILENT_MODE, false)
+	err := mockedInterpreter.Report(engine.SILENT_MODE, false)
 
 	assert.Nil(t, err)
 	assert.True(t, isDeletedCommentRequested)
@@ -701,7 +642,8 @@ func TestReport_OnSilentMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 
 func TestReport_OnSilentMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 	var isDeletedCommentRequested bool
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -717,15 +659,12 @@ func TestReport_OnSilentMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
 	}
 
-	err = mockedInterpreter.Report(engine.SILENT_MODE, false)
+	err := mockedInterpreter.Report(engine.SILENT_MODE, false)
 
 	assert.Nil(t, err)
 	assert.False(t, isDeletedCommentRequested)
@@ -734,7 +673,8 @@ func TestReport_OnSilentMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 	var addedComment string
 	commentToBeAdded := "<!--@annotation-reviewpad-report-->\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated"
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -754,15 +694,12 @@ func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
 	}
 
-	err = mockedInterpreter.Report(engine.VERBOSE_MODE, false)
+	err := mockedInterpreter.Report(engine.VERBOSE_MODE, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, commentToBeAdded, addedComment)
@@ -771,7 +708,8 @@ func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 func TestReport_OnVerboseMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 	var updatedComment string
 	commentUpdated := "<!--@annotation-reviewpad-report-->\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated"
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -796,15 +734,12 @@ func TestReport_OnVerboseMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) 
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
 
 	mockedInterpreter := &Interpreter{
 		Env: mockedEnv,
 	}
 
-	err = mockedInterpreter.Report(engine.VERBOSE_MODE, false)
+	err := mockedInterpreter.Report(engine.VERBOSE_MODE, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, commentUpdated, updatedComment)
@@ -844,10 +779,7 @@ func TestNewInterpreter_WhenNewEvalEnvFails(t *testing.T) {
 }
 
 func TestNewInterpreter(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("MockDefaultEnv failed: %v", err))
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	wantInterpreter := &Interpreter{
 		Env: mockedEnv,

--- a/lang/aladino/report_internal_test.go
+++ b/lang/aladino/report_internal_test.go
@@ -236,7 +236,8 @@ func TestBuildVerboseReport(t *testing.T) {
 
 func TestDeleteReportComment_WhenCommentCannotBeDeleted(t *testing.T) {
 	failMessage := "DeleteCommentRequestFailed"
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.DeleteReposIssuesCommentsByOwnerByRepoByCommentId,
@@ -251,20 +252,18 @@ func TestDeleteReportComment_WhenCommentCannotBeDeleted(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
 
 	testCommentId := int64(1234)
 
-	err = DeleteReportComment(mockedEnv, testCommentId)
+	err := DeleteReportComment(mockedEnv, testCommentId)
 
 	assert.EqualError(t, err, fmt.Sprintf("[report] error on deleting report comment %v", failMessage))
 }
 
 func TestDeleteReportComment_WhenCommentCanBeDeleted(t *testing.T) {
 	var deletedComment int64
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.DeleteReposIssuesCommentsByOwnerByRepoByCommentId,
@@ -280,13 +279,10 @@ func TestDeleteReportComment_WhenCommentCanBeDeleted(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
 
 	commentToBeDeleted := int64(1234)
 
-	err = DeleteReportComment(mockedEnv, commentToBeDeleted)
+	err := DeleteReportComment(mockedEnv, commentToBeDeleted)
 
 	assert.Nil(t, err)
 	assert.Equal(t, commentToBeDeleted, deletedComment)
@@ -294,7 +290,8 @@ func TestDeleteReportComment_WhenCommentCanBeDeleted(t *testing.T) {
 
 func TestUpdateReportComment_WhenCommentCannotBeEdited(t *testing.T) {
 	failMessage := "EditCommentRequestFailed"
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
@@ -309,21 +306,19 @@ func TestUpdateReportComment_WhenCommentCannotBeEdited(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
 
 	testCommentId := int64(1234)
 	wantUpdatedComment := "Test update report comment"
 
-	err = UpdateReportComment(mockedEnv, testCommentId, wantUpdatedComment)
+	err := UpdateReportComment(mockedEnv, testCommentId, wantUpdatedComment)
 
 	assert.EqualError(t, err, fmt.Sprintf("[report] error on updating report comment %v", failMessage))
 }
 
 func TestUpdateReportComment_WhenCommentCanBeEdited(t *testing.T) {
 	var gotUpdatedComment string
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
@@ -339,14 +334,11 @@ func TestUpdateReportComment_WhenCommentCanBeEdited(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
 
 	testCommentId := int64(1234)
 	wantUpdatedComment := "Test update report comment"
 
-	err = UpdateReportComment(mockedEnv, testCommentId, wantUpdatedComment)
+	err := UpdateReportComment(mockedEnv, testCommentId, wantUpdatedComment)
 
 	assert.Nil(t, err)
 	assert.Equal(t, wantUpdatedComment, gotUpdatedComment)
@@ -354,7 +346,8 @@ func TestUpdateReportComment_WhenCommentCanBeEdited(t *testing.T) {
 
 func TestAddReportComment_WhenCommentCannotBeCreated(t *testing.T) {
 	failMessage := "CreateCommentRequestFailed"
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -369,13 +362,10 @@ func TestAddReportComment_WhenCommentCannotBeCreated(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
 
 	comment := "Test add report comment"
 
-	err = AddReportComment(mockedEnv, comment)
+	err := AddReportComment(mockedEnv, comment)
 
 	assert.EqualError(t, err, fmt.Sprintf("[report] error on creating report comment %v", failMessage))
 }
@@ -384,7 +374,8 @@ func TestAddReportComment_WhenCommentCanBeCreated(t *testing.T) {
 	var createdComment string
 	commentToBeCreated := "Test add report comment"
 
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -400,11 +391,8 @@ func TestAddReportComment_WhenCommentCanBeCreated(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
 
-	err = AddReportComment(mockedEnv, commentToBeCreated)
+	err := AddReportComment(mockedEnv, commentToBeCreated)
 
 	assert.Nil(t, err)
 	assert.Equal(t, createdComment, commentToBeCreated)
@@ -412,7 +400,8 @@ func TestAddReportComment_WhenCommentCanBeCreated(t *testing.T) {
 
 func TestFindReportComment_WhenPullRequestCommentsListingFails(t *testing.T) {
 	failMessage := "ListCommentsRequestFailed"
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -427,9 +416,6 @@ func TestFindReportComment_WhenPullRequestCommentsListingFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
 
 	gotComment, err := FindReportComment(mockedEnv)
 
@@ -441,7 +427,8 @@ func TestFindReportComment_WhenThereIsReviewpadComment(t *testing.T) {
 	wantComment := &github.IssueComment{
 		Body: github.String("<!--@annotation-reviewpad-report-->\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated"),
 	}
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -452,9 +439,6 @@ func TestFindReportComment_WhenThereIsReviewpadComment(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
 
 	gotComment, err := FindReportComment(mockedEnv)
 
@@ -466,7 +450,8 @@ func TestFindReportComment_WhenThereIsNoReviewpadComment(t *testing.T) {
 	comment := &github.IssueComment{
 		Body: github.String("Test comment"),
 	}
-	mockedEnv, err := MockDefaultEnv(
+	mockedEnv := MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -477,9 +462,6 @@ func TestFindReportComment_WhenThereIsNoReviewpadComment(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
 
 	gotComment, err := FindReportComment(mockedEnv)
 

--- a/lang/aladino/typeinfer_internal_test.go
+++ b/lang/aladino/typeinfer_internal_test.go
@@ -34,10 +34,7 @@ func (op *mockBinaryOperator) Eval(lhs, rhs Value) Value {
 }
 
 func TestTypeInference_WhenGivenNonExistingBuiltIn(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	expr := BuildVariable("nonBuiltIn")
 
@@ -48,10 +45,7 @@ func TestTypeInference_WhenGivenNonExistingBuiltIn(t *testing.T) {
 }
 
 func TestTypeInference_WhenGivenBoolConst(t *testing.T) {
-	mockedEnv, err := MockDefaultEnv(nil, nil)
-	if err != nil {
-		assert.FailNow(t, "MockDefaultEnv returned unexpected error: %v", err)
-	}
+	mockedEnv := MockDefaultEnv(t, nil, nil)
 
 	expr := BuildBoolConst(true)
 

--- a/plugins/aladino/actions/addLabel_test.go
+++ b/plugins/aladino/actions/addLabel_test.go
@@ -7,7 +7,6 @@ package plugins_aladino_actions_test
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"testing"
 
@@ -23,7 +22,8 @@ var addLabel = plugins_aladino.PluginBuiltIns().Actions["addLabel"].Code
 func TestAddLabel_WhenAddLabelToIssueRequestFails(t *testing.T) {
 	label := "bug"
 	failMessage := "AddLabelsToIssueRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposLabelsByOwnerByRepoByName,
@@ -44,12 +44,9 @@ func TestAddLabel_WhenAddLabelToIssueRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(label)}
-	err = addLabel(mockedEnv, args)
+	err := addLabel(mockedEnv, args)
 
 	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
 }
@@ -60,7 +57,8 @@ func TestAddLabel_WhenLabelIsInEnvironment(t *testing.T) {
 		label,
 	}
 	gotLabels := []string{}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposLabelsByOwnerByRepoByName,
@@ -80,14 +78,11 @@ func TestAddLabel_WhenLabelIsInEnvironment(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 	internalLabelID := aladino.BuildInternalLabelID(label)
 	mockedEnv.GetRegisterMap()[internalLabelID] = aladino.BuildStringValue(label)
 
 	args := []aladino.Value{aladino.BuildStringValue(label)}
-	err = addLabel(mockedEnv, args)
+	err := addLabel(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, wantLabels, gotLabels)
@@ -99,7 +94,8 @@ func TestAddLabel_WhenLabelIsNotInEnvironment(t *testing.T) {
 		label,
 	}
 	gotLabels := []string{}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposLabelsByOwnerByRepoByName,
@@ -119,12 +115,9 @@ func TestAddLabel_WhenLabelIsNotInEnvironment(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(label)}
-	err = addLabel(mockedEnv, args)
+	err := addLabel(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, wantLabels, gotLabels)

--- a/plugins/aladino/actions/assignAssignees_test.go
+++ b/plugins/aladino/actions/assignAssignees_test.go
@@ -7,7 +7,6 @@ package plugins_aladino_actions_test
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"testing"
 
@@ -25,22 +24,16 @@ type AssigneesRequestPostBody struct {
 }
 
 func TestAssignAssignees_WhenListOfAssigneesIsEmpty(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{})}
-	err = assignAssignees(mockedEnv, args)
+	err := assignAssignees(mockedEnv, args)
 
 	assert.EqualError(t, err, "assignAssignees: list of assignees can't be empty")
 }
 
 func TestAssignAssignees_WhenListOfAssigneesExceeds10Users(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{
 		aladino.BuildStringValue("john"),
@@ -55,7 +48,7 @@ func TestAssignAssignees_WhenListOfAssigneesExceeds10Users(t *testing.T) {
 		aladino.BuildStringValue("michael"),
 		aladino.BuildStringValue("tom"),
 	})}
-	err = assignAssignees(mockedEnv, args)
+	err := assignAssignees(mockedEnv, args)
 
 	assert.EqualError(t, err, "assignAssignees: can only assign up to 10 assignees")
 }
@@ -69,7 +62,8 @@ func TestAssignAssignees(t *testing.T) {
 		Assignees: []*github.User{},
 	})
 
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -91,9 +85,6 @@ func TestAssignAssignees(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	assignees := make([]aladino.Value, len(wantAssignees))
 	for i, assignee := range wantAssignees {
@@ -101,7 +92,7 @@ func TestAssignAssignees(t *testing.T) {
 	}
 
 	args := []aladino.Value{aladino.BuildArrayValue(assignees)}
-	err = assignAssignees(mockedEnv, args)
+	err := assignAssignees(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, wantAssignees, gotAssignees)

--- a/plugins/aladino/actions/assignRandomReviewer_test.go
+++ b/plugins/aladino/actions/assignRandomReviewer_test.go
@@ -7,7 +7,6 @@ package plugins_aladino_actions_test
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"testing"
 
@@ -26,7 +25,8 @@ type ReviewersRequestPostBody struct {
 
 func TestAssignRandomReviewer_WhenListReviewersRequestFails(t *testing.T) {
 	failMessage := "ListReviewersRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
@@ -41,12 +41,9 @@ func TestAssignRandomReviewer_WhenListReviewersRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
-	err = assignRandomReviewer(mockedEnv, args)
+	err := assignRandomReviewer(mockedEnv, args)
 
 	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
 }
@@ -54,7 +51,8 @@ func TestAssignRandomReviewer_WhenListReviewersRequestFails(t *testing.T) {
 func TestAssignRandomReviewer_WhenPullRequestAlreadyHasReviewers(t *testing.T) {
 	var isListAssigneesFetched bool
 	requestedReviewer := "jane"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
@@ -74,12 +72,9 @@ func TestAssignRandomReviewer_WhenPullRequestAlreadyHasReviewers(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
-	err = assignRandomReviewer(mockedEnv, args)
+	err := assignRandomReviewer(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.False(t, isListAssigneesFetched, "shouldn't fetch the list of available assignees since the pull request already has reviewers")
@@ -87,7 +82,8 @@ func TestAssignRandomReviewer_WhenPullRequestAlreadyHasReviewers(t *testing.T) {
 
 func TestAssignRandomReviewer_WhenListAssigneesRequestFails(t *testing.T) {
 	failMessage := "ListAssigneesRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
@@ -106,12 +102,9 @@ func TestAssignRandomReviewer_WhenListAssigneesRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
-	err = assignRandomReviewer(mockedEnv, args)
+	err := assignRandomReviewer(mockedEnv, args)
 
 	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
 }
@@ -123,7 +116,8 @@ func TestAssignRandomReviewer_ShouldFilterPullRequestAuthor(t *testing.T) {
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		User: &github.User{Login: github.String(authorLogin)},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -156,12 +150,9 @@ func TestAssignRandomReviewer_ShouldFilterPullRequestAuthor(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
-	err = assignRandomReviewer(mockedEnv, args)
+	err := assignRandomReviewer(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{assigneeLogin}, selectedReviewers)
@@ -172,7 +163,8 @@ func TestAssignRandomReviewer_WhenThereIsNoUsers(t *testing.T) {
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		User: &github.User{Login: github.String(authorLogin)},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -193,12 +185,9 @@ func TestAssignRandomReviewer_WhenThereIsNoUsers(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
-	err = assignRandomReviewer(mockedEnv, args)
+	err := assignRandomReviewer(mockedEnv, args)
 
 	assert.EqualError(t, err, "can't assign a random user because there is no users")
 }

--- a/plugins/aladino/actions/assignReviewer_test.go
+++ b/plugins/aladino/actions/assignReviewer_test.go
@@ -7,7 +7,6 @@ package plugins_aladino_actions_test
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"testing"
 
@@ -21,10 +20,7 @@ import (
 var assignReviewer = plugins_aladino.PluginBuiltIns().Actions["assignReviewer"].Code
 
 func TestAssignReviewer_WhenTotalRequiredReviewersIsZero(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{
 		aladino.BuildArrayValue(
@@ -34,19 +30,16 @@ func TestAssignReviewer_WhenTotalRequiredReviewersIsZero(t *testing.T) {
 		),
 		aladino.BuildIntValue(0),
 	}
-	err = assignReviewer(mockedEnv, args)
+	err := assignReviewer(mockedEnv, args)
 
 	assert.EqualError(t, err, "assignReviewer: total required reviewers can't be 0")
 }
 
 func TestAssignReviewer_WhenListOfReviewersIsEmpty(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{}), aladino.BuildIntValue(1)}
-	err = assignReviewer(mockedEnv, args)
+	err := assignReviewer(mockedEnv, args)
 
 	assert.EqualError(t, err, "assignReviewer: list of reviewers can't be empty")
 }
@@ -62,7 +55,8 @@ func TestAssignReviewer_WhenAuthorIsInListOfReviewers(t *testing.T) {
 		User:               &github.User{Login: github.String(authorLogin)},
 		RequestedReviewers: []*github.User{},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -88,9 +82,6 @@ func TestAssignReviewer_WhenAuthorIsInListOfReviewers(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{
 		aladino.BuildArrayValue(
@@ -101,7 +92,7 @@ func TestAssignReviewer_WhenAuthorIsInListOfReviewers(t *testing.T) {
 		),
 		aladino.BuildIntValue(1),
 	}
-	err = assignReviewer(mockedEnv, args)
+	err := assignReviewer(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, wantReviewers, gotReviewers, "pr author shouldn't be assigned as a reviewer")
@@ -119,7 +110,8 @@ func TestAssignReviewer_WhenTotalRequiredReviewersIsMoreThanTotalAvailableReview
 	wantReviewers := []string{
 		reviewerLogin,
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -145,9 +137,6 @@ func TestAssignReviewer_WhenTotalRequiredReviewersIsMoreThanTotalAvailableReview
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{
 		aladino.BuildArrayValue(
@@ -157,7 +146,7 @@ func TestAssignReviewer_WhenTotalRequiredReviewersIsMoreThanTotalAvailableReview
 		),
 		aladino.BuildIntValue(totalRequiredReviewers),
 	}
-	err = assignReviewer(mockedEnv, args)
+	err := assignReviewer(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, wantReviewers, gotReviewers, "the list of assign reviewers should be all provided reviewers")
@@ -165,7 +154,8 @@ func TestAssignReviewer_WhenTotalRequiredReviewersIsMoreThanTotalAvailableReview
 
 func TestAssignReviewer_WhenListReviewsRequestFails(t *testing.T) {
 	failMessage := "ListReviewsRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -180,9 +170,6 @@ func TestAssignReviewer_WhenListReviewsRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{
 		aladino.BuildArrayValue(
@@ -192,7 +179,7 @@ func TestAssignReviewer_WhenListReviewsRequestFails(t *testing.T) {
 		),
 		aladino.BuildIntValue(3),
 	}
-	err = assignReviewer(mockedEnv, args)
+	err := assignReviewer(mockedEnv, args)
 
 	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
 }
@@ -208,7 +195,8 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasReviews(t *testing.T) {
 		User:               &github.User{Login: github.String(authorLogin)},
 		RequestedReviewers: []*github.User{},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -241,9 +229,6 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasReviews(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{
 		aladino.BuildArrayValue(
@@ -253,7 +238,7 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasReviews(t *testing.T) {
 		),
 		aladino.BuildIntValue(1),
 	}
-	err = assignReviewer(mockedEnv, args)
+	err := assignReviewer(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, wantReviewers, gotReviewers)
@@ -269,7 +254,8 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasApproval(t *testing.T) {
 		User:               &github.User{Login: github.String(authorLogin)},
 		RequestedReviewers: []*github.User{},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -302,9 +288,6 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasApproval(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{
 		aladino.BuildArrayValue(
@@ -314,7 +297,7 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasApproval(t *testing.T) {
 		),
 		aladino.BuildIntValue(1),
 	}
-	err = assignReviewer(mockedEnv, args)
+	err := assignReviewer(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, wantReviewers, gotReviewers)
@@ -334,7 +317,8 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasRequestedReviewers(t *testing.T
 			{Login: github.String(reviewerA)},
 		},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -360,9 +344,6 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasRequestedReviewers(t *testing.T
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{
 		aladino.BuildArrayValue(
@@ -373,7 +354,7 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasRequestedReviewers(t *testing.T
 		),
 		aladino.BuildIntValue(2),
 	}
-	err = assignReviewer(mockedEnv, args)
+	err := assignReviewer(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, wantReviewers, gotReviewers, "when a reviewer already has a requested review, then it shouldn't be re-requested")
@@ -394,7 +375,8 @@ func TestAssignReviewer_HasNoAvailableReviewers(t *testing.T) {
 			{Login: github.String(reviewerLogin)},
 		},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -416,9 +398,6 @@ func TestAssignReviewer_HasNoAvailableReviewers(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{
 		aladino.BuildArrayValue(
@@ -428,7 +407,7 @@ func TestAssignReviewer_HasNoAvailableReviewers(t *testing.T) {
 		),
 		aladino.BuildIntValue(totalRequiredReviewers),
 	}
-	err = assignReviewer(mockedEnv, args)
+	err := assignReviewer(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.False(t, isRequestReviewersRequestPerformed, "the action shouldn't request for reviewers")
@@ -453,7 +432,8 @@ func TestAssignReviewer_WhenPullRequestAlreadyApproved(t *testing.T) {
 			User:  &github.User{Login: github.String(reviewerA)},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -475,9 +455,6 @@ func TestAssignReviewer_WhenPullRequestAlreadyApproved(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{
 		aladino.BuildArrayValue(
@@ -487,7 +464,7 @@ func TestAssignReviewer_WhenPullRequestAlreadyApproved(t *testing.T) {
 		),
 		aladino.BuildIntValue(1),
 	}
-	err = assignReviewer(mockedEnv, args)
+	err := assignReviewer(mockedEnv, args)
 	assert.Nil(t, err)
 	assert.False(t, isRequestReviewersRequestPerformed, "the action shouldn't request for reviewers")
 }

--- a/plugins/aladino/actions/assignTeamReviewer_test.go
+++ b/plugins/aladino/actions/assignTeamReviewer_test.go
@@ -7,7 +7,6 @@ package plugins_aladino_actions_test
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"testing"
 
@@ -24,13 +23,10 @@ type TeamReviewersRequestPostBody struct {
 }
 
 func TestAssignTeamReviewer_WhenNoTeamSlugsAreProvided(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{})}
-	err = assignTeamReviewer(mockedEnv, args)
+	err := assignTeamReviewer(mockedEnv, args)
 
 	assert.EqualError(t, err, "assignTeamReviewer: requires at least 1 team to request for review")
 }
@@ -40,7 +36,8 @@ func TestAssignTeamReviewer(t *testing.T) {
 	teamB := "reviewpad-project"
 	wantTeamReviewers := []string{teamA, teamB}
 	gotTeamReviewers := []string{}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.PostReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
@@ -56,12 +53,9 @@ func TestAssignTeamReviewer(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue(teamA), aladino.BuildStringValue(teamB)})}
-	err = assignTeamReviewer(mockedEnv, args)
+	err := assignTeamReviewer(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.Equal(t, wantTeamReviewers, gotTeamReviewers)

--- a/plugins/aladino/actions/close_test.go
+++ b/plugins/aladino/actions/close_test.go
@@ -7,7 +7,6 @@ package plugins_aladino_actions_test
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"testing"
 
@@ -22,7 +21,8 @@ var close = plugins_aladino.PluginBuiltIns().Actions["close"].Code
 
 func TestClose_WhenEditRequestFails(t *testing.T) {
 	failMessage := "EditRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.PatchReposPullsByOwnerByRepoByPullNumber,
@@ -37,12 +37,9 @@ func TestClose_WhenEditRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
-	err = close(mockedEnv, args)
+	err := close(mockedEnv, args)
 
 	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
 }
@@ -50,7 +47,8 @@ func TestClose_WhenEditRequestFails(t *testing.T) {
 func TestClose(t *testing.T) {
 	wantState := "closed"
 	var gotState string
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.PatchReposPullsByOwnerByRepoByPullNumber,
@@ -66,12 +64,9 @@ func TestClose(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
-	err = close(mockedEnv, args)
+	err := close(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.Equal(t, wantState, gotState)

--- a/plugins/aladino/actions/commentOnce_test.go
+++ b/plugins/aladino/actions/commentOnce_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"testing"
 
@@ -26,7 +25,8 @@ var commentOnce = plugins_aladino.PluginBuiltIns().Actions["commentOnce"].Code
 func TestCommentOnce_WhenGetCommentsRequestFails(t *testing.T) {
 	failMessage := "GetCommentRequestFail"
 	comment := "Lorem Ipsum"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -41,12 +41,9 @@ func TestCommentOnce_WhenGetCommentsRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(fmt.Sprintf("%v%v", ReviewpadCommentAnnotation, comment))}
-	err = commentOnce(mockedEnv, args)
+	err := commentOnce(mockedEnv, args)
 
 	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
 }
@@ -55,7 +52,8 @@ func TestCommentOnce_WhenCommentAlreadyExists(t *testing.T) {
 	existingComment := "Lorem Ipsum"
 	commentCreated := false
 
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -75,12 +73,9 @@ func TestCommentOnce_WhenCommentAlreadyExists(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(existingComment)}
-	err = commentOnce(mockedEnv, args)
+	err := commentOnce(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.False(t, commentCreated, "The comment should not be created")
@@ -90,7 +85,8 @@ func TestCommentOnce_WhenFirstTime(t *testing.T) {
 	commentToAdd := "Lorem Ipsum"
 	addedComment := ""
 
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -110,12 +106,9 @@ func TestCommentOnce_WhenFirstTime(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(commentToAdd)}
-	err = commentOnce(mockedEnv, args)
+	err := commentOnce(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.Equal(t, fmt.Sprintf("%v%v", ReviewpadCommentAnnotation, commentToAdd), addedComment)

--- a/plugins/aladino/actions/comment_test.go
+++ b/plugins/aladino/actions/comment_test.go
@@ -7,7 +7,6 @@ package plugins_aladino_actions_test
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"testing"
 
@@ -24,7 +23,8 @@ func TestComment(t *testing.T) {
 	wantComment := "Lorem Ipsum"
 	gotComment := ""
 
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -44,12 +44,9 @@ func TestComment(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(wantComment)}
-	err = comment(mockedEnv, args)
+	err := comment(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.Equal(t, wantComment, gotComment)

--- a/plugins/aladino/actions/merge_test.go
+++ b/plugins/aladino/actions/merge_test.go
@@ -7,7 +7,6 @@ package plugins_aladino_actions_test
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"testing"
 
@@ -24,13 +23,10 @@ type MergeRequestPostBody struct {
 }
 
 func TestMerge_WhenMergeMethodIsUnsupported(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{aladino.BuildStringValue("INVALID")}
-	err = merge(mockedEnv, args)
+	err := merge(mockedEnv, args)
 
 	assert.EqualError(t, err, "merge: unsupported merge method INVALID")
 }
@@ -38,7 +34,8 @@ func TestMerge_WhenMergeMethodIsUnsupported(t *testing.T) {
 func TestMerge_WhenNoMergeMethodIsProvided(t *testing.T) {
 	wantMergeMethod := "merge"
 	var gotMergeMethod string
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.PutReposPullsMergeByOwnerByRepoByPullNumber,
@@ -54,12 +51,9 @@ func TestMerge_WhenNoMergeMethodIsProvided(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
-	err = merge(mockedEnv, args)
+	err := merge(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.Equal(t, wantMergeMethod, gotMergeMethod)
@@ -68,7 +62,8 @@ func TestMerge_WhenNoMergeMethodIsProvided(t *testing.T) {
 func TestMerge_WhenMergeMethodIsProvided(t *testing.T) {
 	wantMergeMethod := "rebase"
 	var gotMergeMethod string
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.PutReposPullsMergeByOwnerByRepoByPullNumber,
@@ -84,12 +79,9 @@ func TestMerge_WhenMergeMethodIsProvided(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(wantMergeMethod)}
-	err = merge(mockedEnv, args)
+	err := merge(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.Equal(t, wantMergeMethod, gotMergeMethod)

--- a/plugins/aladino/actions/removeLabel_test.go
+++ b/plugins/aladino/actions/removeLabel_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_actions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -22,7 +21,8 @@ var removeLabel = plugins_aladino.PluginBuiltIns().Actions["removeLabel"].Code
 func TestRemoveLabel_WhenLabelIsNotAppliedToPullRequest(t *testing.T) {
 	wantLabel := "bug"
 	var isLabelRemoved bool
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposLabelsByOwnerByRepoByName,
@@ -40,12 +40,9 @@ func TestRemoveLabel_WhenLabelIsNotAppliedToPullRequest(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(wantLabel)}
-	err = removeLabel(mockedEnv, args)
+	err := removeLabel(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.False(t, isLabelRemoved, "The label should not be removed")
@@ -54,7 +51,8 @@ func TestRemoveLabel_WhenLabelIsNotAppliedToPullRequest(t *testing.T) {
 func TestRemoveLabel_WhenLabelIsAppliedToPullRequestAndLabelIsInEnvironment(t *testing.T) {
 	wantLabel := "enhancement"
 	var gotLabel string
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposLabelsByOwnerByRepoByName,
@@ -72,15 +70,12 @@ func TestRemoveLabel_WhenLabelIsAppliedToPullRequestAndLabelIsInEnvironment(t *t
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	internalLabelID := aladino.BuildInternalLabelID(wantLabel)
 	mockedEnv.GetRegisterMap()[internalLabelID] = aladino.BuildStringValue(wantLabel)
 
 	args := []aladino.Value{aladino.BuildStringValue(wantLabel)}
-	err = removeLabel(mockedEnv, args)
+	err := removeLabel(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.Equal(t, wantLabel, gotLabel)
@@ -89,7 +84,8 @@ func TestRemoveLabel_WhenLabelIsAppliedToPullRequestAndLabelIsInEnvironment(t *t
 func TestRemoveLabel_WhenLabelIsAppliedToPullRequestAndLabelIsNotInEnvironment(t *testing.T) {
 	wantLabel := "enhancement"
 	var gotLabel string
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposLabelsByOwnerByRepoByName,
@@ -107,12 +103,9 @@ func TestRemoveLabel_WhenLabelIsAppliedToPullRequestAndLabelIsNotInEnvironment(t
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(wantLabel)}
-	err = removeLabel(mockedEnv, args)
+	err := removeLabel(mockedEnv, args)
 
 	assert.Nil(t, err)
 	assert.Equal(t, wantLabel, gotLabel)

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -39,10 +39,10 @@ func PluginBuiltIns() *aladino.BuiltIns {
 			"labels":            functions.Labels(),
 			"milestone":         functions.Milestone(),
 			"reviewers":         functions.Reviewers(),
+			"reviewerStatus":    functions.ReviewerStatus(),
 			"size":              functions.Size(),
 			"title":             functions.Title(),
 			"workflowStatus":    functions.WorkflowStatus(),
-			"reviewerStatus":    functions.ReviewerStatus(),
 			// Organization
 			"organization": functions.Organization(),
 			"team":         functions.Team(),

--- a/plugins/aladino/functions/appendString_test.go
+++ b/plugins/aladino/functions/appendString_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
@@ -16,10 +15,7 @@ import (
 var appendString = plugins_aladino.PluginBuiltIns().Functions["append"].Code
 
 func TestAppendString(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	slice := aladino.BuildArrayValue(
 		[]aladino.Value{

--- a/plugins/aladino/functions/assignees_test.go
+++ b/plugins/aladino/functions/assignees_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -25,7 +24,8 @@ func TestAssignees(t *testing.T) {
 			{Login: github.String(assigneeLogin)},
 		},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -36,9 +36,6 @@ func TestAssignees(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedAssignees := mockedEnv.GetPullRequest().Assignees
 	wantAssigneesLogins := make([]aladino.Value, len(mockedAssignees))

--- a/plugins/aladino/functions/author_test.go
+++ b/plugins/aladino/functions/author_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -23,7 +22,8 @@ func TestAuthor(t *testing.T) {
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		User: &github.User{Login: github.String(authorLogin)},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -34,9 +34,6 @@ func TestAuthor(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantAuthor := aladino.BuildStringValue(authorLogin)
 

--- a/plugins/aladino/functions/base_test.go
+++ b/plugins/aladino/functions/base_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -31,7 +30,8 @@ func TestBase(t *testing.T) {
 			Ref: github.String(baseRef),
 		},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -42,9 +42,6 @@ func TestBase(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantBase := aladino.BuildStringValue(baseRef)
 

--- a/plugins/aladino/functions/commentCount_test.go
+++ b/plugins/aladino/functions/commentCount_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
@@ -18,10 +17,7 @@ var commentCount = plugins_aladino.PluginBuiltIns().Functions["commentCount"].Co
 func TestCommentCount(t *testing.T) {
 	wantCommentCount := aladino.BuildIntValue(6)
 
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{}
 	gotCommentCount, err := commentCount(mockedEnv, args)

--- a/plugins/aladino/functions/comments_test.go
+++ b/plugins/aladino/functions/comments_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -25,7 +24,8 @@ func TestComments(t *testing.T) {
 		},
 	)
 
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -39,10 +39,6 @@ func TestComments(t *testing.T) {
 		nil,
 	)
 
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
-
 	args := []aladino.Value{}
 	gotComments, err := comments(mockedEnv, args)
 
@@ -52,8 +48,8 @@ func TestComments(t *testing.T) {
 
 func TestComments_WhenGetCommentsRequestFailed(t *testing.T) {
 	failMessage := "GetCommentsRequestFailed"
-
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -68,10 +64,6 @@ func TestComments_WhenGetCommentsRequestFailed(t *testing.T) {
 		},
 		nil,
 	)
-
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
 	gotComments, err := comments(mockedEnv, args)

--- a/plugins/aladino/functions/commitCount_test.go
+++ b/plugins/aladino/functions/commitCount_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -23,7 +22,8 @@ func TestCommitCount(t *testing.T) {
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		Commits: &totalCommits,
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -34,9 +34,6 @@ func TestCommitCount(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantCommitCount := aladino.BuildIntValue(totalCommits)
 

--- a/plugins/aladino/functions/commits_test.go
+++ b/plugins/aladino/functions/commits_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -20,7 +19,8 @@ var commits = plugins_aladino.PluginBuiltIns().Functions["commits"].Code
 
 func TestCommits_WhenListCommitsRequestFails(t *testing.T) {
 	failMessage := "ListCommitsRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
@@ -35,9 +35,6 @@ func TestCommits_WhenListCommitsRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
 	gotCommits, err := commits(mockedEnv, args)
@@ -54,7 +51,8 @@ func TestCommits(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
@@ -63,9 +61,6 @@ func TestCommits(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantCommitsMessages := make([]aladino.Value, len(repoCommits))
 	for i, repoCommit := range repoCommits {

--- a/plugins/aladino/functions/contains_test.go
+++ b/plugins/aladino/functions/contains_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
@@ -16,10 +15,7 @@ import (
 var contains = plugins_aladino.PluginBuiltIns().Functions["contains"].Code
 
 func TestContainsTrue(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantVal := aladino.BuildBoolValue(true)
 
@@ -35,10 +31,7 @@ func TestContainsTrue(t *testing.T) {
 }
 
 func TestContainsFalse(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantVal := aladino.BuildBoolValue(false)
 

--- a/plugins/aladino/functions/createdAt_test.go
+++ b/plugins/aladino/functions/createdAt_test.go
@@ -24,7 +24,8 @@ func TestCreatedAt(t *testing.T) {
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		CreatedAt: &date,
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -35,9 +36,6 @@ func TestCreatedAt(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantCreatedAtTime, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", date.String())
 	if err != nil {

--- a/plugins/aladino/functions/description_test.go
+++ b/plugins/aladino/functions/description_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -23,7 +22,8 @@ func TestDescription(t *testing.T) {
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		Body: github.String(prDescription),
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -34,9 +34,6 @@ func TestDescription(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantDescription := aladino.BuildStringValue(prDescription)
 

--- a/plugins/aladino/functions/fileCount_test.go
+++ b/plugins/aladino/functions/fileCount_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -25,7 +24,8 @@ func TestFileCount(t *testing.T) {
 			Patch:    nil,
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -36,9 +36,6 @@ func TestFileCount(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantFileCount := aladino.BuildIntValue(len(*mockedPullRequestFileList))
 

--- a/plugins/aladino/functions/filter_test.go
+++ b/plugins/aladino/functions/filter_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
@@ -17,10 +16,7 @@ var filter = plugins_aladino.PluginBuiltIns().Functions["filter"].Code
 
 func TestFilter(t *testing.T) {
 	mockedIntValue := aladino.BuildIntValue(1)
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{
 		aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("1"), mockedIntValue}),

--- a/plugins/aladino/functions/group_test.go
+++ b/plugins/aladino/functions/group_test.go
@@ -6,7 +6,6 @@ package plugins_aladino_functions_test
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
@@ -18,10 +17,7 @@ var group = plugins_aladino.PluginBuiltIns().Functions["group"].Code
 
 func TestGroup(t *testing.T) {
 	groupName := "techLeads"
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantGroup := aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("john"), aladino.BuildStringValue("arthur")})
 
@@ -36,10 +32,7 @@ func TestGroup(t *testing.T) {
 
 func TestGroup_WhenGroupIsNonExisting(t *testing.T) {
 	groupName := "techLeads"
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	// Make sure that the group 'techLeads' doesn't exist
 	delete(mockedEnv.GetRegisterMap(), groupName)

--- a/plugins/aladino/functions/hasCodePattern_test.go
+++ b/plugins/aladino/functions/hasCodePattern_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -24,7 +23,8 @@ func TestHasCodePattern_WhenPullRequestPatchHasNilFile(t *testing.T) {
 		Patch:    nil,
 		Filename: github.String(fileName),
 	}}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -35,9 +35,6 @@ func TestHasCodePattern_WhenPullRequestPatchHasNilFile(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedEnv.GetPatch()[fileName] = nil
 
@@ -51,10 +48,7 @@ func TestHasCodePattern_WhenPullRequestPatchHasNilFile(t *testing.T) {
 }
 
 func TestHasCodePattern_WhenPatternIsInvalid(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{aladino.BuildStringValue("a(")}
 	gotVal, err := hasCodePattern(mockedEnv, args)
@@ -68,7 +62,8 @@ func TestHasCodePattern(t *testing.T) {
 		Patch:    github.String("@@ -2,9 +2,11 @@ package main\n- func previous() {\n+ func new() {\n+\nreturn"),
 		Filename: github.String("default-mock-repo/file1.ts"),
 	}}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -79,9 +74,6 @@ func TestHasCodePattern(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue("new\\(.*\\)")}
 	gotVal, err := hasCodePattern(mockedEnv, args)

--- a/plugins/aladino/functions/hasFileExtensions_test.go
+++ b/plugins/aladino/functions/hasFileExtensions_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -26,7 +25,8 @@ func TestHasFileExtensions_WhenFalse(t *testing.T) {
 			Patch:    nil,
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -37,9 +37,6 @@ func TestHasFileExtensions_WhenFalse(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue(".md")})}
 	gotVal, err := hasFileExtensions(mockedEnv, args)
@@ -58,7 +55,8 @@ func TestHasFileExtensions_WhenTrue(t *testing.T) {
 			Patch:    nil,
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -69,9 +67,6 @@ func TestHasFileExtensions_WhenTrue(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue(".ts")})}
 	gotVal, err := hasFileExtensions(mockedEnv, args)

--- a/plugins/aladino/functions/hasFileName_test.go
+++ b/plugins/aladino/functions/hasFileName_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -26,7 +25,8 @@ func TestHasFileName_WhenTrue(t *testing.T) {
 			Patch:    nil,
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -37,9 +37,6 @@ func TestHasFileName_WhenTrue(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(defaultMockPrFileName)}
 	gotVal, err := hasFileName(mockedEnv, args)
@@ -58,7 +55,8 @@ func TestHasFileName_WhenFalse(t *testing.T) {
 			Patch:    nil,
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -69,9 +67,6 @@ func TestHasFileName_WhenFalse(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(defaultMockPrFileName)}
 	gotVal, err := hasFileName(mockedEnv, args)

--- a/plugins/aladino/functions/hasFilePattern_test.go
+++ b/plugins/aladino/functions/hasFilePattern_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -19,10 +18,7 @@ import (
 var hasFilePattern = plugins_aladino.PluginBuiltIns().Functions["hasFilePattern"].Code
 
 func TestHasFilePattern_WhenFileBadPattern(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{aladino.BuildStringValue("[0-9")}
 	gotVal, err := hasFilePattern(mockedEnv, args)
@@ -41,7 +37,8 @@ func TestHasFilePattern_WhenTrue(t *testing.T) {
 			Patch:    nil,
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -52,9 +49,6 @@ func TestHasFilePattern_WhenTrue(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue("default-mock-repo/**")}
 	gotVal, err := hasFilePattern(mockedEnv, args)
@@ -73,7 +67,8 @@ func TestHasFilePattern_WhenFalse(t *testing.T) {
 			Patch:    nil,
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -84,9 +79,6 @@ func TestHasFilePattern_WhenFalse(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue("default-mock-repo/test/**")}
 	gotVal, err := hasFilePattern(mockedEnv, args)

--- a/plugins/aladino/functions/hasLinearHistory_test.go
+++ b/plugins/aladino/functions/hasLinearHistory_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -20,7 +19,8 @@ var hasLinearHistory = plugins_aladino.PluginBuiltIns().Functions["hasLinearHist
 
 func TestHasLinearHistory_WhenListCommitsRequestFails(t *testing.T) {
 	failMessage := "ListCommitsRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
@@ -35,9 +35,6 @@ func TestHasLinearHistory_WhenListCommitsRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
 	gotVal, err := hasLinearHistory(mockedEnv, args)
@@ -62,7 +59,8 @@ func TestHasLinearHistory_WhenFalse(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
@@ -71,9 +69,6 @@ func TestHasLinearHistory_WhenFalse(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
 	gotVal, err := hasLinearHistory(mockedEnv, args)
@@ -98,7 +93,8 @@ func TestHasLinearHistory_WhenTrue(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
@@ -107,9 +103,6 @@ func TestHasLinearHistory_WhenTrue(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
 	gotVal, err := hasLinearHistory(mockedEnv, args)

--- a/plugins/aladino/functions/hasLinkedIssues_test.go
+++ b/plugins/aladino/functions/hasLinkedIssues_test.go
@@ -6,7 +6,6 @@ package plugins_aladino_functions_test
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"testing"
 
@@ -20,17 +19,15 @@ import (
 var hasLinkedIssues = plugins_aladino.PluginBuiltIns().Functions["hasLinkedIssues"].Code
 
 func TestHasLinkedIssues_WhenRequestFails(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		nil,
 		func(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, "404 Not Found", http.StatusNotFound)
 		},
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
-	_, err = hasLinkedIssues(mockedEnv, []aladino.Value{})
+	_, err := hasLinkedIssues(mockedEnv, []aladino.Value{})
 
 	assert.NotNil(t, err)
 }
@@ -58,7 +55,8 @@ func TestHasLinkedIssues_WhenHasLinkedIssues(t *testing.T) {
 			},
 		},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -86,9 +84,6 @@ func TestHasLinkedIssues_WhenHasLinkedIssues(t *testing.T) {
 			}
 		},
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEvalEnvWithGQ failed: %v", err)
-	}
 
 	wantVal := aladino.BuildBoolValue(true)
 	gotVal, err := hasLinkedIssues(mockedEnv, []aladino.Value{})
@@ -120,7 +115,8 @@ func TestHasLinkedIssues_WhenNoLinkedIssues(t *testing.T) {
 			},
 		},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -148,9 +144,7 @@ func TestHasLinkedIssues_WhenNoLinkedIssues(t *testing.T) {
 			}
 		},
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEvalEnvWithGQ failed: %v", err)
-	}
+
 	wantVal := aladino.BuildBoolValue(false)
 	gotVal, err := hasLinkedIssues(mockedEnv, []aladino.Value{})
 

--- a/plugins/aladino/functions/head_test.go
+++ b/plugins/aladino/functions/head_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -31,7 +30,8 @@ func TestHead(t *testing.T) {
 			Ref: github.String(headRef),
 		},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -42,9 +42,6 @@ func TestHead(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantHead := aladino.BuildStringValue(headRef)
 

--- a/plugins/aladino/functions/isDraft_test.go
+++ b/plugins/aladino/functions/isDraft_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -22,7 +21,8 @@ func TestIsDraft_WhenTrue(t *testing.T) {
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		Draft: github.Bool(true),
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -33,9 +33,6 @@ func TestIsDraft_WhenTrue(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
 	gotVal, err := isDraft(mockedEnv, args)
@@ -50,7 +47,8 @@ func TestIsDraft_WhenFalse(t *testing.T) {
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		Draft: github.Bool(false),
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -61,9 +59,6 @@ func TestIsDraft_WhenFalse(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
 	gotVal, err := isDraft(mockedEnv, args)

--- a/plugins/aladino/functions/isElementOf_test.go
+++ b/plugins/aladino/functions/isElementOf_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
@@ -16,10 +15,7 @@ import (
 var isElementOf = plugins_aladino.PluginBuiltIns().Functions["isElementOf"].Code
 
 func TestIsElementOf_WhenTrue(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{
 		aladino.BuildStringValue("elemA"),
@@ -37,10 +33,7 @@ func TestIsElementOf_WhenTrue(t *testing.T) {
 }
 
 func TestIsElementOf_WhenFalse(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{
 		aladino.BuildStringValue("elemA"),

--- a/plugins/aladino/functions/labels_test.go
+++ b/plugins/aladino/functions/labels_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -26,7 +25,8 @@ func TestLabels(t *testing.T) {
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		Labels: ghLabels,
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -37,9 +37,6 @@ func TestLabels(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantLabels := aladino.BuildArrayValue([]aladino.Value{
 		aladino.BuildStringValue("bug"),

--- a/plugins/aladino/functions/length_test.go
+++ b/plugins/aladino/functions/length_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
@@ -16,10 +15,7 @@ import (
 var length = plugins_aladino.PluginBuiltIns().Functions["length"].Code
 
 func TestLength(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	slice := aladino.BuildArrayValue(
 		[]aladino.Value{

--- a/plugins/aladino/functions/milestone_test.go
+++ b/plugins/aladino/functions/milestone_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -25,7 +24,8 @@ func TestMilestone(t *testing.T) {
 			Title: github.String(milestoneTitle),
 		},
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -36,9 +36,6 @@ func TestMilestone(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
 	gotMilestoneTitle, err := milestone(mockedEnv, args)

--- a/plugins/aladino/functions/organization_test.go
+++ b/plugins/aladino/functions/organization_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -20,7 +19,8 @@ var organization = plugins_aladino.PluginBuiltIns().Functions["organization"].Co
 
 func TestOrganization_WhenListMembersRequestFails(t *testing.T) {
 	failMessage := "ListMembersRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetOrgsPublicMembersByOrg,
@@ -45,9 +45,6 @@ func TestOrganization_WhenListMembersRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{}
 	gotMembers, err := organization(mockedEnv, args)
@@ -61,7 +58,8 @@ func TestOrganization(t *testing.T) {
 		{Login: github.String("john")},
 		{Login: github.String("jane")},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetOrgsMembersByOrg,
@@ -70,9 +68,6 @@ func TestOrganization(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantMembers := aladino.BuildArrayValue([]aladino.Value{
 		aladino.BuildStringValue("john"),

--- a/plugins/aladino/functions/reviewerStatus_test.go
+++ b/plugins/aladino/functions/reviewerStatus_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -20,7 +19,8 @@ var reviewerStatus = plugins_aladino.PluginBuiltIns().Functions["reviewerStatus"
 
 func TestReviewerStatus_WhenRequestFails(t *testing.T) {
 	failMessage := "ReviewerStatusRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -35,9 +35,6 @@ func TestReviewerStatus_WhenRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue("mary")}
 	gotReviewState, err := reviewerStatus(mockedEnv, args)
@@ -52,7 +49,8 @@ func TestReviewerStatus_WhenUserIsNil(t *testing.T) {
 			State: github.String("COMMENTED"),
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -61,9 +59,6 @@ func TestReviewerStatus_WhenUserIsNil(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantReviewState := aladino.BuildStringValue("")
 
@@ -82,7 +77,8 @@ func TestReviewerStatus_WhenStateIsNil(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -91,9 +87,6 @@ func TestReviewerStatus_WhenStateIsNil(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantReviewState := aladino.BuildStringValue("")
 
@@ -113,7 +106,8 @@ func TestReviewerStatus_WhenStateUnknown(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -122,9 +116,6 @@ func TestReviewerStatus_WhenStateUnknown(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantReviewState := aladino.BuildStringValue("")
 
@@ -150,7 +141,8 @@ func TestReviewerStatus_WhenStateCommented(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -159,9 +151,6 @@ func TestReviewerStatus_WhenStateCommented(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantReviewState := aladino.BuildStringValue("COMMENTED")
 
@@ -205,7 +194,8 @@ func TestReviewerStatus_WhenStateApproved(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -214,9 +204,6 @@ func TestReviewerStatus_WhenStateApproved(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantReviewState := aladino.BuildStringValue("APPROVED")
 
@@ -254,7 +241,8 @@ func TestReviewerStatus_WhenStateRequestedChanges(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -263,9 +251,6 @@ func TestReviewerStatus_WhenStateRequestedChanges(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantReviewState := aladino.BuildStringValue("CHANGES_REQUESTED")
 

--- a/plugins/aladino/functions/reviewers_test.go
+++ b/plugins/aladino/functions/reviewers_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -32,7 +31,8 @@ func TestReviewers(t *testing.T) {
 		RequestedReviewers: ghUsersReviewers,
 		RequestedTeams:     ghTeamReviewers,
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -43,9 +43,6 @@ func TestReviewers(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantReviewers := aladino.BuildArrayValue([]aladino.Value{
 		aladino.BuildStringValue("mary"),

--- a/plugins/aladino/functions/rule_test.go
+++ b/plugins/aladino/functions/rule_test.go
@@ -6,7 +6,6 @@ package plugins_aladino_functions_test
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
@@ -18,10 +17,7 @@ var rule = plugins_aladino.PluginBuiltIns().Functions["rule"].Code
 
 func TestRule_WhenRuleIsAbsent(t *testing.T) {
 	ruleName := "is-absent"
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	args := []aladino.Value{aladino.BuildStringValue(ruleName)}
 	gotVal, err := rule(mockedEnv, args)
@@ -33,10 +29,7 @@ func TestRule_WhenRuleIsAbsent(t *testing.T) {
 func TestRule_WhenRuleIsInvalid(t *testing.T) {
 	ruleName := "is-invalid"
 	internalRuleName := fmt.Sprintf("@rule:%v", ruleName)
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	mockedEnv.GetRegisterMap()[internalRuleName] = aladino.BuildStringValue("1 == \"a\"")
 
@@ -50,10 +43,7 @@ func TestRule_WhenRuleIsInvalid(t *testing.T) {
 func TestRule_WhenRuleIsTrue(t *testing.T) {
 	ruleName := "tautology"
 	internalRuleName := fmt.Sprintf("@rule:%v", ruleName)
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	mockedEnv.GetRegisterMap()[internalRuleName] = aladino.BuildStringValue("1 == 1")
 
@@ -69,10 +59,7 @@ func TestRule_WhenRuleIsTrue(t *testing.T) {
 func TestRule_WhenRuleIsFalse(t *testing.T) {
 	ruleName := "is-false-premise"
 	internalRuleName := fmt.Sprintf("@rule:%v", ruleName)
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	mockedEnv.GetRegisterMap()[internalRuleName] = aladino.BuildStringValue("1 == 2")
 

--- a/plugins/aladino/functions/size_test.go
+++ b/plugins/aladino/functions/size_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -25,7 +24,8 @@ func TestSize(t *testing.T) {
 		Additions: github.Int(additions),
 		Deletions: github.Int(deletions),
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -36,9 +36,6 @@ func TestSize(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantSize := aladino.BuildIntValue(additions + deletions)
 

--- a/plugins/aladino/functions/startsWith_test.go
+++ b/plugins/aladino/functions/startsWith_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
@@ -16,10 +15,7 @@ import (
 var startsWith = plugins_aladino.PluginBuiltIns().Functions["startsWith"].Code
 
 func TestStarts_WhenTrue(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantVal := aladino.BuildBoolValue(true)
 
@@ -35,10 +31,7 @@ func TestStarts_WhenTrue(t *testing.T) {
 }
 
 func TestStarts_WhenFalse(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	wantVal := aladino.BuildBoolValue(false)
 

--- a/plugins/aladino/functions/team_test.go
+++ b/plugins/aladino/functions/team_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -21,7 +20,8 @@ var team = plugins_aladino.PluginBuiltIns().Functions["team"].Code
 func TestTeam_WhenListTeamMembersBySlugRequestFails(t *testing.T) {
 	teamSlug := "reviewpad-team"
 	failMessage := "ListTeamMembersBySlugRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetOrgsTeamsMembersByOrgByTeamSlug,
@@ -36,9 +36,6 @@ func TestTeam_WhenListTeamMembersBySlugRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(teamSlug)}
 	gotMembers, err := team(mockedEnv, args)
@@ -53,7 +50,8 @@ func TestTeam(t *testing.T) {
 		{Login: github.String("john")},
 		{Login: github.String("jane")},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetOrgsTeamsMembersByOrgByTeamSlug,
@@ -62,9 +60,6 @@ func TestTeam(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantMembers := aladino.BuildArrayValue([]aladino.Value{
 		aladino.BuildStringValue("john"),

--- a/plugins/aladino/functions/title_test.go
+++ b/plugins/aladino/functions/title_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -23,7 +22,8 @@ func TestTitle(t *testing.T) {
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		Title: github.String(prTitle),
 	})
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepoByPullNumber,
@@ -34,9 +34,6 @@ func TestTitle(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantTitle := aladino.BuildStringValue(prTitle)
 

--- a/plugins/aladino/functions/totalCreatedPullRequests_test.go
+++ b/plugins/aladino/functions/totalCreatedPullRequests_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -21,7 +20,8 @@ var totalCreatedPullRequests = plugins_aladino.PluginBuiltIns().Functions["total
 func TestTotalCreatedPullRequests_WhenListIssuesByRepoRequestFails(t *testing.T) {
 	devName := "steve"
 	failMessage := "ListListIssuesByRepoRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposIssuesByOwnerByRepo,
@@ -36,9 +36,6 @@ func TestTotalCreatedPullRequests_WhenListIssuesByRepoRequestFails(t *testing.T)
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(devName)}
 	gotTotal, err := totalCreatedPullRequests(mockedEnv, args)
@@ -61,7 +58,8 @@ func TestTotalCreatedPullRequests_WhenThereIsPullRequestIssues(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesByOwnerByRepo,
@@ -70,9 +68,6 @@ func TestTotalCreatedPullRequests_WhenThereIsPullRequestIssues(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	wantTotal := aladino.BuildIntValue(1)
 

--- a/plugins/aladino/functions/workflowStatus_test.go
+++ b/plugins/aladino/functions/workflowStatus_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_functions_test
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -23,14 +22,12 @@ func TestWorkflowStatus_WhenEventPayloadIsNotWorkflowRunEvent(t *testing.T) {
 	wantValue := aladino.BuildStringValue("")
 
 	eventPayload := &github.CheckRunEvent{}
-	mockedEnv, err := aladino.MockDefaultEnvWithEvent(
+	mockedEnv := aladino.MockDefaultEnvEvent(
+		t,
 		nil,
 		nil,
 		eventPayload,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnvWithEvent failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(checkName)}
 	gotValue, err := workflowStatus(mockedEnv, args)
@@ -46,14 +43,12 @@ func TestWorkflowStatus_WhenWorkflowRunIsNil(t *testing.T) {
 	eventPayload := &github.WorkflowRunEvent{
 		WorkflowRun: nil,
 	}
-	mockedEnv, err := aladino.MockDefaultEnvWithEvent(
+	mockedEnv := aladino.MockDefaultEnvEvent(
+		t,
 		nil,
 		nil,
 		eventPayload,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnvWithEvent failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(checkName)}
 	gotValue, err := workflowStatus(mockedEnv, args)
@@ -72,7 +67,8 @@ func TestWorkflowStatus_WhenListCheckRunsForRefRequestFails(t *testing.T) {
 			HeadSHA: &headSHA,
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnvWithEvent(
+	mockedEnv := aladino.MockDefaultEnvEvent(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -88,9 +84,6 @@ func TestWorkflowStatus_WhenListCheckRunsForRefRequestFails(t *testing.T) {
 		nil,
 		eventPayload,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnvWithEvent failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(checkName)}
 	gotValue, err := workflowStatus(mockedEnv, args)
@@ -113,7 +106,8 @@ func TestWorkflowStatus_WhenCheckRunNotFoundDueToEmptyCheckRuns(t *testing.T) {
 	emptyCheckRuns := &github.ListCheckRunsResults{
 		CheckRuns: []*github.CheckRun{},
 	}
-	mockedEnv, err := aladino.MockDefaultEnvWithEvent(
+	mockedEnv := aladino.MockDefaultEnvEvent(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -125,9 +119,6 @@ func TestWorkflowStatus_WhenCheckRunNotFoundDueToEmptyCheckRuns(t *testing.T) {
 		nil,
 		eventPayload,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnvWithEvent failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(checkName)}
 	gotValue, err := workflowStatus(mockedEnv, args)
@@ -155,7 +146,8 @@ func TestWorkflowStatus_WhenCheckRunIsMissingInNonEmptyCheckRuns(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnvWithEvent(
+	mockedEnv := aladino.MockDefaultEnvEvent(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -167,9 +159,6 @@ func TestWorkflowStatus_WhenCheckRunIsMissingInNonEmptyCheckRuns(t *testing.T) {
 		nil,
 		eventPayload,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnvWithEvent failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(checkName)}
 	gotValue, err := workflowStatus(mockedEnv, args)
@@ -204,7 +193,8 @@ func TestWorkflowStatus_WhenEventIsCompleted(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnvWithEvent(
+	mockedEnv := aladino.MockDefaultEnvEvent(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -216,9 +206,6 @@ func TestWorkflowStatus_WhenEventIsCompleted(t *testing.T) {
 		nil,
 		eventPayload,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnvWithEvent failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(checkName)}
 	gotValue, err := workflowStatus(mockedEnv, args)
@@ -251,7 +238,8 @@ func TestWorkflowStatus_WhenEventIsNotCompleted(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnvWithEvent(
+	mockedEnv := aladino.MockDefaultEnvEvent(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -263,9 +251,6 @@ func TestWorkflowStatus_WhenEventIsNotCompleted(t *testing.T) {
 		nil,
 		eventPayload,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnvWithEvent failed: %v", err)
-	}
 
 	args := []aladino.Value{aladino.BuildStringValue(checkName)}
 	gotValue, err := workflowStatus(mockedEnv, args)

--- a/utils/github_test.go
+++ b/utils/github_test.go
@@ -6,7 +6,6 @@ package utils_test
 
 import (
 	"errors"
-	"log"
 	"net/http"
 	"testing"
 
@@ -56,10 +55,7 @@ func TestGetPullRequestHeadRepoName(t *testing.T) {
 }
 
 func TestGetPullRequestBaseOwnerName(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	wantOwnerName := mockedPullRequest.Base.Repo.Owner.GetLogin()
@@ -69,10 +65,7 @@ func TestGetPullRequestBaseOwnerName(t *testing.T) {
 }
 
 func TestGetPullRequestBaseRepoName(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	wantRepoName := mockedPullRequest.Base.Repo.GetName()
@@ -82,10 +75,7 @@ func TestGetPullRequestBaseRepoName(t *testing.T) {
 }
 
 func TestGetPullRequestNumber(t *testing.T) {
-	mockedEnv, err := aladino.MockDefaultEnv(nil, nil)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil)
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	wantPullRequestNumber := mockedPullRequest.GetNumber()
@@ -255,7 +245,8 @@ func TestParseNumPages(t *testing.T) {
 
 func TestGetPullRequestComments_WhenListCommentsRequestFails(t *testing.T) {
 	failMessage := "ListCommentsRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -270,9 +261,6 @@ func TestGetPullRequestComments_WhenListCommentsRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	comments, err := utils.GetPullRequestComments(
@@ -292,7 +280,8 @@ func TestGetPullRequestComments(t *testing.T) {
 	wantComments := []*github.IssueComment{
 		{Body: github.String("Lorem Ipsum")},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
@@ -301,9 +290,6 @@ func TestGetPullRequestComments(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	gotComments, err := utils.GetPullRequestComments(
@@ -326,7 +312,8 @@ func TestGetPullRequestFiles(t *testing.T) {
 			Patch:    nil,
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -337,9 +324,6 @@ func TestGetPullRequestFiles(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	gotFiles, err := utils.GetPullRequestFiles(
@@ -356,7 +340,8 @@ func TestGetPullRequestFiles(t *testing.T) {
 
 func TestGetPullRequestReviewers_WhenListReviewersRequestFails(t *testing.T) {
 	failMessage := "ListReviewersRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
@@ -371,9 +356,6 @@ func TestGetPullRequestReviewers_WhenListReviewersRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	reviewers, err := utils.GetPullRequestReviewers(
@@ -398,7 +380,8 @@ func TestGetPullRequestReviewers(t *testing.T) {
 			{Slug: github.String("reviewpad-team")},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
@@ -407,9 +390,6 @@ func TestGetPullRequestReviewers(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	gotReviewers, err := utils.GetPullRequestReviewers(
@@ -427,7 +407,8 @@ func TestGetPullRequestReviewers(t *testing.T) {
 
 func TestGetRepoCollaborators_WhenListCollaboratorsRequestFails(t *testing.T) {
 	failMessage := "ListCollaboratorsRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposCollaboratorsByOwnerByRepo,
@@ -442,9 +423,6 @@ func TestGetRepoCollaborators_WhenListCollaboratorsRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	collaborators, err := utils.GetRepoCollaborators(
@@ -462,7 +440,8 @@ func TestGetRepoCollaborators(t *testing.T) {
 	wantCollaborators := []*github.User{
 		{Login: github.String("mary")},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposCollaboratorsByOwnerByRepo,
@@ -471,9 +450,6 @@ func TestGetRepoCollaborators(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	gotCollaborators, err := utils.GetRepoCollaborators(
@@ -489,7 +465,8 @@ func TestGetRepoCollaborators(t *testing.T) {
 
 func TestGetIssuesAvailableAssignees_WhenListAssigneesRequestFails(t *testing.T) {
 	failMessage := "ListAssigneesRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposAssigneesByOwnerByRepo,
@@ -504,9 +481,6 @@ func TestGetIssuesAvailableAssignees_WhenListAssigneesRequestFails(t *testing.T)
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	gotAssignees, err := utils.GetIssuesAvailableAssignees(
@@ -524,7 +498,8 @@ func TestGetIssuesAvailableAssignees(t *testing.T) {
 	wantAssignees := []*github.User{
 		{Login: github.String("jane")},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposAssigneesByOwnerByRepo,
@@ -533,9 +508,6 @@ func TestGetIssuesAvailableAssignees(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	gotAssignees, err := utils.GetIssuesAvailableAssignees(
@@ -551,7 +523,8 @@ func TestGetIssuesAvailableAssignees(t *testing.T) {
 
 func TestGetPullRequestCommits_WhenListCommistsRequestFails(t *testing.T) {
 	failMessage := "ListCommitsRequestFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
@@ -566,9 +539,6 @@ func TestGetPullRequestCommits_WhenListCommistsRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	gotCommits, err := utils.GetPullRequestCommits(
@@ -591,7 +561,8 @@ func TestGetPullRequestCommits(t *testing.T) {
 			},
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsCommitsByOwnerByRepoByPullNumber,
@@ -600,9 +571,6 @@ func TestGetPullRequestCommits(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	gotCommits, err := utils.GetPullRequestCommits(
@@ -626,7 +594,8 @@ func TestGetPullRequestReviews(t *testing.T) {
 			State: github.String("COMMENTED"),
 		},
 	}
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -635,9 +604,6 @@ func TestGetPullRequestReviews(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	gotReviews, err := utils.GetPullRequestReviews(
@@ -654,7 +620,8 @@ func TestGetPullRequestReviews(t *testing.T) {
 
 func TestGetPullRequestReviews_WhenRequestFails(t *testing.T) {
 	failMessage := "ListPullRequestReviewsFail"
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -669,9 +636,6 @@ func TestGetPullRequestReviews_WhenRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	mockedPullRequest := mockedEnv.GetPullRequest()
 	gotReviews, err := utils.GetPullRequestReviews(
@@ -692,7 +656,8 @@ func TestGetPullRequests(t *testing.T) {
 
 	wantPullRequests := []*github.PullRequest{}
 
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatch(
 				mock.GetReposPullsByOwnerByRepo,
@@ -701,9 +666,6 @@ func TestGetPullRequests(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	gotReviews, err := utils.GetPullRequests(
 		mockedEnv.GetCtx(),
@@ -722,7 +684,8 @@ func TestGetPullRequests_WhenRequestFails(t *testing.T) {
 	ownerName := "testOrg"
 	repoName := "testRepo"
 
-	mockedEnv, err := aladino.MockDefaultEnv(
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
 		[]mock.MockBackendOption{
 			mock.WithRequestMatchHandler(
 				mock.GetReposPullsByOwnerByRepo,
@@ -737,9 +700,6 @@ func TestGetPullRequests_WhenRequestFails(t *testing.T) {
 		},
 		nil,
 	)
-	if err != nil {
-		log.Fatalf("mockDefaultEnv failed: %v", err)
-	}
 
 	gotReviews, err := utils.GetPullRequests(
 		mockedEnv.GetCtx(),


### PR DESCRIPTION
## Description

The function mocks function for `env` are being for all the tests and may return an error, which pollutes all tests with the famous `if err != nil`.

However, this can be avoided if the function itself fails, which is enough for the unit test to fail. This is what this pull request proposes.

The big change is related with the fact that mocked `env` touches all unit tests.

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Related to #156 
<!-- Closes # (issue) -->

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
Refactor (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

The command `task check -f` was run and the coverage was maintained.

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues
