### PR TITLE
fix: addToProject fetches the wrong project

### DIFF
--- a/plugins/aladino/actions/addToProject_test.go
+++ b/plugins/aladino/actions/addToProject_test.go
@@ -44,10 +44,11 @@ func TestAddToProject(t *testing.T) {
 	mockedGetProjectQuery := `{
         "query":"query($name: String! $repositoryName: String! $repositoryOwner: String!) {
             repository(owner: $repositoryOwner, name: $repositoryName) {
-                projectsV2(query: $name, first: 1, orderBy: {field: TITLE, direction: ASC}) {
+                projectsV2(query: $name, first: 50, orderBy: {field: TITLE, direction: ASC}) {
                     nodes{
                         id,
-                        number
+                        number,
+                        title
                     }
                 }
             }
@@ -143,7 +144,7 @@ func TestAddToProject(t *testing.T) {
 		{
 			name:                  "error getting project fields",
 			getProjectQuery:       mockedGetProjectQuery,
-			getProjectQueryBody:   `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1}]}}}}`,
+			getProjectQueryBody:   `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1, "title": "reviewpad"}]}}}}`,
 			getProjectFieldsQuery: mockedGetProjectFieldsQuery,
 			getProjectFieldsBody:  ``,
 			expectedError:         io.EOF,
@@ -151,7 +152,7 @@ func TestAddToProject(t *testing.T) {
 		{
 			name:                  "when project has no status field",
 			getProjectQuery:       mockedGetProjectQuery,
-			getProjectQueryBody:   `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1}]}}}}`,
+			getProjectQueryBody:   `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1, "title": "reviewpad"}]}}}}`,
 			getProjectFieldsQuery: mockedGetProjectFieldsQuery,
 			getProjectFieldsBody:  `{"data": {"repository":{"projectV2": {"fields": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": []}}}}}`,
 			expectedError:         plugins_aladino_actions.ErrProjectHasNoStatusField,
@@ -159,7 +160,7 @@ func TestAddToProject(t *testing.T) {
 		{
 			name:                  "when project status option is not found",
 			getProjectQuery:       mockedGetProjectQuery,
-			getProjectQueryBody:   `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1}]}}}}`,
+			getProjectQueryBody:   `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1, "title": "reviewpad"}]}}}}`,
 			getProjectFieldsQuery: mockedGetProjectFieldsQuery,
 			getProjectFieldsBody:  `{"data": {"repository":{"projectV2": {"fields": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [{"id": "1", "name": "status", "options": []}]}}}}}`,
 			expectedError:         plugins_aladino_actions.ErrProjectStatusNotFound,
@@ -167,7 +168,7 @@ func TestAddToProject(t *testing.T) {
 		{
 			name:                         "add project item error",
 			getProjectQuery:              mockedGetProjectQuery,
-			getProjectQueryBody:          `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1}]}}}}`,
+			getProjectQueryBody:          `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1, "title": "reviewpad"}]}}}}`,
 			getProjectFieldsQuery:        mockedGetProjectFieldsQuery,
 			getProjectFieldsBody:         `{"data": {"repository":{"projectV2": {"fields": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [{"id": "1", "name": "status", "options": [{"id": "1", "name": "to do"}]}]}}}}}`,
 			addProjectV2ItemByIdMutation: mockedAddProjectV2ItemByIdMutation,
@@ -176,7 +177,7 @@ func TestAddToProject(t *testing.T) {
 		{
 			name:                                  "no error",
 			getProjectQuery:                       mockedGetProjectQuery,
-			getProjectQueryBody:                   `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1}]}}}}`,
+			getProjectQueryBody:                   `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1, "title": "reviewpad"}]}}}}`,
 			getProjectFieldsQuery:                 mockedGetProjectFieldsQuery,
 			getProjectFieldsBody:                  `{"data": {"repository":{"projectV2": {"fields": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [{"id": "1", "name": "status", "options": [{"id": "1", "name": "to do"}]}]}}}}}`,
 			addProjectV2ItemByIdMutation:          mockedAddProjectV2ItemByIdMutation,


### PR DESCRIPTION
## Description

Fixed issue when we get project with similar name

## Related issue

Closes [issue #222](https://github.com/reviewpad/reviewpad/issues/222)

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

run tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
[x] Ask: this pull request requires a code review before merge
