### PR TITLE
fix: incorrect conversion between integer types code scanning alert

### DIFF
--- a/codehost/diff.go
+++ b/codehost/diff.go
@@ -118,7 +118,7 @@ func parseLines(line string) (*chunkLinesInfo, error) {
 
 func parseVersionSection(section string) (int32, int32, error) {
 	blocks := strings.Split(section, ",")
-	line, err := strconv.Atoi(blocks[0])
+	line, err := strconv.ParseInt(blocks[0], 10, 32)
 	if err != nil {
 		return 0, 0, fmt.Errorf("wrong line format (%s): %v", blocks[0], err)
 	}
@@ -127,7 +127,7 @@ func parseVersionSection(section string) (int32, int32, error) {
 		return replyLine, replyLine, nil
 	}
 
-	numLines, err := strconv.Atoi(blocks[1])
+	numLines, err := strconv.ParseInt(blocks[1], 10, 32)
 	if err != nil {
 		return 0, 0, fmt.Errorf("wrong num old lines format (%s): %v", blocks[1], err)
 	}


### PR DESCRIPTION
## Description
This PR fixes the incorrect conversion between integer types code scanning alert by parsing numbers that are cast to int32 as 32bit
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #439 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
This was tested by building a CodeQL database locally and running the `IncorrectIntegerConversionQuery.ql` query and checking the result
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

- [x] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
<!-- - [ ] Ask: this pull request requires a code review before merge -->
