### PR TITLE
fix: Editorconfig config file tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,12 +11,14 @@ root = true
 [*]
 indent_style = space
 indent_size = 4
-
-[*.yml]
-indent_size = 2
-
-# We recommend you to keep these unchanged
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.go]
+indent_size = 4
+indent_style = tab
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
## Description

The existing `editorconfig` configuration file had a couple of issues. One of them I detailed in #342, but the second I only really noticed after I was already tweaking the configuration. The two issues were:

- Editorconfig was set up for using 4 Spaces for indentation, even in Go files, which use tabs
- Because of the way the file was structured, many of the rules weren't matching for all files (they were only matching for `YAML` files)

This changeset fixes both issues. It adds a lean configuration specifically for Go files (it only really imposes the use of tabs), and moves the rules below to the top level (any file) configuration. These rules were being ignored for non-YAML files since 9f1b7fbe982c63bef7f149338cc5423fd7aea226, because of how the file was re-structured in that particular commit.

```editorconfig
end_of_line = lf
charset = utf-8
trim_trailing_whitespace = true
insert_final_newline = true
```

## Related issue

Closes #342 

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How was this tested?

Not necessarily applicable, but I did test out the changes while editing a Go file, and it now works as expected.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

- [x] Ask: this pull request requires a code review before merge
