### PR TITLE
fix: retrieve creation time when timeline has only one event

### DIFF
--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -27,6 +27,7 @@ const DefaultMockPrNum = 6
 const DefaultMockPrOwner = "foobar"
 const DefaultMockPrRepoName = "default-mock-repo"
 
+var DefaultMockPrDate = time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
 var DefaultMockContext = context.Background()
 var DefaultMockCollector = collector.NewCollector("", "", "pull_request", "")
 var DefaultMockTargetEntity = &handler.TargetEntity{
@@ -42,7 +43,7 @@ func GetDefaultMockPullRequestDetails() *github.PullRequest {
 	prOwner := DefaultMockPrOwner
 	prRepoName := DefaultMockPrRepoName
 	prUrl := fmt.Sprintf("https://api.github.com/repos/%v/%v/pulls/%v", prOwner, prRepoName, prNum)
-	prDate := time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
+	prDate := DefaultMockPrDate
 
 	return &github.PullRequest{
 		ID:   &prId,

--- a/plugins/aladino/functions/lastEventAt.go
+++ b/plugins/aladino/functions/lastEventAt.go
@@ -43,7 +43,7 @@ func lastEventAtCode(e aladino.Env, args []aladino.Value) (aladino.Value, error)
 		return aladino.BuildIntValue(int(createdAtTime.Unix())), nil
 	}
 
-    lastEvent := timeline[len(timeline)-1]
+	lastEvent := timeline[len(timeline)-1]
 	var lastEventTime int
 	if *lastEvent.Event == "reviewed" {
 		lastEventTime = int(lastEvent.GetSubmittedAt().Unix())

--- a/plugins/aladino/functions/lastEventAt.go
+++ b/plugins/aladino/functions/lastEventAt.go
@@ -5,6 +5,8 @@
 package plugins_aladino_functions
 
 import (
+	"time"
+
 	"github.com/reviewpad/host-event-handler/handler"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
 )
@@ -25,7 +27,23 @@ func lastEventAtCode(e aladino.Env, args []aladino.Value) (aladino.Value, error)
 		return nil, err
 	}
 
-	lastEvent := timeline[len(timeline)-1]
+	// The request for the issue timeline doesn't include the creation time of the first event.
+	// Since the first event is the opening of the issue, we know the last event time will be its creation time.
+	if len(timeline) == 1 {
+		createdAt, err := e.GetTarget().GetCreatedAt()
+		if err != nil {
+			return nil, err
+		}
+
+		createdAtTime, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", createdAt)
+		if err != nil {
+			return nil, err
+		}
+
+		return aladino.BuildIntValue(int(createdAtTime.Unix())), nil
+	}
+
+    lastEvent := timeline[len(timeline)-1]
 	var lastEventTime int
 	if *lastEvent.Event == "reviewed" {
 		lastEventTime = int(lastEvent.GetSubmittedAt().Unix())

--- a/plugins/aladino/functions/lastEventAt_test.go
+++ b/plugins/aladino/functions/lastEventAt_test.go
@@ -113,7 +113,7 @@ func TestLastEvent(t *testing.T) {
 					mock.WithRequestMatch(
 						mock.GetReposIssuesTimelineByOwnerByRepoByIssueNumber,
 						[]*github.Timeline{
-							{ID:        github.Int64(6430295168)},
+							{ID: github.Int64(6430295168)},
 						},
 					),
 				},

--- a/plugins/aladino/functions/lastEventAt_test.go
+++ b/plugins/aladino/functions/lastEventAt_test.go
@@ -106,6 +106,23 @@ func TestLastEvent(t *testing.T) {
 			),
 			wantVal: aladino.BuildIntValue(int(lastEventDate.Unix())),
 		},
+		"when timeline has only one event": {
+			mockedEnv: aladino.MockDefaultEnv(
+				t,
+				[]mock.MockBackendOption{
+					mock.WithRequestMatch(
+						mock.GetReposIssuesTimelineByOwnerByRepoByIssueNumber,
+						[]*github.Timeline{
+							{ID:        github.Int64(6430295168)},
+						},
+					),
+				},
+				nil,
+				aladino.MockBuiltIns(),
+				nil,
+			),
+			wantVal: aladino.BuildIntValue(int(aladino.DefaultMockPrDate.Unix())),
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request proposes a fix for the bug of the related issue.
The proposal is to directly retrieve the creation time of the issue when the timeline only has an event since we know this event is the creation of the issue.
This bug may be happening because the issue event types doesn't have the "opened" event - check https://docs.github.com/en/developers/webhooks-and-events/events/issue-event-types.

## Related issue

<!-- Closes # (issue) -->
Closes #277 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
It was done 2 tests.
1. Ran `task check -f`.
2. Opened a PR on the testing repo and ran the `reviewpad-cli` command on the branch of the PR: `./reviewpad-cli run -p [PULL_REQUEST] -t [GITHUB_TOKEN] -e [EVENT_PAYLOAD] -f [REVIEWPAD_FILE]`.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
