### PR TITLE
feat: Allow number sign in label color hex values

### DIFF
--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -102,7 +102,7 @@ func TestEval_WhenGitHubRequestsFail(t *testing.T) {
 			gotProgram, err := engine.Eval(reviewpadFile, mockedEnv)
 
 			assert.Nil(t, gotProgram)
-			assert.Equal(t, err.(*github.ErrorResponse).Message, test.wantErr)
+			assert.Equal(t, test.wantErr, err.(*github.ErrorResponse).Message)
 		})
 	}
 }

--- a/engine/labels.go
+++ b/engine/labels.go
@@ -13,12 +13,8 @@ import (
 
 func validateLabelColor(label *PadLabel) error {
 	if label.Color != "" {
-		matched, _ := regexp.MatchString(`(?i)^([0-9A-F]{6}){1,2}$`, label.Color)
+		matched, _ := regexp.MatchString(`(?i)^#?([0-9A-F]{6}){1,2}$`, label.Color)
 		if !matched {
-			if strings.HasPrefix(label.Color, "#") {
-				return execError("evalLabel: the hexadecimal color code for the label should be without the leading #")
-			}
-
 			return execError("evalLabel: color code not valid")
 		}
 	}
@@ -34,6 +30,10 @@ func createLabel(e *Env, labelName *string, label *PadLabel) error {
 
 	var labelColor *string
 	if label.Color != "" {
+		if strings.HasPrefix(label.Color, "#") {
+			label.Color = label.Color[1:]
+		}
+
 		labelColor = &label.Color
 	}
 

--- a/engine/labels.go
+++ b/engine/labels.go
@@ -30,10 +30,7 @@ func createLabel(e *Env, labelName *string, label *PadLabel) error {
 
 	var labelColor *string
 	if label.Color != "" {
-		if strings.HasPrefix(label.Color, "#") {
-			label.Color = label.Color[1:]
-		}
-
+		label.Color = strings.TrimPrefix(label.Color, "#")
 		labelColor = &label.Color
 	}
 

--- a/engine/labels_internal_test.go
+++ b/engine/labels_internal_test.go
@@ -1,0 +1,54 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateLabelColor(t *testing.T) {
+	tests := map[string]struct {
+		arg     *PadLabel
+		wantErr error
+	}{
+		"hex value with #": {
+			arg:     &PadLabel{Color: "#91cf60"},
+			wantErr: nil,
+		},
+		"hex value without #": {
+			arg:     &PadLabel{Color: "91cf60"},
+			wantErr: nil,
+		},
+		"invalid hex value with #": {
+			arg:     &PadLabel{Color: "#91cg60"},
+			wantErr: execError("evalLabel: color code not valid"),
+		},
+		"invalid hex value without #": {
+			arg:     &PadLabel{Color: "91cg60"},
+			wantErr: execError("evalLabel: color code not valid"),
+		},
+		"invalid hex value because of size with #": {
+			arg:     &PadLabel{Color: "#91cg6"},
+			wantErr: execError("evalLabel: color code not valid"),
+		},
+		"invalid hex value because of size without #": {
+			arg:     &PadLabel{Color: "91cg6"},
+			wantErr: execError("evalLabel: color code not valid"),
+		},
+		"english color": {
+			arg:     &PadLabel{Color: "red"},
+			wantErr: execError("evalLabel: color code not valid"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotErr := validateLabelColor(test.arg)
+			assert.Equal(t, test.wantErr, gotErr)
+		})
+	}
+}

--- a/engine/labels_internal_test.go
+++ b/engine/labels_internal_test.go
@@ -5,8 +5,12 @@
 package engine
 
 import (
+	"encoding/json"
+	"net/http"
 	"testing"
 
+	"github.com/google/go-github/v45/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,6 +52,190 @@ func TestValidateLabelColor(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			gotErr := validateLabelColor(test.arg)
+			assert.Equal(t, test.wantErr, gotErr)
+		})
+	}
+}
+
+func TestCreateLabel(t *testing.T) {
+	tests := map[string]struct {
+		labelName     string
+		label         *PadLabel
+		clientOptions []mock.MockBackendOption
+		wantErr       error
+	}{
+		"when validate label color fails": {
+			labelName: "test",
+			label: &PadLabel{
+				Name: "test",
+				// invalid hex value because of size
+				Color:       "#91cf6",
+				Description: "test",
+			},
+			clientOptions: []mock.MockBackendOption{},
+			wantErr:       execError("evalLabel: color code not valid"),
+		},
+		"when label color has leading #": {
+			labelName: "test-name",
+			label: &PadLabel{
+				Color:       "#91cf60",
+				Description: "test description",
+			},
+			clientOptions: []mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.PostReposLabelsByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						var gotLabel github.Label
+						json.NewDecoder(r.Body).Decode(&gotLabel)
+
+						assert.Equal(t, "test-name", gotLabel.GetName())
+						assert.Equal(t, "91cf60", gotLabel.GetColor())
+						assert.Equal(t, "test description", gotLabel.GetDescription())
+
+						w.WriteHeader(http.StatusOK)
+					}),
+				),
+			},
+			wantErr: nil,
+		},
+		"when label color does not have leading #": {
+			labelName: "test-name",
+			label: &PadLabel{
+				Color:       "91cf60",
+				Description: "test description",
+			},
+			clientOptions: []mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.PostReposLabelsByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						var gotLabel github.Label
+						json.NewDecoder(r.Body).Decode(&gotLabel)
+
+						assert.Equal(t, "test-name", gotLabel.GetName())
+						assert.Equal(t, "91cf60", gotLabel.GetColor())
+						assert.Equal(t, "test description", gotLabel.GetDescription())
+
+						w.WriteHeader(http.StatusOK)
+					}),
+				),
+			},
+			wantErr: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedClient := MockGithubClient(test.clientOptions)
+
+			mockedEnv, err := MockEnvWith(mockedClient, nil)
+			if err != nil {
+				assert.FailNow(t, "engine MockDefaultEnvWith: %v", err)
+			}
+
+			gotErr := createLabel(mockedEnv, &test.labelName, test.label)
+
+			assert.Equal(t, test.wantErr, gotErr)
+		})
+	}
+}
+
+func TestCheckLabelExists_WhenGetLabelFails(t *testing.T) {
+	tests := map[string]struct {
+		labelName     string
+		clientOptions []mock.MockBackendOption
+		wantVal       bool
+		wantErr       string
+	}{
+		"when get label request 500": {
+			labelName: "test",
+			clientOptions: []mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.GetReposLabelsByOwnerByRepoByName,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write(mock.MustMarshal(github.ErrorResponse{
+							Response: &http.Response{
+								StatusCode: 500,
+							},
+							Message: "GetLabelRequestFailed",
+						}))
+					}),
+				),
+			},
+			wantErr: "GetLabelRequestFailed",
+			wantVal: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedClient := MockGithubClient(test.clientOptions)
+
+			mockedEnv, err := MockEnvWith(mockedClient, nil)
+			if err != nil {
+				assert.FailNow(t, "MockDefaultEnvWith: %v", err)
+			}
+
+			gotVal, gotErr := checkLabelExists(mockedEnv, test.labelName)
+
+			assert.Equal(t, test.wantVal, gotVal)
+			assert.Equal(t, test.wantErr, gotErr.(*github.ErrorResponse).Message)
+		})
+	}
+}
+
+func TestCheckLabelExists(t *testing.T) {
+	tests := map[string]struct {
+		labelName     string
+		clientOptions []mock.MockBackendOption
+		wantVal       bool
+		wantErr       error
+	}{
+		"when get label request 404": {
+			labelName: "test",
+			clientOptions: []mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.GetReposLabelsByOwnerByRepoByName,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write(mock.MustMarshal(github.ErrorResponse{
+							Response: &http.Response{
+								StatusCode: 404,
+							},
+						}))
+					}),
+				),
+			},
+			wantErr: nil,
+			wantVal: false,
+		},
+		"when get label request 200": {
+			labelName: "test",
+			clientOptions: []mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.GetReposLabelsByOwnerByRepoByName,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusOK)
+					}),
+				),
+			},
+			wantErr: nil,
+			wantVal: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedClient := MockGithubClient(test.clientOptions)
+
+			mockedEnv, err := MockEnvWith(mockedClient, nil)
+			if err != nil {
+				assert.FailNow(t, "MockDefaultEnvWith: %v", err)
+			}
+
+			gotVal, gotErr := checkLabelExists(mockedEnv, test.labelName)
+
+			assert.Equal(t, test.wantVal, gotVal)
 			assert.Equal(t, test.wantErr, gotErr)
 		})
 	}


### PR DESCRIPTION
## Description

When describing label colors while editing the Reviewpad configuration file, it is often useful to visualize the colors in place without having to copy the hex values somewhere else. The current [Reviewpad specification](https://docs.reviewpad.com/guides/syntax#label) for labels requires hex values defined in the configuration to _not_ include the number sign. That means mechanisms that detect hex color values will not match. Like so:

Very uncool:

![Screenshot 2022-09-02 at 12 40 24](https://user-images.githubusercontent.com/4189/188132033-47484d9c-878a-45b8-bc05-983325a9b4c0.png)

Isn't this a lot better:

![Screenshot 2022-09-02 at 12 41 01](https://user-images.githubusercontent.com/4189/188132082-6422d923-ae4d-4a7c-88f3-42d98129de11.png)

This changeset makes the number sign optional, by doing 2 main things:

- The regex that matches and validates colors now allows for an optional `#` (e.g: `#abcdef` is now valid)
- Before we [push the label to Github](https://docs.github.com/en/rest/issues/labels#create-a-label), we trim the `#` if it exists [^1]

## Related issue

Closes #340 

## Type of change

Improvements (non-breaking change without functionality)

## How was this tested?

My Go chops aren't formidable, but I assume I didn't completely botch it (yet) 😂 

```
❯ task test
task: [test] gotestsum -- -coverprofile=coverage.out ./...
∅  .
∅  cli
∅  cli/cmd
✓  codehost (473ms) (coverage: 73.5% of statements)
✓  utils (169ms) (coverage: 39.1% of statements)
✓  handler (243ms) (coverage: 94.6% of statements)
✓  lang/aladino (445ms) (coverage: 84.5% of statements)
✓  utils/fmtio (523ms) (coverage: 100.0% of statements)
✓  utils/report (601ms) (coverage: 100.0% of statements)
✓  engine (857ms) (coverage: 73.1% of statements)
✓  plugins/aladino/actions (496ms) (coverage: 89.0% of statements)
✓  plugins/aladino/functions (274ms) (coverage: 97.8% of statements)
✓  codehost/github (1.458s) (coverage: 62.5% of statements)
∅  codehost/github/target
∅  collector
∅  engine/testutils
∅  plugins/aladino
∅  plugins/aladino/services

DONE 685 tests in 4.909s
task: [test] . scripts/exclude-from-code-coverage.sh
```

## Checklist

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

- [x] Ask: this pull request requires a code review before merge

[^1]: Why is everybody hating on the number sign `#`? We're taking a stand here.