### PR TITLE
feat: normalize ReviewpadFile functionality

### DIFF
--- a/engine/normalize.go
+++ b/engine/normalize.go
@@ -1,0 +1,171 @@
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// normalize function normalizes *ReviewpadFile with default values, validates and modifies property values.
+// If no customNormalizeRules specified, normalize uses default normalization rules
+// specified in defaultNormalizers
+// general usage: err := normalize(reviewpadFile)
+// normalize is not critical to errors. So if the error occurs while normalizing some property,
+// it just adds the error to the error list, and assigns the default value to the property.
+// It's up to you how to react on errors, but the idea is to normalize *ReviewpadFile with default values,
+// and to log errors if needed
+func normalize(f *ReviewpadFile, customNormalizeRules ...map[propertyKey]*NormalizeRule) error {
+	rules := defaultNormalizers
+	if len(customNormalizeRules) > 0 {
+		rules = customNormalizeRules[0]
+	}
+
+	// create a slice for the errors
+	var errStrings []string
+
+	for key, rule := range rules {
+		var err error
+		switch key {
+		case _version:
+			f.Version, err = rule.Do(f.Version)
+		case _edition:
+			f.Edition, err = rule.Do(f.Edition)
+		case _mode:
+			f.Mode, err = rule.Do(f.Mode)
+		}
+		if err != nil {
+			errStrings = append(errStrings, err.Error())
+		}
+	}
+
+	if errStrings != nil {
+		return fmt.Errorf(strings.Join(errStrings, "\n"))
+	}
+	return nil
+}
+
+// default properties values
+const (
+	defaultApiVersion = "reviewpad.com/v3.x"
+	defaultEdition    = "professional"
+	defaultMode       = "silent"
+)
+
+// allowed properties values
+var (
+	allowedEditions = []string{"professional", "team"} //[]string{defaultEdition, "team"}
+	allowedModes    = []string{"silent", "verbose"}
+)
+
+type propertyKey string
+
+const (
+	_version propertyKey = "Version"
+	_edition propertyKey = "Edition"
+	_mode    propertyKey = "Mode"
+)
+
+// defaultNormalizers contains all we need to properly normalize property values by default
+var defaultNormalizers = map[propertyKey]*NormalizeRule{
+	_version: NewNormalizeRule(defaultApiVersion).
+		WithValidators(func(val string) error {
+			apiVersReg := regexp.MustCompile(`^reviewpad\.com/v[0-3]\.[\dx]$`)
+			if apiVersReg.MatchString(val) {
+				return nil
+			}
+			return fmt.Errorf("incorrect api-version: %s", val)
+		}),
+	_edition: NewNormalizeRule(defaultEdition, allowedEditions...),
+	_mode:    NewNormalizeRule(defaultMode, allowedModes...),
+}
+
+// validator & modificator functions signature
+type (
+	validator   func(val string) error
+	modificator func(val string) string
+)
+
+// NormalizeRule normalizes property values
+type NormalizeRule struct {
+	// Default contains default property value
+	Default string
+
+	// Allowed contains allowed property values
+	Allowed []string
+
+	// Validators slice of functions to control property value
+	// could be checks, regexp etc
+	Validators []validator
+
+	// Modificators modify property value before validate and other controls
+	Modificators []modificator
+}
+
+// NewNormalizeRule creates NormalizeRule with default value as first argument
+// and with the list of allowed values if provided.
+// Two modificators to trim spaces and to lower case are added by default.
+func NewNormalizeRule(defaultVal string, allowed ...string) *NormalizeRule {
+	n := &NormalizeRule{Default: defaultVal, Allowed: allowed}
+	n.WithModificators(strings.TrimSpace, strings.ToLower)
+	return n
+}
+
+// Do is the main method for property value normalization.
+// 1) if Modificators available - modifies value.
+// 2) if empty value - return default value
+// 3) if Validators available - try to validate value:
+//    - if validation fails returns default value and validation error
+//    - if validation passes returns value and nil error
+// 4) if Allowed list of values provided, checks if value in this list.
+//    - if ok return value and nil error
+//    - if not ok return default value and not allowed error
+// 5) returns value (if: not empty, nil Validators, nil Allowed). Returned value is modified with Modificators.
+func (n *NormalizeRule) Do(val string) (string, error) {
+	if n.Modificators != nil {
+		for _, modiF := range n.Modificators {
+			val = modiF(val)
+		}
+	}
+
+	if val == "" {
+		return n.Default, nil
+	}
+
+	if n.Validators != nil {
+		for _, valFunc := range n.Validators {
+			if err := valFunc(val); err != nil {
+				return n.Default, fmt.Errorf("normalize.Do validation: %w", err)
+			}
+		}
+		return val, nil
+	}
+
+	if n.Allowed != nil {
+		for _, a := range n.Allowed {
+			if val == a {
+				return val, nil
+			}
+		}
+		return n.Default, fmt.Errorf("normalize.Do not in allowed list: %s", val)
+	}
+
+	return val, nil
+}
+
+// WithValidators adds validator functions to the NormalizeRule
+func (n *NormalizeRule) WithValidators(v ...validator) *NormalizeRule {
+	if n.Validators == nil {
+		n.Validators = make([]validator, 0, len(v))
+	}
+	n.Validators = append(n.Validators, v...)
+	return n
+}
+
+// WithModificators adds modificator functions to the NormalizeRule
+func (n *NormalizeRule) WithModificators(m ...modificator) *NormalizeRule {
+	if n.Modificators == nil {
+		n.Modificators = make([]modificator, 0, len(m))
+	}
+	n.Modificators = append(n.Modificators, m...)
+	return n
+}

--- a/engine/normalize_test.go
+++ b/engine/normalize_test.go
@@ -1,0 +1,193 @@
+package engine
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestNormalize(t *testing.T) {
+	t.Run("missing edition and mode", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeNoEditionNoMode))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+
+		_ = normalize(reviewpadFile)
+
+		if reviewpadFile.Edition != defaultEdition {
+			t.Fatalf("expected edition: %s, got edition: %s", defaultEdition, reviewpadFile.Edition)
+		}
+		if reviewpadFile.Mode != defaultMode {
+			t.Fatalf("expected mode: %s, got mode: %s", defaultMode, reviewpadFile.Mode)
+		}
+	})
+
+	t.Run("incorrect api-version number", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeIncorrectApiVersionNumber))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+
+		_ = normalize(reviewpadFile)
+
+		if reviewpadFile.Version != defaultApiVersion {
+			t.Fatalf("expected api-version: %s, got api-version: %s", defaultApiVersion, reviewpadFile.Version)
+		}
+	})
+
+	t.Run("correct lower api-version number", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeCorrectLowerApiVersionNumber))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+
+		_ = normalize(reviewpadFile)
+
+		if reviewpadFile.Version != testNormalizeCorrectExpectedVersion {
+			t.Fatalf("expected api-version: %s, got api-version: %s", testNormalizeCorrectExpectedVersion, reviewpadFile.Version)
+		}
+	})
+
+	t.Run("incorrect string case in edition", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeIncorrectCase))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+
+		_ = normalize(reviewpadFile)
+
+		if reviewpadFile.Edition != "team" {
+			t.Fatalf("expected edition: %s, got edition: %s", "team", reviewpadFile.Edition)
+		}
+	})
+}
+
+func TestNormalize_WithCustomNormalizers(t *testing.T) {
+	var newNormalizeRuleCustom = func(defaultVal string, allowed ...string) *NormalizeRule {
+		n := &NormalizeRule{Default: defaultVal, Allowed: allowed}
+		return n
+	}
+
+	const (
+		customApiVersion = "reviewpad.com/v4.0.0-alpha"
+		customEdition    = "Ultimate" // only if "professional"
+	)
+
+	/*
+	   api-version: reviewpad.com/v4.0.0-alpha
+	   edition: Ultimate
+	   mode: SILENT
+	*/
+	var customNormalizers = map[propertyKey]*NormalizeRule{
+		// always use version, if it's empty or not: "reviewpad.com/v4.0.0-alpha"
+		_version: (&NormalizeRule{}).WithModificators(func(_ string) string { return customApiVersion }),
+
+		// replace edition: professional, to: ultimate
+		// and Title, so if current edition == "professional", it should become: "Ultimate"
+		_edition: newNormalizeRuleCustom(customEdition, "Ultimate", "Team").
+			WithModificators(func(val string) string { return strings.Replace(val, "professional", "ultimate", 1) }).
+			WithModificators(strings.ToLower, strings.Title),
+
+		// our mode should be in Upper Case. So we:
+		// - define default in UpperCase (if Mode empty)
+		// - specify allowed values in UpperCase (this long strings split join construction just for testing purpose)
+		// - specify modificator to UpperCase value
+		_mode: newNormalizeRuleCustom(strings.ToUpper(defaultMode), strings.Split(strings.ToUpper(strings.Join(allowedModes, " ")), " ")...),
+	}
+
+	t.Run("missing edition and mode", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeNoEditionNoMode))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+
+		//debugOutput(reviewpadFile)
+		_ = normalize(reviewpadFile, customNormalizers)
+		//debugOutput(reviewpadFile)
+
+		if reviewpadFile.Version != customApiVersion {
+			t.Fatalf("expected api-version: %s, got api-version: %s", customApiVersion, reviewpadFile.Version)
+		}
+		if reviewpadFile.Edition != customEdition {
+			t.Fatalf("expected edition: %s, got edition: %s", customEdition, reviewpadFile.Edition)
+		}
+		if reviewpadFile.Mode != strings.ToUpper(defaultMode) {
+			t.Fatalf("expected mode: %s, got mode: %s", strings.ToUpper(defaultMode), reviewpadFile.Mode)
+		}
+	})
+
+	t.Run("incorrect api-version number", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeIncorrectApiVersionNumber))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+
+		_ = normalize(reviewpadFile, customNormalizers)
+
+		if reviewpadFile.Version != customApiVersion {
+			t.Fatalf("expected api-version: %s, got api-version: %s", customApiVersion, reviewpadFile.Version)
+		}
+	})
+
+	t.Run("incorrect string case in edition", func(t *testing.T) {
+		t.Parallel()
+		reviewpadFile, err := Load([]byte(testNormalizeIncorrectCase))
+		if err != nil {
+			t.Fatalf("err Load: %s", err.Error())
+		}
+
+		//debugOutput(reviewpadFile)
+		_ = normalize(reviewpadFile, customNormalizers)
+		//debugOutput(reviewpadFile)
+
+		if reviewpadFile.Edition != "Team" {
+			t.Fatalf("expected edition: %s, got edition: %s", "Team", reviewpadFile.Edition)
+		}
+	})
+
+}
+
+func debugOutput(f *ReviewpadFile) {
+	y, err := yaml.Marshal(f)
+	if err != nil {
+		log.Println(err)
+	}
+	fmt.Println(string(y))
+}
+
+const (
+	testNormalizeCorrectExpectedVersion       = "reviewpad.com/v2.x"
+	testNormalizeCorrectLowerApiVersionNumber = "api-version: " + testNormalizeCorrectExpectedVersion
+	testNormalizeIncorrectApiVersionNumber    = "api-version: reviewpad.com/v6.x"
+	testNormalizeIncorrectCase                = "edition: TeaM"
+	testNormalizeNoEditionNoMode              = `api-version: reviewpad.com/v3.x
+
+labels:
+  small:
+    description: Pull requests with less than 90 LOC
+    color: "f15d22"
+
+rules:
+  - name: isSmallPatch
+    kind: patch
+    description: Patch has less than 90 LOC
+    spec: $size() < 90
+
+workflows:
+  - name: labelSmall
+    description: Label small pull requests
+    if:
+      - rule: isSmallPatch
+    then:
+      - $addLabel("small")`
+)


### PR DESCRIPTION
## Description

normalize function takes as its argument pointer to the *ReviewpadFile, and normalizes its property values. 
"normalize" means validate, modify, check, and assign a default value if empty by specified rules. If no customNormalizeRules passed as a second argument, default normalize rules are used. 

## Related issue

#162 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Unit tests in engine/normalize_test.go for default and custom normalize rules

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
 - [ ] Ask: this pull request requires a code review before merge 
