### PR TITLE
fix: no alternative for when pushedDate is nil

### DIFF
--- a/codehost/github/pull_requests.go
+++ b/codehost/github/pull_requests.go
@@ -380,10 +380,10 @@ func (c *GithubClient) GetPullRequestLastPushDate(ctx context.Context, owner str
 	event := lastPushQuery.Repository.PullRequest.TimelineItems.Nodes[0]
 	switch event.Typename {
 	case "PullRequestCommit":
-		if pushedDate := event.PullRequestCommit.Commit.PushedDate; pushDate != nil {
+		if pushedDate := event.PullRequestCommit.Commit.PushedDate; pushedDate != nil {
 			pushDate = pushedDate
 		} else {
-			pushDate = event.PullRequestCommit.Commit.PushedDate
+			pushDate = event.PullRequestCommit.Commit.CommittedDate
 		}
 	case "HeadRefForcePushedEvent":
 		pushDate = event.HeadRefForcePushedEvent.CreatedAt

--- a/codehost/github/pull_requests_test.go
+++ b/codehost/github/pull_requests_test.go
@@ -767,7 +767,7 @@ func TestGetPullRequestLastPushDate(t *testing.T) {
 			wantLastPushDate: time.Time{},
 			wantErr:          "last push not found",
 		},
-		"when pull request's last event is a push": {
+		"when pull request's last event is a push and pushDate is not nil": {
 			mockedGQLQueryBody: `{
 				"data": {
 					"repository": {
@@ -786,6 +786,26 @@ func TestGetPullRequestLastPushDate(t *testing.T) {
 				}
 			}`,
 			wantLastPushDate: time.Date(2011, 1, 26, 19, 06, 43, 0, time.UTC),
+			wantErr:          "",
+		},
+		"when pull request's last event is a push and pushedDate is nil": {
+			mockedGQLQueryBody: `{
+				"data": {
+					"repository": {
+						"pullRequest": {
+							"timelineItems": {
+								"nodes": [{
+									"__typename": "PullRequestCommit",
+									"commit": {
+										"committedDate": "2011-01-26T19:01:12Z"
+									}
+								}]
+							}
+						}
+					}
+				}
+			}`,
+			wantLastPushDate: time.Date(2011, 1, 26, 19, 01, 12, 0, time.UTC),
 			wantErr:          "",
 		},
 		"when pull request's last event is a force push": {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request handles the case of `pushedDate` being `nil` when executing [`GetPullRequestLastPushDate`](https://github.com/reviewpad/reviewpad/blob/main/codehost/github/pull_requests.go#L360) in the case scenario of the last pull request event being a commit.
The handling of this consists in considering the `CommittedDate` of the commit.

## Related issue

<!-- Closes # (issue) -->
Closes #379 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran `task check -f` cmd.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
