### PR TITLE
feat: normalize via injecting in yaml unmarshaller

### DIFF
--- a/engine/normalize.go
+++ b/engine/normalize.go
@@ -1,0 +1,133 @@
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// default properties values
+const (
+	defaultApiVersion = "reviewpad.com/v3.x"
+	defaultEdition    = "professional"
+	defaultMode       = "silent"
+)
+
+// allowed properties values
+var (
+	allowedEditions = []string{"professional", "team"} //[]string{defaultEdition, "team"}
+	allowedModes    = []string{"silent", "verbose"}
+)
+
+type propertyKey string
+
+const (
+	_version propertyKey = "Version"
+	_edition propertyKey = "Edition"
+	_mode    propertyKey = "Mode"
+)
+
+// normalizers contains all we need to properly normalize property values
+var normalizers = map[propertyKey]*Normalize{
+	_version: NewNormalize(defaultApiVersion).
+		WithValidators(func(val string) error {
+			apiVersReg := regexp.MustCompile(`^reviewpad\.com/v[0-3]\.[\dx]$`)
+			if apiVersReg.MatchString(val) {
+				return nil
+			}
+			return fmt.Errorf("incorrect api-version: %s", val)
+		}),
+	_edition: NewNormalize(defaultEdition, allowedEditions...),
+	_mode:    NewNormalize(defaultMode, allowedModes...),
+}
+
+// validator & modificator functions signature
+type (
+	validator   func(val string) error
+	modificator func(val string) string
+)
+
+// Normalize normalizes property values
+type Normalize struct {
+	// Default contains default property value
+	Default string
+
+	// Allowed contains allowed property values
+	Allowed []string
+
+	// Validators slice of functions to control property value
+	// could be checks, regexp etc
+	Validators []validator
+
+	// Modificators modify property value before validate and other controls
+	Modificators []modificator
+}
+
+// NewNormalize creates Normalize with default value as first argument
+// and with the list of allowed values if provided.
+// Two modificators to trim spaces and to lower case are added by default.
+func NewNormalize(defaultVal string, allowed ...string) *Normalize {
+	n := &Normalize{Default: defaultVal, Allowed: allowed}
+	n.WithModificators(strings.TrimSpace, strings.ToLower)
+	return n
+}
+
+// Do is the main method for property value normalization.
+// 1) if Modificators available - modifies value.
+// 2) if empty value - return default value
+// 3) if Validators available - try to validate value:
+//    - if validation fails returns default value and validation error
+//    - if validation passes returns value and nil error
+// 4) if Allowed list of values provided, checks if value in this list.
+//    - if ok return value and nil error
+//    - if not ok return default value and not allowed error
+// 5) returns value (if: not empty, nil Validators, nil Allowed). Returned value is modified with Modificators.
+func (n *Normalize) Do(val string) (string, error) {
+	if n.Modificators != nil {
+		for _, modiF := range n.Modificators {
+			val = modiF(val)
+		}
+	}
+
+	if val == "" {
+		return n.Default, nil
+	}
+
+	if n.Validators != nil {
+		for _, valFunc := range n.Validators {
+			if err := valFunc(val); err != nil {
+				return n.Default, fmt.Errorf("normalize.Do validation: %w", err)
+			}
+		}
+		return val, nil
+	}
+
+	if n.Allowed != nil {
+		for _, a := range n.Allowed {
+			if val == a {
+				return val, nil
+			}
+		}
+		return n.Default, fmt.Errorf("normalize.Do not in allowed list: %s", val)
+	}
+
+	return val, nil
+}
+
+// WithValidators adds validator functions to the Normalize
+func (n *Normalize) WithValidators(v ...validator) *Normalize {
+	if n.Validators == nil {
+		n.Validators = make([]validator, 0, len(v))
+	}
+	n.Validators = append(n.Validators, v...)
+	return n
+}
+
+// WithModificators adds modificator functions to the Normalize
+func (n *Normalize) WithModificators(m ...modificator) *Normalize {
+	if n.Modificators == nil {
+		n.Modificators = make([]modificator, 0, len(m))
+	}
+	n.Modificators = append(n.Modificators, m...)
+	return n
+}

--- a/engine/normalize_test.go
+++ b/engine/normalize_test.go
@@ -1,0 +1,89 @@
+package engine
+
+import (
+	"testing"
+)
+
+func TestNormalization(t *testing.T) {
+	t.Run("missing edition and mode", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeNoEditionNoMode))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+
+		if reviewpadFile.Edition != defaultEdition {
+			t.Fatalf("expected edition: %s, got edition: %s", defaultEdition, reviewpadFile.Edition)
+		}
+		if reviewpadFile.Mode != defaultMode {
+			t.Fatalf("expected mode: %s, got mode: %s", defaultMode, reviewpadFile.Mode)
+		}
+	})
+
+	t.Run("incorrect api-version number", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeIncorrectApiVersionNumber))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+		if reviewpadFile.Version != defaultApiVersion {
+			t.Fatalf("expected api-version: %s, got api-version: %s", defaultApiVersion, reviewpadFile.Version)
+		}
+	})
+
+	t.Run("correct lower api-version number", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeCorrectLowerApiVersionNumber))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+		if reviewpadFile.Version != testNormalizeCorrectExpectedVersion {
+			t.Fatalf("expected api-version: %s, got api-version: %s", testNormalizeCorrectExpectedVersion, reviewpadFile.Version)
+		}
+	})
+
+	t.Run("incorrect string case in edition", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeIncorrectCase))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+		if reviewpadFile.Edition != "team" {
+			t.Fatalf("expected edition: %s, got edition: %s", "team", reviewpadFile.Edition)
+		}
+	})
+
+	//debug output
+	/*y, err := yaml.Marshal(reviewpadFile)
+	  if err != nil {
+	  	t.Fatalf("err marshalling reviewpadFile: %s", err.Error())
+	  }
+	  fmt.Println(string(y))*/
+}
+
+const (
+	testNormalizeCorrectExpectedVersion       = "reviewpad.com/v2.x"
+	testNormalizeCorrectLowerApiVersionNumber = "api-version: " + testNormalizeCorrectExpectedVersion
+	testNormalizeIncorrectApiVersionNumber    = "api-version: reviewpad.com/v6.x"
+	testNormalizeIncorrectCase                = "edition: TeaM"
+	testNormalizeNoEditionNoMode              = `api-version: reviewpad.com/v3.x
+
+labels:
+  small:
+    description: Pull requests with less than 90 LOC
+    color: "f15d22"
+
+rules:
+  - name: isSmallPatch
+    kind: patch
+    description: Patch has less than 90 LOC
+    spec: $size() < 90
+
+workflows:
+  - name: labelSmall
+    description: Label small pull requests
+    if:
+      - rule: isSmallPatch
+    then:
+      - $addLabel("small")`
+)

--- a/engine/unmarshallers.go
+++ b/engine/unmarshallers.go
@@ -1,0 +1,39 @@
+package engine
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+// UnmarshalYAML our custom implementation of unmarshaller yaml interface.
+// On this stage we can inject normalizers for property values without affecting existing codebase.
+func (r *ReviewpadFile) UnmarshalYAML(value *yaml.Node) error {
+	var interim struct {
+		Version      string    `yaml:"api-version"`
+		Edition      string    `yaml:"edition"`
+		Mode         string    `yaml:"mode"`
+		IgnoreErrors bool      `yaml:"ignore-errors"`
+		Imports      yaml.Node `yaml:"imports"`
+		Groups       yaml.Node `yaml:"groups"`
+		Rules        yaml.Node `yaml:"rules"`
+		Labels       yaml.Node `yaml:"labels"`    //map[string]PadLabel
+		Workflows    yaml.Node `yaml:"workflows"` //[]PadWorkflow
+	}
+	if err := value.Decode(&interim); err != nil {
+		return err
+	}
+
+	// we need only default property values if incorrect or empty for these fields.
+	// so the errors are ignored here
+	r.Version, _ = normalizers[_version].Do(interim.Version)
+	r.Edition, _ = normalizers[_edition].Do(interim.Edition)
+	r.Mode, _ = normalizers[_mode].Do(interim.Mode)
+	r.IgnoreErrors = interim.IgnoreErrors
+
+	_ = interim.Imports.Decode(&r.Imports)
+	_ = interim.Groups.Decode(&r.Groups)
+	_ = interim.Rules.Decode(&r.Rules)
+	_ = interim.Labels.Decode(&r.Labels)
+	_ = interim.Workflows.Decode(&r.Workflows)
+
+	return nil
+}


### PR DESCRIPTION
## Description
 
This is the solution N1 for the normalization property values issue.
The advantage of this solution is that it doesn't affect the existing codebase and is based on abstractions and interfaces.
The idea is to inject normalization functionality on YAML unmarshalling stage ./engine/unmarshallers.go
The "Normalization" functionality itself is composable for different modifications and validations and concentrated in one place.
My solution N2 is partially based on N1 but will provide more flexibility and control on "getting property values" stage. But it will affect on existing codebase. N2 will be soon.
 
## Related issue
 
#162
 
## Type of change
 
<!-- Uncomment the right types of change from the options bellow: -->
 
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
 
## How was this tested?
 
Unit tests in ./engine/normalize_test.go
 
## Checklist
 
<!-- All checks are required in order to open a pull request ready to review. -->
 
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues
 
## Code review and merge strategy (ship/show/ask) 
 
<!-- Please uncomment and check only *one* of the following -->
 
<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
 - [x] Ask: this pull request requires a code review before merge
