### PR TITLE
feat: add label descriptions also if label is already created

### DIFF
--- a/codehost/github/issues.go
+++ b/codehost/github/issues.go
@@ -42,6 +42,10 @@ func (c *GithubClient) AddLabels(ctx context.Context, owner string, repo string,
 	return c.clientREST.Issues.AddLabelsToIssue(ctx, owner, repo, number, labels)
 }
 
+func (c *GithubClient) EditLabel(ctx context.Context, owner string, repo string, name string, label *github.Label) (*github.Label, *github.Response, error) {
+	return c.clientREST.Issues.EditLabel(ctx, owner, repo, name, label)
+}
+
 func (c *GithubClient) RemoveLabelForIssue(ctx context.Context, owner string, repo string, number int, label string) (*github.Response, error) {
 	return c.clientREST.Issues.RemoveLabelForIssue(ctx, owner, repo, number, label)
 }

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -77,20 +77,20 @@ func Eval(file *ReviewpadFile, env *Env) (*Program, error) {
 		}
 
 		if !env.DryRun {
-			labelExists, err := checkLabelExists(env, labelName)
+			ghLabel, err := checkLabelExists(env, labelName)
 			if err != nil {
 				return nil, err
 			}
 
-			if labelExists {
-				labelHasUpdates, err := checkLabelHasUpdates(env, &label, labelName)
+			if ghLabel != nil {
+				labelHasUpdates, err := checkLabelHasUpdates(env, &label, ghLabel)
 				if err != nil {
 					CollectError(env, err)
 					return nil, err
 				}
 
 				if labelHasUpdates {
-					err = updateLabel(env, &label, labelName)
+					err = updateLabel(env, &labelName, &label)
 					if err != nil {
 						CollectError(env, err)
 						return nil, err

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -82,6 +82,22 @@ func Eval(file *ReviewpadFile, env *Env) (*Program, error) {
 				return nil, err
 			}
 
+			if labelExists {
+				labelHasUpdates, err := checkLabelHasUpdates(env, &label)
+				if err != nil {
+					CollectError(env, err)
+					return nil, err
+				}
+
+				if labelHasUpdates {
+					err = updateLabel(env, &label)
+					if err != nil {
+						CollectError(env, err)
+						return nil, err
+					}
+				}
+			}
+
 			if !labelExists {
 				err = createLabel(env, &labelName, &label)
 				if err != nil {

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -83,22 +83,20 @@ func Eval(file *ReviewpadFile, env *Env) (*Program, error) {
 			}
 
 			if labelExists {
-				labelHasUpdates, err := checkLabelHasUpdates(env, &label)
+				labelHasUpdates, err := checkLabelHasUpdates(env, &label, labelName)
 				if err != nil {
 					CollectError(env, err)
 					return nil, err
 				}
 
 				if labelHasUpdates {
-					err = updateLabel(env, &label)
+					err = updateLabel(env, &label, labelName)
 					if err != nil {
 						CollectError(env, err)
 						return nil, err
 					}
 				}
-			}
-
-			if !labelExists {
+			} else {
 				err = createLabel(env, &labelName, &label)
 				if err != nil {
 					CollectError(env, err)

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -26,7 +26,7 @@ func TestEval_WhenGitHubRequestsFail(t *testing.T) {
 		wantErr                string
 	}{
 		"when get label request fails": {
-			inputReviewpadFilePath: "testdata/exec/reviewpad_with_valid_label.yml",
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_label_without_description.yml",
 			clientOptions: []mock.MockBackendOption{
 				mock.WithRequestMatchHandler(
 					mock.GetReposLabelsByOwnerByRepoByName,
@@ -46,7 +46,7 @@ func TestEval_WhenGitHubRequestsFail(t *testing.T) {
 			wantErr: "GetLabelRequestFailed",
 		},
 		"when create label request fails": {
-			inputReviewpadFilePath: "testdata/exec/reviewpad_with_valid_label.yml",
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_label_without_description.yml",
 			clientOptions: []mock.MockBackendOption{
 				mock.WithRequestMatchHandler(
 					mock.GetReposLabelsByOwnerByRepoByName,
@@ -116,7 +116,7 @@ func TestEval(t *testing.T) {
 	}{
 		"when label has no name": {
 			inputReviewpadFilePath: "testdata/exec/reviewpad_with_unnamed_label.yml",
-			clientOptions:          []mock.MockBackendOption{mockGetReposLabelsByOwnerByRepoByName("bug")},
+			clientOptions:          []mock.MockBackendOption{mockGetReposLabelsByOwnerByRepoByName("bug", "")},
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
 					engine.BuildStatement(`$addLabel("test-unnamed-label")`),
@@ -124,29 +124,49 @@ func TestEval(t *testing.T) {
 			),
 		},
 		"when label exists": {
-			inputReviewpadFilePath: "testdata/exec/reviewpad_with_valid_label.yml",
-			clientOptions:          []mock.MockBackendOption{mockGetReposLabelsByOwnerByRepoByName("bug")},
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_label_without_description.yml",
+			clientOptions:          []mock.MockBackendOption{mockGetReposLabelsByOwnerByRepoByName("bug", "")},
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
-					engine.BuildStatement(`$addLabel("test-valid-label")`),
+					engine.BuildStatement(`$addLabel("test-label-without-description")`),
 				},
 			),
 		},
 		"when label does not exist": {
-			inputReviewpadFilePath: "testdata/exec/reviewpad_with_valid_label.yml",
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_label_without_description.yml",
 			clientOptions: []mock.MockBackendOption{
-				mockGetReposLabelsByOwnerByRepoByName(""),
-				mockPostReposLabelsByOwnerByRepo("bug", "f29513", ""),
+				mockGetReposLabelsByOwnerByRepoByName("bug", ""),
+				mockPostReposLabelsByOwnerByRepo("bug", ""),
 			},
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
-					engine.BuildStatement(`$addLabel("test-valid-label")`),
+					engine.BuildStatement(`$addLabel("test-label-without-description")`),
+				},
+			),
+		},
+		"when label has updates": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_label_with_diff_repo_description.yml",
+			clientOptions: []mock.MockBackendOption{
+				mockGetReposLabelsByOwnerByRepoByName("bug", "Something is wrong"),
+				mockPatchReposLabelsByOwnerByRepo("bug", "Something is definitely wrong"),
+			},
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(`$addLabel("test-label-update")`),
+				},
+			),
+		},
+		"when label has no updates": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_label_with_repo_description.yml",
+			clientOptions:          []mock.MockBackendOption{mockGetReposLabelsByOwnerByRepoByName("bug", "Something is wrong")},
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(`$addLabel("test-label-with-no-updates")`),
 				},
 			),
 		},
 		"when group is valid": {
 			inputReviewpadFilePath: "testdata/exec/reviewpad_with_valid_group.yml",
-			clientOptions:          []mock.MockBackendOption{mockGetReposLabelsByOwnerByRepoByName("test-valid-group")},
 			wantProgram: engine.BuildProgram(
 				[]*engine.Statement{
 					engine.BuildStatement(`$addLabel("test-valid-group")`),
@@ -155,7 +175,6 @@ func TestEval(t *testing.T) {
 		},
 		"when group is invalid": {
 			inputReviewpadFilePath: "testdata/exec/reviewpad_with_invalid_group.yml",
-			clientOptions:          []mock.MockBackendOption{mockGetReposLabelsByOwnerByRepoByName("test-invalid-group")},
 			wantErr:                "ProcessGroup:evalGroup expression is not a valid group",
 		},
 		"when workflow is invalid": {
@@ -231,7 +250,7 @@ func TestEval(t *testing.T) {
 			gotProgram, gotErr := engine.Eval(reviewpadFile, mockedEnv)
 
 			if gotErr != nil && gotErr.Error() != test.wantErr {
-				assert.FailNow(t, "Load() error = %v, wantErr %v", gotErr, test.wantErr)
+				assert.FailNow(t, "Eval() error = %v, wantErr %v", gotErr, test.wantErr)
 			}
 			assert.Equal(t, test.wantProgram, gotProgram)
 		})
@@ -256,12 +275,13 @@ func mockAladinoInterpreter(githubClient *gh.GithubClient) (engine.Interpreter, 
 	return mockedAladinoInterpreter, nil
 }
 
-func mockGetReposLabelsByOwnerByRepoByName(label string) mock.MockBackendOption {
+func mockGetReposLabelsByOwnerByRepoByName(name, description string) mock.MockBackendOption {
 	labelsMockedResponse := &github.Label{}
 
-	if label != "" {
+	if name != "" {
 		labelsMockedResponse = &github.Label{
-			Name: github.String(label),
+			Name:        github.String(name),
+			Description: github.String(description),
 		}
 	}
 
@@ -271,10 +291,21 @@ func mockGetReposLabelsByOwnerByRepoByName(label string) mock.MockBackendOption 
 	)
 }
 
-func mockPostReposLabelsByOwnerByRepo(name, color, description string) mock.MockBackendOption {
+func mockPatchReposLabelsByOwnerByRepo(name, description string) mock.MockBackendOption {
 	labelsMockedResponse := &github.Label{
 		Name:        github.String(name),
-		Color:       github.String(color),
+		Description: github.String(description),
+	}
+
+	return mock.WithRequestMatch(
+		mock.PatchReposLabelsByOwnerByRepoByName,
+		labelsMockedResponse,
+	)
+}
+
+func mockPostReposLabelsByOwnerByRepo(name, description string) mock.MockBackendOption {
+	labelsMockedResponse := &github.Label{
+		Name:        github.String(name),
 		Description: github.String(description),
 	}
 

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -81,17 +81,17 @@ func TestEval_WhenGitHubRequestsFail(t *testing.T) {
 
 			mockedAladinoInterpreter, err := mockAladinoInterpreter(mockedClient)
 			if err != nil {
-				assert.FailNow(t, "mockDefaultAladinoInterpreterWith: %v", err)
+				assert.FailNow(t, fmt.Sprintf("mockDefaultAladinoInterpreterWith: %v", err))
 			}
 
 			mockedEnv, err := engine.MockEnvWith(mockedClient, mockedAladinoInterpreter)
 			if err != nil {
-				assert.FailNow(t, "engine MockDefaultEnvWith: %v", err)
+				assert.FailNow(t, fmt.Sprintf("engine MockDefaultEnvWith: %v", err))
 			}
 
 			reviewpadFileData, err := utils.LoadFile(test.inputReviewpadFilePath)
 			if err != nil {
-				assert.FailNow(t, "Error reading reviewpad file: %v", err)
+				assert.FailNow(t, fmt.Sprintf("Error reading reviewpad file: %v", err))
 			}
 
 			reviewpadFile, err := testutils.ParseReviewpadFile(reviewpadFileData)
@@ -229,28 +229,28 @@ func TestEval(t *testing.T) {
 
 			mockedAladinoInterpreter, err := mockAladinoInterpreter(mockedClient)
 			if err != nil {
-				assert.FailNow(t, "mockDefaultAladinoInterpreterWith: %v", err)
+				assert.FailNow(t, fmt.Sprintf("mockDefaultAladinoInterpreterWith: %v", err))
 			}
 
 			mockedEnv, err := engine.MockEnvWith(mockedClient, mockedAladinoInterpreter)
 			if err != nil {
-				assert.FailNow(t, "engine MockDefaultEnvWith: %v", err)
+				assert.FailNow(t, fmt.Sprintf("engine MockDefaultEnvWith: %v", err))
 			}
 
 			reviewpadFileData, err := utils.LoadFile(test.inputReviewpadFilePath)
 			if err != nil {
-				assert.FailNow(t, "Error reading reviewpad file: %v", err)
+				assert.FailNow(t, fmt.Sprintf("Error reading reviewpad file: %v", err))
 			}
 
 			reviewpadFile, err := testutils.ParseReviewpadFile(reviewpadFileData)
 			if err != nil {
-				assert.FailNow(t, "Error parsing reviewpad file: %v", err)
+				assert.FailNow(t, fmt.Sprintf("Error parsing reviewpad file: %v", err))
 			}
 
 			gotProgram, gotErr := engine.Eval(reviewpadFile, mockedEnv)
 
 			if gotErr != nil && gotErr.Error() != test.wantErr {
-				assert.FailNow(t, "Eval() error = %v, wantErr %v", gotErr, test.wantErr)
+				assert.FailNow(t, fmt.Sprintf("Eval() error = %v, wantErr %v", gotErr, test.wantErr))
 			}
 			assert.Equal(t, test.wantProgram, gotProgram)
 		})

--- a/engine/labels.go
+++ b/engine/labels.go
@@ -48,6 +48,42 @@ func createLabel(e *Env, labelName *string, label *PadLabel) error {
 	return err
 }
 
+func checkLabelHasUpdates(e *Env, label *PadLabel) (bool, error) {
+	owner := e.TargetEntity.Owner
+	repo := e.TargetEntity.Repo
+
+	ghLabel, _, err := e.GithubClient.GetLabel(e.Ctx, owner, repo, label.Name)
+	if err != nil {
+		return false, err
+	}
+
+	if ghLabel.Name == &label.Name && ghLabel.Color == &label.Color && ghLabel.Description == &label.Description {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func updateLabel(e *Env, label *PadLabel) error {
+	owner := e.TargetEntity.Owner
+	repo := e.TargetEntity.Repo
+
+	err := validateLabelColor(label)
+	if err != nil {
+		return err
+	}
+
+	updatedGithubLabel := &github.Label{
+		Name:        github.String(label.Name),
+		Color:       github.String(label.Color),
+		Description: github.String(label.Description),
+	}
+
+	_, _, err = e.GithubClient.EditLabel(e.Ctx, owner, repo, label.Name, updatedGithubLabel)
+
+	return err
+}
+
 func checkLabelExists(e *Env, labelName string) (bool, error) {
 	owner := e.TargetEntity.Owner
 	repo := e.TargetEntity.Repo

--- a/engine/labels.go
+++ b/engine/labels.go
@@ -48,38 +48,36 @@ func createLabel(e *Env, labelName *string, label *PadLabel) error {
 	return err
 }
 
-func checkLabelHasUpdates(e *Env, label *PadLabel) (bool, error) {
+func checkLabelHasUpdates(e *Env, label *PadLabel, labelName string) (bool, error) {
 	owner := e.TargetEntity.Owner
 	repo := e.TargetEntity.Repo
 
-	ghLabel, _, err := e.GithubClient.GetLabel(e.Ctx, owner, repo, label.Name)
+	ghLabel, _, err := e.GithubClient.GetLabel(e.Ctx, owner, repo, labelName)
 	if err != nil {
 		return false, err
 	}
 
-	if ghLabel.Name == &label.Name && ghLabel.Color == &label.Color && ghLabel.Description == &label.Description {
+	if *ghLabel.Name == labelName && ghLabel.Color == &label.Color && ghLabel.Description == &label.Description {
 		return false, nil
 	}
 
 	return true, nil
 }
 
-func updateLabel(e *Env, label *PadLabel) error {
+func updateLabel(e *Env, label *PadLabel, labelName string) error {
 	owner := e.TargetEntity.Owner
 	repo := e.TargetEntity.Repo
 
-	err := validateLabelColor(label)
-	if err != nil {
-		return err
+	var updatedLabelDescription *string
+	if label.Description != "" {
+		updatedLabelDescription = &label.Description
 	}
 
 	updatedGithubLabel := &github.Label{
-		Name:        github.String(label.Name),
-		Color:       github.String(label.Color),
-		Description: github.String(label.Description),
+		Description: updatedLabelDescription,
 	}
 
-	_, _, err = e.GithubClient.EditLabel(e.Ctx, owner, repo, label.Name, updatedGithubLabel)
+	_, _, err := e.GithubClient.EditLabel(e.Ctx, owner, repo, labelName, updatedGithubLabel)
 
 	return err
 }

--- a/engine/labels.go
+++ b/engine/labels.go
@@ -68,13 +68,8 @@ func updateLabel(e *Env, label *PadLabel, labelName string) error {
 	owner := e.TargetEntity.Owner
 	repo := e.TargetEntity.Repo
 
-	var updatedLabelDescription *string
-	if label.Description != "" {
-		updatedLabelDescription = &label.Description
-	}
-
 	updatedGithubLabel := &github.Label{
-		Description: updatedLabelDescription,
+		Description: &label.Description,
 	}
 
 	_, _, err := e.GithubClient.EditLabel(e.Ctx, owner, repo, labelName, updatedGithubLabel)

--- a/engine/testdata/exec/reviewpad_with_label_with_diff_repo_description.yml
+++ b/engine/testdata/exec/reviewpad_with_label_with_diff_repo_description.yml
@@ -1,0 +1,22 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+api-version: reviewpad.com/v1alpha
+
+labels:
+  bug:
+    name: bug
+    description: Something is definitely wrong
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+
+workflows:
+  - name: test-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("test-label-update")

--- a/engine/testdata/exec/reviewpad_with_label_with_diff_repo_description.yml
+++ b/engine/testdata/exec/reviewpad_with_label_with_diff_repo_description.yml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a license that can be
 # found in the LICENSE file.
 
-api-version: reviewpad.com/v1alpha
+api-version: reviewpad.com/v3.x
 
 labels:
   bug:

--- a/engine/testdata/exec/reviewpad_with_label_with_repo_description.yml
+++ b/engine/testdata/exec/reviewpad_with_label_with_repo_description.yml
@@ -2,12 +2,12 @@
 # Use of this source code is governed by a license that can be
 # found in the LICENSE file.
 
-api-version: reviewpad.com/v3.x
+api-version: reviewpad.com/v1alpha
 
 labels:
   bug:
     name: bug
-    color: f29513
+    description: Something is wrong
 
 rules:
   - name: tautology
@@ -19,4 +19,4 @@ workflows:
     if:
       - rule: tautology
     then:
-      - $addLabel("test-valid-label")
+      - $addLabel("test-label-with-no-updates")

--- a/engine/testdata/exec/reviewpad_with_label_with_repo_description.yml
+++ b/engine/testdata/exec/reviewpad_with_label_with_repo_description.yml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a license that can be
 # found in the LICENSE file.
 
-api-version: reviewpad.com/v1alpha
+api-version: reviewpad.com/v3.x
 
 labels:
   bug:

--- a/engine/testdata/exec/reviewpad_with_label_without_description.yml
+++ b/engine/testdata/exec/reviewpad_with_label_without_description.yml
@@ -1,0 +1,21 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+api-version: reviewpad.com/v3.x
+
+labels:
+  bug:
+    name: bug
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+
+workflows:
+  - name: test-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("test-label-without-description")


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
At the moment, if a label is already persistent in a repository and its description is different from the one set in the `reviewpad.yml` if it's mentioned, nothing happens.
This pull request adds the possibility to the update the label in the repository with the description defined in the `reviewpad.yml` if they are different.

## Related issue

<!-- Closes # (issue) -->
Closes #334 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran `task check -f` cmd, testing the associated tests.
Used a testing repository.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [ ] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
