### PR TITLE
chore: update ci build to use reviewpad ci container image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,19 +2,19 @@ name: Build
 
 on:
   push:
-    tags:        
+    tags:
       - '**'
+
+env:
+  LD_LIBRARY_PATH: /usr/local/lib
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: reviewpad/ci:latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
 
       - name: Download dependencies
         run: |

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -4,17 +4,17 @@ on:
   pull_request:
     types: [ labeled, synchronize ]
 
+env:
+  LD_LIBRARY_PATH: /usr/local/lib
+
 jobs:
   pr-build:
     if: ${{ (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-build')) || (github.event.action == 'labeled' && github.event.label.name == 'run-build') }}
     runs-on: ubuntu-latest
+    container:
+      image: reviewpad/ci:latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
 
       - name: Download dependencies
         run: |

--- a/ci/baseimage/dockerfile
+++ b/ci/baseimage/dockerfile
@@ -1,0 +1,26 @@
+# Copyright (C) 2022 Explore.dev, Unipessoal Lda - All Rights Reserved
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+# This dockerfile is used to create Reviewpad base image to run ci build on github actions.
+# You can see the image being used at .github/workflows/build.yml under jobs > build > container > image.
+# The image is publish on https://hub.docker.com/repository/docker/reviewpad/ci.
+
+FROM golang:1.18
+
+ENV LIBGIT2_ZIP v1.2.0.zip
+ENV LIBGIT2 libgit2-1.2.0
+
+WORKDIR /app
+
+# Install necessary packages
+RUN apt-get update && apt-get -y install unzip cmake libssl-dev && apt-get clean
+
+# Install libgit2
+RUN curl -OL https://github.com/libgit2/libgit2/archive/refs/tags/${LIBGIT2_ZIP} && \
+    unzip -o $LIBGIT2_ZIP -d /tmp && \
+    cd /tmp/${LIBGIT2} && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    cmake --build . --target install


### PR DESCRIPTION
## Description

This pull request introduces the use of reviewpad ci image for the build.

A reviewpad image is required due to the use of libgit2.

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #312
<!-- Closes # (issue) -->

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Created a fork under ferreiratiago/reviewpad and tested.

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

- [x] Ship: this pull request can be automatically merged and does not require code review
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
<!-- - [ ] Ask: this pull request requires a code review before merge -->
