### PR TITLE
feat: $totalCodeReviews function built-in

### DIFF
--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -91,6 +91,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			// User
 			"issueCountBy":             functions.IssueCountBy(),
 			"pullRequestCountBy":       functions.PullRequestCountBy(),
+			"totalCodeReviews":         functions.TotalCodeReviews(),
 			"totalCreatedPullRequests": functions.TotalCreatedPullRequests(),
 			// Utilities
 			"all":         functions.All(),

--- a/plugins/aladino/functions/totalCodeReviews.go
+++ b/plugins/aladino/functions/totalCodeReviews.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	"github.com/shurcooL/githubv4"
+)
+
+func TotalCodeReviews() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType()}, aladino.BuildIntType()),
+		Code:           totalCodeReviewsCode,
+		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest},
+	}
+}
+
+func totalCodeReviewsCode(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
+	username := args[0].(*aladino.StringValue).Val
+
+	var totalPullRequestReviewsQuery struct {
+		User struct {
+			ContributionsCollection struct {
+				TotalPullRequestReviewContributions githubv4.Int
+			} `graphql:"contributionsCollection"`
+		} `graphql:"user(login: $username)"`
+	}
+
+	varGQLTotalPullRequestReviewsQuery := map[string]interface{}{
+		"username": githubv4.String(username),
+	}
+
+	err := e.GetGithubClient().GetClientGraphQL().Query(e.GetCtx(), &totalPullRequestReviewsQuery, varGQLTotalPullRequestReviewsQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	return aladino.BuildIntValue(int(totalPullRequestReviewsQuery.User.ContributionsCollection.TotalPullRequestReviewContributions)), nil
+}

--- a/plugins/aladino/functions/totalCodeReviews_test.go
+++ b/plugins/aladino/functions/totalCodeReviews_test.go
@@ -1,0 +1,94 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+	"github.com/reviewpad/reviewpad/v3/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var totalCodeReviews = plugins_aladino.PluginBuiltIns().Functions["totalCodeReviews"].Code
+
+func TestTotalCodeReviews_WhenRequestFails(t *testing.T) {
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetails()
+	author := mockedPullRequest.GetUser().GetLogin()
+
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		nil,
+		func(w http.ResponseWriter, req *http.Request) {
+			http.Error(w, "Total user code reviews request failed", http.StatusBadRequest)
+		},
+		aladino.MockBuiltIns(),
+		nil,
+	)
+
+	args := []aladino.Value{aladino.BuildStringValue(author)}
+	gotVal, gotErr := totalCodeReviews(mockedEnv, args)
+
+	assert.Nil(t, gotVal)
+	assert.EqualError(t, gotErr, "non-200 OK status code: 400 Bad Request body: \"Total user code reviews request failed\\n\"")
+}
+
+func TestTotalCodeReviews(t *testing.T) {
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetails()
+	author := mockedPullRequest.GetUser().GetLogin()
+	codeReviewsNum := 80
+
+	mockedTotalPullRequestReviewsQuery := fmt.Sprintf(`{
+	    "query": "query($username:String!) {
+			user(login:$username){
+				contributionsCollection {
+					totalPullRequestReviewContributions
+				}
+			}
+	    }",
+	    "variables": {
+	        "username": "%s"
+	    }
+	}`, author)
+
+	mockedTotalPullRequestReviewsQueryBody := fmt.Sprintf(`{
+		"data": {
+			"user": {
+				"contributionsCollection": {
+					"totalPullRequestReviewContributions": %d
+				}
+			}
+		}
+	}`, codeReviewsNum)
+
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		nil,
+		func(res http.ResponseWriter, req *http.Request) {
+			query := utils.MinifyQuery(aladino.MustRead(req.Body))
+			switch query {
+			case utils.MinifyQuery(mockedTotalPullRequestReviewsQuery):
+				aladino.MustWrite(res, mockedTotalPullRequestReviewsQueryBody)
+			}
+		},
+		aladino.MockBuiltIns(),
+		nil,
+	)
+
+	wantErr := ""
+	wantVal := aladino.BuildIntValue(codeReviewsNum)
+
+	args := []aladino.Value{aladino.BuildStringValue(author)}
+	gotVal, gotErr := totalCodeReviews(mockedEnv, args)
+
+	if gotErr != nil && gotErr.Error() != wantErr {
+		assert.FailNow(t, "totalCodeReviews() error = %v, wantErr %v", gotErr, wantErr)
+	}
+
+	assert.Equal(t, wantVal, gotVal)
+}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request introduces a new built-in called `$totalCodeReviews` that given a GitHub user login, returns the total number of code reviews made by that user.

## Related issue

<!-- Closes # (issue) -->
Closes #335 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran `task check -f` cmd.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [ ] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
