### PR TITLE
fix: string literal regex breaks for strings which contain other strings

### DIFF
--- a/lang/aladino/expr.go
+++ b/lang/aladino/expr.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/reviewpad/reviewpad/v3/utils/report"
@@ -112,7 +113,10 @@ type StringConst struct {
 }
 
 func BuildStringConst(val string) *StringConst {
-	return &StringConst{val}
+	// String may contain other strings.
+	// To handle this we need to add manual escapes for parsing substrings (e.g. "hello \"world\"")
+	// However, those escapes are escaped internally, so we need to unescape them.
+	return &StringConst{strings.ReplaceAll(val, "\\\"", "\"")}
 }
 
 func (c *StringConst) Kind() string {

--- a/lang/aladino/expr_internal_test.go
+++ b/lang/aladino/expr_internal_test.go
@@ -166,10 +166,30 @@ func TestBoolConstEquals_WhenEqual(t *testing.T) {
 }
 
 func TestBuildStringConst(t *testing.T) {
-	wantVal := &StringConst{"LoremIpsum"}
-	gotVal := BuildStringConst("LoremIpsum")
+	tests := map[string]struct {
+		input   string
+		wantVal *StringConst
+	}{
+		"empty": {
+			input:   "",
+			wantVal: &StringConst{""},
+		},
+		"non-empty": {
+			input:   "LoremIpsum",
+			wantVal: &StringConst{"LoremIpsum"},
+		},
+		"with spaced string": {
+			input:   "Lorem \\\"Ipsum\\\"",
+			wantVal: &StringConst{"Lorem \"Ipsum\""},
+		},
+	}
 
-	assert.Equal(t, wantVal, gotVal)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotVal := BuildStringConst(test.input)
+			assert.Equal(t, test.wantVal, gotVal)
+		})
+	}
 }
 
 func TestStringConstKind(t *testing.T) {

--- a/lang/aladino/lex.go
+++ b/lang/aladino/lex.go
@@ -73,7 +73,7 @@ var tokens = []tokenDef{
 		token: IDENTIFIER,
 	},
 	{
-		regex: regexp.MustCompile(`^"[^"]*"`),
+		regex: regexp.MustCompile(`^"([^"\\]|\\[\s\S])*"`),
 		kind:  "stringLiteral",
 		token: STRINGLITERAL,
 	},

--- a/lang/aladino/parse_test.go
+++ b/lang/aladino/parse_test.go
@@ -36,6 +36,13 @@ func TestParse(t *testing.T) {
 				BuildStringConst("hello world"),
 			}),
 		},
+		"comment a string with spaced strings": {
+			input: `$comment("hello \"world\" and \"world\" again")`,
+			wantExpr: BuildFunctionCall(
+				BuildVariable("comment"),
+				[]Expr{BuildStringConst("hello \"world\" and \"world\" again")},
+			),
+		},
 		"array of strings": {
 			input: `["hello", "world"]`,
 			wantExpr: BuildArray([]Expr{


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request introduces a fix to the bug string literal regex breaking for strings which contain other strings.
This bug was occuring because it was being done the escaping of `"` inside the string.
This fix was based on https://gist.github.com/cellularmitosis/6fd5fc2a65225364f72d3574abd9d5d5.
We only add the escape for the `reviewpad.yml`. Internally, we remove this escape (upon building strings) because we only use the escape for parsing effects and furthermore this escape is not needed anymore.

## Related issue

<!-- Closes # (issue) -->
Closes #370 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran `task check -f` cmd and performed tests against a testing repo.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [ ] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
