### PR TITLE
feat: extend cron event for issues and pull requests

### DIFF
--- a/handler/processors_test.go
+++ b/handler/processors_test.go
@@ -179,6 +179,32 @@ func TestProcessEvent(t *testing.T) {
 		},
 	)
 
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://api.github.com/repos/%v/%v/issues", owner, repo),
+		func(req *http.Request) (*http.Response, error) {
+			b, err := json.Marshal([]*github.Issue{
+				{
+					Number: github.Int(aladino.DefaultMockPrNum),
+					PullRequestLinks: &github.PullRequestLinks{
+						HTMLURL: github.String(fmt.Sprintf("https://api.github.com/repos/%v/%v/pull/%v", owner, repo, aladino.DefaultMockPrNum)),
+					},
+				},
+				{
+					Number: github.Int(130),
+					PullRequestLinks: &github.PullRequestLinks{
+						HTMLURL: github.String(fmt.Sprintf("https://api.github.com/repos/%v/%v/pull/%v", owner, repo, 130)),
+					},
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			resp := httpmock.NewBytesResponse(200, b)
+
+			return resp, nil
+		},
+	)
+
 	tests := map[string]struct {
 		event   *handler.ActionEvent
 		wantVal []*handler.TargetEntity


### PR DESCRIPTION
## Description

This pull request introduces the following changes:

- Paginate the request for GitHub issues.
- Extend the cron event to retrieve all issues (including pull requests).

## Related issue

Closes #298.

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

- [x] Ship: this pull request can be automatically merged and does not require code review 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
<!-- - [ ] Ask: this pull request requires a code review before merge -->
