### PR TITLE
test: improve PaginatedRequest and ParseLink tests

### DIFF
--- a/codehost/github/pull_requests_test.go
+++ b/codehost/github/pull_requests_test.go
@@ -18,64 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetPullRequestHeadOwnerName(t *testing.T) {
-	mockedHeadOwnerName := "reviewpad"
-	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
-		Head: &github.PullRequestBranch{
-			Repo: &github.Repository{
-				Owner: &github.User{
-					Login: github.String(mockedHeadOwnerName),
-				},
-			},
-		},
-	})
-	wantOwnerName := mockedPullRequest.Head.Repo.Owner.GetLogin()
-	gotOwnerName := host.GetPullRequestHeadOwnerName(mockedPullRequest)
-
-	assert.Equal(t, wantOwnerName, gotOwnerName)
-	assert.Equal(t, mockedHeadOwnerName, gotOwnerName)
-}
-
-func TestGetPullRequestHeadRepoName(t *testing.T) {
-	mockedHeadRepoName := "mocks-test"
-	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
-		Head: &github.PullRequestBranch{
-			Repo: &github.Repository{
-				Name: &mockedHeadRepoName,
-			},
-		},
-	})
-	wantRepoName := mockedPullRequest.Head.Repo.GetName()
-	gotRepoName := host.GetPullRequestHeadRepoName(mockedPullRequest)
-
-	assert.Equal(t, wantRepoName, gotRepoName)
-	assert.Equal(t, mockedHeadRepoName, gotRepoName)
-}
-
-func TestGetPullRequestBaseOwnerName(t *testing.T) {
-	mockedPullRequest := aladino.GetDefaultMockPullRequestDetails()
-	wantOwnerName := mockedPullRequest.Base.Repo.Owner.GetLogin()
-	gotOwnerName := host.GetPullRequestBaseOwnerName(mockedPullRequest)
-
-	assert.Equal(t, wantOwnerName, gotOwnerName)
-}
-
-func TestGetPullRequestBaseRepoName(t *testing.T) {
-	mockedPullRequest := aladino.GetDefaultMockPullRequestDetails()
-	wantRepoName := mockedPullRequest.Base.Repo.GetName()
-	gotRepoName := host.GetPullRequestBaseRepoName(mockedPullRequest)
-
-	assert.Equal(t, wantRepoName, gotRepoName)
-}
-
-func TestGetPullRequestNumber(t *testing.T) {
-	mockedPullRequest := aladino.GetDefaultMockPullRequestDetails()
-	wantPullRequestNumber := mockedPullRequest.GetNumber()
-	gotPullRequestNumber := host.GetPullRequestNumber(mockedPullRequest)
-
-	assert.Equal(t, wantPullRequestNumber, gotPullRequestNumber)
-}
-
 func TestPaginatedRequest(t *testing.T) {
 	failMessage := "PaginatedRequestFail"
 

--- a/codehost/github/pull_requests_test.go
+++ b/codehost/github/pull_requests_test.go
@@ -39,13 +39,13 @@ func TestPaginatedRequest(t *testing.T) {
 	repoAOnFirstPage := "repo-A-on-first-page"
 	repoBOnSecondPage := "repo-B-on-second-page"
 
-	firstPageRequestUrl := buildGitHubListReposRequestUrl(1)
+	firstPageRequestUrl := buildGitHubListReposPageRequestUrl(1)
 	firstPageContentData := fmt.Sprintf("[{\"name\": \"%v\"}]", repoAOnFirstPage)
 	firstPageContent := []*github.Repository{
 		{Name: github.String(repoAOnFirstPage)},
 	}
 
-	secondPageRequestUrl := buildGitHubListReposRequestUrl(2)
+	secondPageRequestUrl := buildGitHubListReposPageRequestUrl(2)
 	secondPageContentData := fmt.Sprintf("[{\"name\": \"%v\"}]", repoBOnSecondPage)
 	secondPageContent := []*github.Repository{
 		{Name: github.String(repoBOnSecondPage)},
@@ -833,7 +833,7 @@ func registerHttpResponders(httpMockResponders []httpMockResponder) {
 	}
 }
 
-func buildGitHubListReposRequestUrl(page int) string {
+func buildGitHubListReposPageRequestUrl(page int) string {
 	return fmt.Sprintf("https://api.github.com/orgs/%v/repos?page=%v", aladino.DefaultMockPrOwner, page)
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request introduces the improvement of PaginatedRequest and ParseLink related tests in order to adopt the TDT format; another improvement made was the adoption of `mock.WithRequestMatchPages` in order to mock paginated requests.
Besides this, it was removed the unit tests for getters since there is no logic to be tested there.

_Edit:_
It was disregarded the usage of `mock.WithRequestMatchPages` since this wouldn't help us cover the scenario of when a non first page request failed because we can't force an error for this request using the mentioned method.
Said that, we implement the pagination mock explicitly using `httpmock` for only 2 pages request.

## Related issue

<!-- Closes # (issue) -->
*None*

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran `task check -f` cmd.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
