### PR TITLE
feat: issue and pull request count by built-ins

### DIFF
--- a/engine/loader.go
+++ b/engine/loader.go
@@ -78,7 +78,7 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 			Name:        rule.Name,
 			Kind:        kind,
 			Description: rule.Description,
-			Spec:        rule.Spec,
+			Spec:        transformAladinoExpression(rule.Spec),
 		})
 	}
 
@@ -88,7 +88,7 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 		for _, rule := range workflow.Rules {
 			var transformedExtraActions []string
 			for _, extraAction := range rule.ExtraActions {
-				transformedExtraActions = append(transformedExtraActions, transformActionStr(extraAction))
+				transformedExtraActions = append(transformedExtraActions, transformAladinoExpression(extraAction))
 			}
 
 			transformedRules = append(transformedRules, PadWorkflowRule{
@@ -99,7 +99,7 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 
 		var transformedActions []string
 		for _, action := range workflow.Actions {
-			transformedActions = append(transformedActions, transformActionStr(action))
+			transformedActions = append(transformedActions, transformAladinoExpression(action))
 		}
 
 		transformedOn := []handler.TargetEntityKind{handler.PullRequest}
@@ -125,7 +125,7 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 		for _, stage := range pipeline.Stages {
 			var transformedActions []string
 			for _, action := range stage.Actions {
-				transformedActions = append(transformedActions, transformActionStr(action))
+				transformedActions = append(transformedActions, transformAladinoExpression(action))
 			}
 
 			transformedStages = append(transformedStages, PadStage{

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -31,12 +31,41 @@ func addDefaultMergeMethod(str string) string {
 	return strings.ReplaceAll(str, "$merge()", "$merge(\"merge\")")
 }
 
-func transformActionStr(str string) string {
+// reviewpad-an: generated-by-co-pilot
+func addDefaultIssueCountBy(str string) string {
+	m := regexp.MustCompile("\\$issueCountBy\\(\"[^\"]*\"\\)")
+	match := m.FindString(str)
+
+	if match == "" {
+		return str
+	}
+
+	matchWithDefaultState := match[0:len(match)-1] + ", \"all\")"
+	transformedStr := strings.ReplaceAll(str, match, matchWithDefaultState)
+	return transformedStr
+}
+
+func addDefaultPullRequestCountBy(str string) string {
+	m := regexp.MustCompile("\\$pullRequestCountBy\\(\"[^\"]*\"\\)")
+	match := m.FindString(str)
+
+	if match == "" {
+		return str
+	}
+
+	matchWithDefaultState := match[0:len(match)-1] + ", \"all\")"
+	transformedStr := strings.ReplaceAll(str, match, matchWithDefaultState)
+	return transformedStr
+}
+
+func transformAladinoExpression(str string) string {
 	transformedActionStr := str
 
 	var transformations = [](func(str string) string){
 		addDefaultTotalRequestedReviewers,
 		addDefaultMergeMethod,
+		addDefaultIssueCountBy,
+		addDefaultPullRequestCountBy,
 	}
 
 	for i := range transformations {

--- a/engine/transform_internal_test.go
+++ b/engine/transform_internal_test.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2022 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformAladinoExpression(t *testing.T) {
+	tests := map[string]struct {
+		arg     string
+		wantVal string
+	}{
+		"id": {
+			arg:     "$id()",
+			wantVal: "$id()",
+		},
+		"merge": {
+			arg:     "$merge()",
+			wantVal: "$merge(\"merge\")",
+		},
+		"issueCountBy simple": {
+			arg:     "$issueCountBy(\"john\", \"open\") > 0",
+			wantVal: "$issueCountBy(\"john\", \"open\") > 0",
+		},
+		"issueCountBy": {
+			arg:     "$issueCountBy(\"john\", \"open\") > 0 && true && $issueCountBy(\"dev\") > 0",
+			wantVal: "$issueCountBy(\"john\", \"open\") > 0 && true && $issueCountBy(\"dev\", \"all\") > 0",
+		},
+		"pullRequestCountBy simple": {
+			arg:     "$pullRequestCountBy(\"john\") > 0",
+			wantVal: "$pullRequestCountBy(\"john\", \"all\") > 0",
+		},
+		"pullRequestCountBy nil state": {
+			arg:     "$pullRequestCountBy(\"john\", \"\") > 0",
+			wantVal: "$pullRequestCountBy(\"john\", \"\") > 0",
+		},
+		"pullRequestCountBy nil dev": {
+			arg:     "$pullRequestCountBy(\"\", \"closed\") > 0",
+			wantVal: "$pullRequestCountBy(\"\", \"closed\") > 0",
+		},
+		"pullRequestCountBy nil dev and state": {
+			arg:     "$pullRequestCountBy(\"\") > 0",
+			wantVal: "$pullRequestCountBy(\"\", \"all\") > 0",
+		},
+		"pullRequestCountBy and issueCountBy": {
+			arg:     "$pullRequestCountBy(\"john\") > 0 && true && $issueCountBy(\"dev\") > 0",
+			wantVal: "$pullRequestCountBy(\"john\", \"all\") > 0 && true && $issueCountBy(\"dev\", \"all\") > 0",
+		},
+		// TODO: test addDefaultTotalRequestedReviewers
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotVal := transformAladinoExpression(test.arg)
+			assert.Equal(t, test.wantVal, gotVal)
+		})
+	}
+}

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -87,6 +87,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"organization": functions.Organization(),
 			"team":         functions.Team(),
 			// User
+			"issueCountBy":             functions.IssueCountBy(),
 			"totalCreatedPullRequests": functions.TotalCreatedPullRequests(),
 			// Utilities
 			"append":      functions.AppendString(),

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -88,6 +88,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"team":         functions.Team(),
 			// User
 			"issueCountBy":             functions.IssueCountBy(),
+			"pullRequestCountBy":       functions.PullRequestCountBy(),
 			"totalCreatedPullRequests": functions.TotalCreatedPullRequests(),
 			// Utilities
 			"append":      functions.AppendString(),

--- a/plugins/aladino/functions/issueCountBy.go
+++ b/plugins/aladino/functions/issueCountBy.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2022 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"github.com/google/go-github/v45/github"
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+)
+
+func IssueCountBy() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType(), aladino.BuildStringType()}, aladino.BuildIntType()),
+		Code:           issueCountByCode,
+		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest, handler.Issue},
+	}
+}
+
+func issueCountByCode(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
+	loginArg := args[0].(*aladino.StringValue).Val
+	stateArg := args[1].(*aladino.StringValue).Val
+
+	state := "all"
+	if stateArg != "" {
+		state = stateArg
+	}
+
+	opts := &github.IssueListByRepoOptions{
+		State: state,
+	}
+	if loginArg != "" {
+		opts.Creator = loginArg
+	}
+
+	return issueCountBy(e, opts, func(issue *github.Issue) bool {
+		return !issue.IsPullRequest()
+	})
+}
+
+func issueCountBy(e aladino.Env, opts *github.IssueListByRepoOptions, predicate func(issue *github.Issue) bool) (aladino.Value, error) {
+	entity := e.GetTarget().GetTargetEntity()
+	owner := entity.Owner
+	repo := entity.Repo
+
+	issues, _, err := e.GetGithubClient().ListIssuesByRepo(e.GetCtx(), owner, repo, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	count := 0
+	for _, issue := range issues {
+		if predicate(issue) {
+			count++
+		}
+	}
+
+	return aladino.BuildIntValue(count), nil
+}

--- a/plugins/aladino/functions/issueCountBy_test.go
+++ b/plugins/aladino/functions/issueCountBy_test.go
@@ -1,0 +1,115 @@
+// Copyright (C) 2022 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var issueCountBy = plugins_aladino.PluginBuiltIns().Functions["issueCountBy"].Code
+
+func TestIssueCountBy_WhenListIssuesByRepoFails(t *testing.T) {
+	failMessage := "ListListIssuesByRepoRequestFail"
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposIssuesByOwnerByRepo,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mock.WriteError(
+						w,
+						http.StatusInternalServerError,
+						failMessage,
+					)
+				}),
+			),
+		},
+		nil,
+		aladino.MockBuiltIns(),
+		nil,
+	)
+
+	args := []aladino.Value{aladino.BuildStringValue(""), aladino.BuildStringValue("")}
+	gotTotal, err := issueCountBy(mockedEnv, args)
+
+	assert.Nil(t, gotTotal)
+	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
+}
+
+func TestIssueCountBy(t *testing.T) {
+	firstIssue := &github.Issue{
+		Title: github.String("First Issue"),
+		State: github.String("open"),
+	}
+
+	secondIssue := &github.Issue{
+		Title: github.String("Second Issue"),
+		PullRequestLinks: &github.PullRequestLinks{
+			URL: github.String("pull-request-link"),
+		},
+		State: github.String("closed"),
+	}
+
+	thirdIssue := &github.Issue{
+		Title: github.String("Third Issue"),
+		State: github.String("closed"),
+		User: &github.User{
+			Login: github.String("steve"),
+		},
+	}
+
+	tests := map[string]struct {
+		args    []aladino.Value
+		issues  []*github.Issue
+		wantVal aladino.Value
+	}{
+		"default values": {
+			args:    []aladino.Value{aladino.BuildStringValue(""), aladino.BuildStringValue("")},
+			issues:  []*github.Issue{firstIssue, secondIssue, thirdIssue},
+			wantVal: aladino.BuildIntValue(2),
+		},
+		"only open issues": {
+			args:    []aladino.Value{aladino.BuildStringValue(""), aladino.BuildStringValue("open")},
+			issues:  []*github.Issue{firstIssue, secondIssue},
+			wantVal: aladino.BuildIntValue(1),
+		},
+		"only issues by steve": {
+			args:    []aladino.Value{aladino.BuildStringValue("steve"), aladino.BuildStringValue("")},
+			issues:  []*github.Issue{thirdIssue},
+			wantVal: aladino.BuildIntValue(1),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedEnv := aladino.MockDefaultEnv(
+				t,
+				[]mock.MockBackendOption{
+					mock.WithRequestMatchHandler(
+						mock.GetReposIssuesByOwnerByRepo,
+						http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+							w.Write(mock.MustMarshal(test.issues))
+						}),
+					),
+				},
+				nil,
+				aladino.MockBuiltIns(),
+				nil,
+			)
+
+			gotVal, err := issueCountBy(mockedEnv, test.args)
+
+			assert.Nil(t, err)
+			assert.Equal(t, test.wantVal, gotVal)
+		})
+	}
+}

--- a/plugins/aladino/functions/pullRequestCountBy.go
+++ b/plugins/aladino/functions/pullRequestCountBy.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"github.com/google/go-github/v45/github"
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+)
+
+func PullRequestCountBy() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType(), aladino.BuildStringType()}, aladino.BuildIntType()),
+		Code:           pullRequestCountByCode,
+		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest, handler.Issue},
+	}
+}
+
+func pullRequestCountByCode(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
+	loginArg := args[0].(*aladino.StringValue).Val
+	stateArg := args[1].(*aladino.StringValue).Val
+
+	state := "all"
+	if stateArg != "" {
+		state = stateArg
+	}
+
+	opts := &github.IssueListByRepoOptions{
+		State: state,
+	}
+	if loginArg != "" {
+		opts.Creator = loginArg
+	}
+
+	return issueCountBy(e, opts, func(issue *github.Issue) bool {
+		return issue.IsPullRequest()
+	})
+}

--- a/plugins/aladino/functions/pullRequestCountBy_test.go
+++ b/plugins/aladino/functions/pullRequestCountBy_test.go
@@ -1,0 +1,115 @@
+// Copyright (C) 2022 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var pullRequestCountBy = plugins_aladino.PluginBuiltIns().Functions["pullRequestCountBy"].Code
+
+func TestPullRequestCountBy_WhenListIssuesByRepoFails(t *testing.T) {
+	failMessage := "ListListIssuesByRepoRequestFail"
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposIssuesByOwnerByRepo,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mock.WriteError(
+						w,
+						http.StatusInternalServerError,
+						failMessage,
+					)
+				}),
+			),
+		},
+		nil,
+		aladino.MockBuiltIns(),
+		nil,
+	)
+
+	args := []aladino.Value{aladino.BuildStringValue(""), aladino.BuildStringValue("")}
+	gotTotal, err := pullRequestCountBy(mockedEnv, args)
+
+	assert.Nil(t, gotTotal)
+	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
+}
+
+func TestPullRequestCountBy(t *testing.T) {
+	firstIssue := &github.Issue{
+		Title: github.String("First Issue"),
+		State: github.String("open"),
+	}
+
+	secondIssue := &github.Issue{
+		Title: github.String("Second Issue"),
+		PullRequestLinks: &github.PullRequestLinks{
+			URL: github.String("pull-request-link"),
+		},
+		State: github.String("closed"),
+	}
+
+	thirdIssue := &github.Issue{
+		Title: github.String("Third Issue"),
+		State: github.String("closed"),
+		User: &github.User{
+			Login: github.String("steve"),
+		},
+	}
+
+	tests := map[string]struct {
+		args    []aladino.Value
+		issues  []*github.Issue
+		wantVal aladino.Value
+	}{
+		"default values": {
+			args:    []aladino.Value{aladino.BuildStringValue(""), aladino.BuildStringValue("")},
+			issues:  []*github.Issue{firstIssue, secondIssue, thirdIssue},
+			wantVal: aladino.BuildIntValue(1),
+		},
+		"only closed pull requests": {
+			args:    []aladino.Value{aladino.BuildStringValue(""), aladino.BuildStringValue("closed")},
+			issues:  []*github.Issue{firstIssue, secondIssue},
+			wantVal: aladino.BuildIntValue(1),
+		},
+		"only pull requests by steve": {
+			args:    []aladino.Value{aladino.BuildStringValue("steve"), aladino.BuildStringValue("")},
+			issues:  []*github.Issue{firstIssue, thirdIssue},
+			wantVal: aladino.BuildIntValue(0),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedEnv := aladino.MockDefaultEnv(
+				t,
+				[]mock.MockBackendOption{
+					mock.WithRequestMatchHandler(
+						mock.GetReposIssuesByOwnerByRepo,
+						http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+							w.Write(mock.MustMarshal(test.issues))
+						}),
+					),
+				},
+				nil,
+				aladino.MockBuiltIns(),
+				nil,
+			)
+
+			gotVal, err := pullRequestCountBy(mockedEnv, test.args)
+
+			assert.Nil(t, err)
+			assert.Equal(t, test.wantVal, gotVal)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This pull request introduces the following changes:
- Adds $issueCountBy built-in 
- Adds $pullRequestCountBy built-in
- Extends the transformation of Aladino actions to Aladino expressions to add optional arguments the xCountBy built-ins
- Adds unit tests to the transformation

Corresponding pull request: https://github.com/reviewpad/docs/pull/27

## Related issue

Closes #308

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
- [x] Show: this pull request can be auto-merged and code review should be done post merge 
<!-- - [ ] Ask: this pull request requires a code review before merge -->
