### PR TITLE
feat: ignore stale labeling for good first issues

### DIFF
--- a/stale.yml
+++ b/stale.yml
@@ -11,8 +11,13 @@ labels:
 rules:
   - name: labeled-as-stale
     kind: patch
-    description: Issue/Pull request has stale label
+    description: Issue/Pull request has "stale" label
     spec: '$isElementOf("stale", $labels())'
+  
+  - name: labeled-as-good-first-issue
+    kind: patch
+    description: Issue has "good first issue" label
+    spec: '$isElementOf("good first issue", $labels())'
 
 workflows:
   - name: stale-issue-or-pr-handling
@@ -20,7 +25,7 @@ workflows:
       - "issue"
       - "pull_request"
     if:
-      - rule: '!$rule("labeled-as-stale") && $lastEventAt() < 7 days ago'
+      - rule: '!$rule("labeled-as-good-first-issue") && !$rule("labeled-as-stale") && $lastEventAt() < 7 days ago'
         extra-actions:
           - '$info("This issue is stale.")'
           - '$addLabel("stale-label")'


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request improves the reviewpad yml configuration for stale issues/pull requests by not performing the stale labelling if the issues are already labeled as "good first issues".

## Related issue

<!-- Closes # (issue) -->
Closes #383 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran `./reviewpad-cli check` cmd in order to check the linting of the file and ran this configuration against a testing repo.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
