### PR TITLE
feat: add review built-in

### DIFF
--- a/codehost/github/pull_requests.go
+++ b/codehost/github/pull_requests.go
@@ -332,6 +332,10 @@ func (c *GithubClient) Merge(ctx context.Context, owner string, repo string, num
 	return c.clientREST.PullRequests.Merge(ctx, owner, repo, number, commitMessage, options)
 }
 
+func (c *GithubClient) Review(ctx context.Context, owner string, repo string, number int, review *github.PullRequestReviewRequest) (*github.PullRequestReview, *github.Response, error) {
+	return c.clientREST.PullRequests.CreateReview(ctx, owner, repo, number, review)
+}
+
 func (c *GithubClient) GetPullRequestClosingIssuesCount(ctx context.Context, owner string, repo string, number int) (int, error) {
 	var pullRequestQuery struct {
 		Repository struct {

--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -6,7 +6,6 @@ package target
 
 import (
 	"context"
-
 	"github.com/google/go-github/v45/github"
 	"github.com/reviewpad/reviewpad/v3/codehost"
 	gh "github.com/reviewpad/reviewpad/v3/codehost/github"
@@ -215,6 +214,21 @@ func (t *PullRequestTarget) Merge(mergeMethod string) error {
 
 	_, _, err := t.githubClient.Merge(ctx, owner, repo, number, "Merged by Reviewpad", &github.PullRequestOptions{
 		MergeMethod: mergeMethod,
+	})
+
+	return err
+}
+
+func (t *PullRequestTarget) Review(reviewEvent, reviewBody string) error {
+	ctx := t.ctx
+	targetEntity := t.targetEntity
+	owner := targetEntity.Owner
+	repo := targetEntity.Repo
+	number := targetEntity.Number
+
+	_, _, err := t.githubClient.Review(ctx, owner, repo, number, &github.PullRequestReviewRequest{
+		Body:  &reviewBody,
+		Event: &reviewEvent,
 	})
 
 	return err

--- a/plugins/aladino/actions/review.go
+++ b/plugins/aladino/actions/review.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_actions
+
+import (
+	"fmt"
+	"github.com/reviewpad/reviewpad/v3/codehost/github/target"
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+)
+
+func Review() *aladino.BuiltInAction {
+	return &aladino.BuiltInAction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType(), aladino.BuildStringType()}, nil),
+		Code:           reviewCode,
+		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest},
+	}
+}
+
+func reviewCode(e aladino.Env, args []aladino.Value) error {
+	t := e.GetTarget().(*target.PullRequestTarget)
+
+	reviewEvent, err := parseReviewEvent(args[0].(*aladino.StringValue).Val)
+	if err != nil {
+		return err
+	}
+
+	reviewBody, err := checkReviewBody(reviewEvent, args[1].(*aladino.StringValue).Val)
+	if err != nil {
+		return err
+	}
+
+	return t.Review(reviewEvent, reviewBody)
+}
+
+func parseReviewEvent(reviewEvent string) (string, error) {
+	switch reviewEvent {
+	case "COMMENT", "REQUEST_CHANGES", "APPROVE":
+		return reviewEvent, nil
+	default:
+		return "", fmt.Errorf("review: unsupported review event %v", reviewEvent)
+	}
+}
+
+func checkReviewBody(reviewEvent, reviewBody string) (string, error) {
+	if reviewEvent != "APPROVE" && reviewBody == "" {
+		return "", fmt.Errorf("review: comment required in %v event", reviewEvent)
+	}
+
+	return reviewBody, nil
+}

--- a/plugins/aladino/actions/review_test.go
+++ b/plugins/aladino/actions/review_test.go
@@ -1,0 +1,120 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_actions_test
+
+import (
+	"encoding/json"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var review = plugins_aladino.PluginBuiltIns().Actions["review"].Code
+
+type ReviewRequestPostBody struct {
+	Event string `json:"event"`
+	Body  string `json:"body"`
+}
+
+func TestReview_WhenReviewMethodIsUnsupported(t *testing.T) {
+	mockedEnv := aladino.MockDefaultEnv(t, nil, nil, aladino.MockBuiltIns(), nil)
+
+	args := []aladino.Value{aladino.BuildStringValue("INVALID"), aladino.BuildStringValue("some comment")}
+	err := review(mockedEnv, args)
+
+	assert.EqualError(t, err, "review: unsupported review event INVALID")
+}
+
+func TestReview_WhenBodyIsNotEmpty(t *testing.T) {
+	reviewBody := "test comment"
+	tests := map[string]struct {
+		inputReviewEvent string
+	}{
+		"when review event is APPROVE": {
+			inputReviewEvent: "APPROVE",
+		},
+		"when review event is REQUEST_CHANGES": {
+			inputReviewEvent: "REQUEST_CHANGES",
+		},
+		"when review event is COMMENT": {
+			inputReviewEvent: "COMMENT",
+		},
+	}
+	for _, test := range tests {
+		var (
+			gotReviewEvent string
+			gotReviewBody  string
+		)
+		mockedEnv := aladino.MockDefaultEnv(
+			t,
+			[]mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						rawBody, _ := ioutil.ReadAll(r.Body)
+						body := ReviewRequestPostBody{}
+						json.Unmarshal(rawBody, &body)
+						gotReviewEvent = body.Event
+						gotReviewBody = body.Body
+					}),
+				),
+			},
+			nil,
+			aladino.MockBuiltIns(),
+			nil,
+		)
+		args := []aladino.Value{aladino.BuildStringValue(test.inputReviewEvent), aladino.BuildStringValue(reviewBody)}
+		err := review(mockedEnv, args)
+		assert.Nil(t, err)
+		assert.Equal(t, test.inputReviewEvent, gotReviewEvent)
+		assert.Equal(t, reviewBody, gotReviewBody)
+	}
+}
+
+func TestReview_WhenBodyIsEmpty(t *testing.T) {
+	tests := map[string]struct {
+		inputReviewEvent string
+		wantErr          string
+	}{
+		"when review event is APPROVE": {
+			inputReviewEvent: "APPROVE",
+			wantErr:          "",
+		},
+		"when review event is REQUEST_CHANGES": {
+			inputReviewEvent: "REQUEST_CHANGES",
+			wantErr:          "review: comment required in REQUEST_CHANGES event",
+		},
+		"when review event is COMMENT": {
+			inputReviewEvent: "COMMENT",
+			wantErr:          "review: comment required in COMMENT event",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedEnv := aladino.MockDefaultEnv(
+				t,
+				[]mock.MockBackendOption{
+					mock.WithRequestMatch(
+						mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+						&ReviewRequestPostBody{},
+					),
+				},
+				nil,
+				aladino.MockBuiltIns(),
+				nil,
+			)
+			args := []aladino.Value{aladino.BuildStringValue(test.inputReviewEvent), aladino.BuildStringValue("")}
+			gotErr := review(mockedEnv, args)
+			if gotErr != nil && gotErr.Error() != test.wantErr {
+				assert.FailNow(t, "review() error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -127,6 +127,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"rebase":               actions.Rebase(),
 			"removeLabel":          actions.RemoveLabel(),
 			"removeLabels":         actions.RemoveLabels(),
+			"review":               actions.Review(),
 			"titleLint":            actions.TitleLint(),
 			"warn":                 actions.Warn(),
 		},


### PR DESCRIPTION
## Description

Adds new built-in $review

## Related issue

Closes [issue #384](https://github.com/reviewpad/reviewpad/issues/384)

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Ran `task test` command.
Use rewiewpad as CLI with test config 

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
<!-- - [x] Ask: this pull request requires a code review before merge -->
