### PR TITLE
feat: add runner env property to mixpanel collector

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -98,7 +98,7 @@ func run() error {
 
 	ctx := context.Background()
 	githubClient := gh.NewGithubClientFromToken(ctx, gitHubToken)
-	collectorClient := collector.NewCollector(mixpanelToken, repositoryOwner, string(entityKind), githubUrl)
+	collectorClient := collector.NewCollector(mixpanelToken, repositoryOwner, string(entityKind), githubUrl, "local-cli")
 
 	data, err := os.ReadFile(reviewpadFile)
 	if err != nil {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -14,9 +14,10 @@ type Collector interface {
 }
 
 type collector struct {
-	Client mixpanel.Mixpanel
-	Id     string
-	Token  string
+	Client    mixpanel.Mixpanel
+	Id        string
+	Token     string
+	RunnerEnv string
 	// Allows to identify a unique source of events
 	RunnerId string
 	// Allows to identify the correct order of events
@@ -27,11 +28,12 @@ type collector struct {
 	Url string
 }
 
-func NewCollector(token, id, eventType, url string) Collector {
+func NewCollector(token, id, eventType, url, runner string) Collector {
 	c := collector{
 		Client:    mixpanel.New(token, ""),
 		Id:        id,
 		Token:     token,
+		RunnerEnv: runner,
 		RunnerId:  uuid.NewString(),
 		Order:     0,
 		EventType: eventType,
@@ -54,6 +56,7 @@ func (c *collector) Collect(eventName string, properties map[string]interface{})
 	if c.Token == "" {
 		return nil
 	}
+	properties["runner"] = c.RunnerEnv
 	properties["runnerId"] = c.RunnerId
 	properties["order"] = c.Order
 	properties["eventType"] = c.EventType

--- a/engine/mocks.go
+++ b/engine/mocks.go
@@ -25,7 +25,7 @@ const DefaultMockPrRepoName = "default-mock-repo"
 
 // Use only for tests
 var DefaultMockCtx = context.Background()
-var DefaultMockCollector = collector.NewCollector("", "", "pull_request", "")
+var DefaultMockCollector = collector.NewCollector("", "", "pull_request", "", "dev-test")
 var DefaultMockEventPayload = &github.CheckRunEvent{}
 var DefaultMockTargetEntity = &handler.TargetEntity{
 	Owner:  DefaultMockPrOwner,

--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -29,7 +29,7 @@ const DefaultMockPrRepoName = "default-mock-repo"
 
 var DefaultMockPrDate = time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
 var DefaultMockContext = context.Background()
-var DefaultMockCollector = collector.NewCollector("", "", "pull_request", "")
+var DefaultMockCollector = collector.NewCollector("", "", "pull_request", "", "dev-test")
 var DefaultMockTargetEntity = &handler.TargetEntity{
 	Owner:  DefaultMockPrOwner,
 	Repo:   DefaultMockPrRepoName,


### PR DESCRIPTION
## Description
This pull request makes the following changes:

- Adds a property `runnerEnv` to the `collector` struct to represent the env where Reviewpad is running;
- Updates the callers of the collector to use the property.

## Related issue

Closes #417

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

None.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge 
