### PR TITLE
fix: add default state for pullRequestCountBy and issueCountBy built-ins in transform

### DIFF
--- a/engine/transform.go
+++ b/engine/transform.go
@@ -41,7 +41,6 @@ func addDefaultSizeMethod(str string) string {
 	return strings.ReplaceAll(str, "$size()", "$size([])")
 }
 
-// reviewpad-an: generated-by-co-pilot
 func addDefaultIssueCountBy(str string) string {
 	r := regexp.MustCompile(`\$issueCountBy\(([^,\s]+)(?:,\s*("[^\(\)]*"))?\)`)
 	str = r.ReplaceAllString(str, `$$issueCountBy($1, $2)`)

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -43,29 +43,17 @@ func addDefaultSizeMethod(str string) string {
 
 // reviewpad-an: generated-by-co-pilot
 func addDefaultIssueCountBy(str string) string {
-	m := regexp.MustCompile("\\$issueCountBy\\(\"[^\"]*\"\\)")
-	match := m.FindString(str)
-
-	if match == "" {
-		return str
-	}
-
-	matchWithDefaultState := match[0:len(match)-1] + ", \"all\")"
-	transformedStr := strings.ReplaceAll(str, match, matchWithDefaultState)
-	return transformedStr
+	r := regexp.MustCompile(`\$issueCountBy\(([^,\s]+)(?:,\s*("[^\(\)]*"))?\)`)
+	str = r.ReplaceAllString(str, `$$issueCountBy($1, $2)`)
+	r = regexp.MustCompile(`\$issueCountBy\(([^,\s]+),\s*("")?\)`)
+	return r.ReplaceAllString(str, `$$issueCountBy($1, "all")`)
 }
 
 func addDefaultPullRequestCountBy(str string) string {
-	m := regexp.MustCompile("\\$pullRequestCountBy\\(\"[^\"]*\"\\)")
-	match := m.FindString(str)
-
-	if match == "" {
-		return str
-	}
-
-	matchWithDefaultState := match[0:len(match)-1] + ", \"all\")"
-	transformedStr := strings.ReplaceAll(str, match, matchWithDefaultState)
-	return transformedStr
+	r := regexp.MustCompile(`\$pullRequestCountBy\(([^,\s]+)(?:,\s*("[^\(\)]*"))?\)`)
+	str = r.ReplaceAllString(str, `$$pullRequestCountBy($1, $2)`)
+	r = regexp.MustCompile(`\$pullRequestCountBy\(([^,\s]+),\s*("")?\)`)
+	return r.ReplaceAllString(str, `$$pullRequestCountBy($1, "all")`)
 }
 
 func addEmptyCloseComment(str string) string {

--- a/engine/transform_internal_test.go
+++ b/engine/transform_internal_test.go
@@ -41,7 +41,7 @@ func TestTransformAladinoExpression(t *testing.T) {
 		},
 		"pullRequestCountBy nil state": {
 			arg:     "$pullRequestCountBy(\"john\", \"\") > 0",
-			wantVal: "$pullRequestCountBy(\"john\", \"\") > 0",
+			wantVal: "$pullRequestCountBy(\"john\", \"all\") > 0",
 		},
 		"pullRequestCountBy nil dev": {
 			arg:     "$pullRequestCountBy(\"\", \"closed\") > 0",
@@ -54,6 +54,22 @@ func TestTransformAladinoExpression(t *testing.T) {
 		"pullRequestCountBy and issueCountBy": {
 			arg:     "$pullRequestCountBy(\"john\") > 0 && true && $issueCountBy(\"dev\") > 0",
 			wantVal: "$pullRequestCountBy(\"john\", \"all\") > 0 && true && $issueCountBy(\"dev\", \"all\") > 0",
+		},
+		"pullRequestCountBy with dev": {
+			arg:     `$pullRequestCountBy("john") > 0 && true && $pullRequestCountBy("john", "open") > 1`,
+			wantVal: `$pullRequestCountBy("john", "all") > 0 && true && $pullRequestCountBy("john", "open") > 1`,
+		},
+		"pullRequestCountBy with function call": {
+			arg:     `$pullRequestCountBy($author()) > 1 && $pullRequestCountBy($author(), "open") > 2`,
+			wantVal: `$pullRequestCountBy($author(), "all") > 1 && $pullRequestCountBy($author(), "open") > 2`,
+		},
+		"pullRequestCountBy with function call and state": {
+			arg:     `$pullRequestCountBy($author(), "open")`,
+			wantVal: `$pullRequestCountBy($author(), "open")`,
+		},
+		"pullRequestCountBy with function call and empty state": {
+			arg:     `$pullRequestCountBy($author(), "")`,
+			wantVal: `$pullRequestCountBy($author(), "all")`,
 		},
 		"close": {
 			arg:     "$close()",

--- a/plugins/aladino/functions/issueCountBy.go
+++ b/plugins/aladino/functions/issueCountBy.go
@@ -22,13 +22,8 @@ func issueCountByCode(e aladino.Env, args []aladino.Value) (aladino.Value, error
 	loginArg := args[0].(*aladino.StringValue).Val
 	stateArg := args[1].(*aladino.StringValue).Val
 
-	state := "all"
-	if stateArg != "" {
-		state = stateArg
-	}
-
 	opts := &github.IssueListByRepoOptions{
-		State: state,
+		State: stateArg,
 	}
 	if loginArg != "" {
 		opts.Creator = loginArg

--- a/plugins/aladino/functions/pullRequestCountBy.go
+++ b/plugins/aladino/functions/pullRequestCountBy.go
@@ -22,13 +22,8 @@ func pullRequestCountByCode(e aladino.Env, args []aladino.Value) (aladino.Value,
 	loginArg := args[0].(*aladino.StringValue).Val
 	stateArg := args[1].(*aladino.StringValue).Val
 
-	state := "all"
-	if stateArg != "" {
-		state = stateArg
-	}
-
 	opts := &github.IssueListByRepoOptions{
-		State: state,
+		State: stateArg,
 	}
 	if loginArg != "" {
 		opts.Creator = loginArg


### PR DESCRIPTION
## Description
This PR adds a default state(all) to the `$pullRequestCountBy` and `$issueCountBy` built-ins
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #434 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit and manual tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

- [x] Ship: this pull request can be automatically merged and does not require code review
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
<!-- - [ ] Ask: this pull request requires a code review before merge -->
