### PR TITLE
fix: don't re-request review unless a new commit has been pushed

### DIFF
--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -6,6 +6,7 @@ package target
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-github/v48/github"
 	"github.com/reviewpad/reviewpad/v3/codehost"
@@ -371,4 +372,14 @@ func (t *PullRequestTarget) IsDraft() (bool, error) {
 
 func (t *PullRequestTarget) GetTitle() string {
 	return t.PullRequest.GetTitle()
+}
+
+func (t *PullRequestTarget) GetPullRequestLastPushDate() (time.Time, error) {
+	ctx := t.ctx
+	targetEntity := t.targetEntity
+	owner := targetEntity.Owner
+	repo := targetEntity.Repo
+	number := targetEntity.Number
+
+	return t.githubClient.GetPullRequestLastPushDate(ctx, owner, repo, number)
 }

--- a/plugins/aladino/actions/assignReviewer.go
+++ b/plugins/aladino/actions/assignReviewer.go
@@ -37,6 +37,11 @@ func assignReviewerCode(e aladino.Env, args []aladino.Value) error {
 	totalRequiredReviewers := args[1].(*aladino.IntValue).Val
 	policy := args[2].(*aladino.StringValue).Val
 	target := e.GetTarget().(*target.PullRequestTarget)
+	targetEntity := target.GetTargetEntity()
+	ctx := e.GetCtx()
+	owner := targetEntity.Owner
+	repo := targetEntity.Repo
+	prNum := targetEntity.Number
 
 	allowedPolicies := map[string]bool{"random": true, "round-robin": true, "reviewpad": true}
 	if _, ok := allowedPolicies[policy]; !ok {
@@ -71,12 +76,17 @@ func assignReviewerCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
+	lastPushDate, err := e.GetGithubClient().GetPullRequestLastPushDate(ctx, owner, repo, prNum)
+	if err != nil {
+		return err
+	}
+
 	// Re-request current reviewers only when last review status is not APPROVED
 	for _, availableReviewer := range availableReviewers {
 		userLogin := availableReviewer.(*aladino.StringValue).Val
 		if codehost.HasReview(reviews, userLogin) {
 			lastReview := codehost.LastReview(reviews, userLogin)
-			if lastReview.State != "APPROVED" {
+			if lastReview.State != "APPROVED" && lastReview.SubmittedAt.Before(lastPushDate) {
 				reviewers = append(reviewers, userLogin)
 			} else {
 				log.Printf("assignReviewer: reviewer %v has already approved the pull request", userLogin)

--- a/plugins/aladino/actions/assignReviewer.go
+++ b/plugins/aladino/actions/assignReviewer.go
@@ -37,11 +37,6 @@ func assignReviewerCode(e aladino.Env, args []aladino.Value) error {
 	totalRequiredReviewers := args[1].(*aladino.IntValue).Val
 	policy := args[2].(*aladino.StringValue).Val
 	target := e.GetTarget().(*target.PullRequestTarget)
-	targetEntity := target.GetTargetEntity()
-	ctx := e.GetCtx()
-	owner := targetEntity.Owner
-	repo := targetEntity.Repo
-	prNum := targetEntity.Number
 
 	allowedPolicies := map[string]bool{"random": true, "round-robin": true, "reviewpad": true}
 	if _, ok := allowedPolicies[policy]; !ok {
@@ -76,7 +71,7 @@ func assignReviewerCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
-	lastPushDate, err := e.GetGithubClient().GetPullRequestLastPushDate(ctx, owner, repo, prNum)
+	lastPushDate, err := target.GetPullRequestLastPushDate()
 	if err != nil {
 		return err
 	}

--- a/plugins/aladino/actions/assignReviewer_test.go
+++ b/plugins/aladino/actions/assignReviewer_test.go
@@ -111,7 +111,29 @@ func TestAssignReviewer_WhenAuthorIsInListOfReviewers(t *testing.T) {
 				}),
 			),
 		},
-		nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			aladino.MustWrite(w, `
+			{
+				"data": {
+				  "repository": {
+					"pullRequest": {
+					  "timelineItems": {
+						"nodes": [
+						  {
+							"__typename": "PullRequestCommit",
+							"commit": {
+							  "pushedDate": "2022-11-11T13:36:05Z",
+							  "committedDate": "2022-11-11T13:36:05Z"
+							}
+						  }
+						]
+					  }
+					}
+				  }
+				}
+			  }
+			`)
+		},
 		aladino.MockBuiltIns(),
 		nil,
 	)
@@ -169,7 +191,29 @@ func TestAssignReviewer_WhenTotalRequiredReviewersIsMoreThanTotalAvailableReview
 				}),
 			),
 		},
-		nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			aladino.MustWrite(w, `
+			{
+				"data": {
+				  "repository": {
+					"pullRequest": {
+					  "timelineItems": {
+						"nodes": [
+						  {
+							"__typename": "PullRequestCommit",
+							"commit": {
+							  "pushedDate": "2022-11-11T13:36:05Z",
+							  "committedDate": "2022-11-11T13:36:05Z"
+							}
+						  }
+						]
+					  }
+					}
+				  }
+				}
+			  }
+			`)
+		},
 		aladino.MockBuiltIns(),
 		nil,
 	)
@@ -225,6 +269,7 @@ func TestAssignReviewer_WhenListReviewsRequestFails(t *testing.T) {
 }
 
 func TestAssignReviewer_WhenPullRequestAlreadyHasReviews(t *testing.T) {
+	time := time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC)
 	var gotReviewers []string
 	authorLogin := "john"
 	reviewerLogin := "mary"
@@ -253,7 +298,8 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasReviews(t *testing.T) {
 						User: &github.User{
 							Login: github.String(reviewerLogin),
 						},
-						State: github.String("COMMENTED"),
+						State:       github.String("COMMENTED"),
+						SubmittedAt: &time,
 					},
 				},
 			),
@@ -269,7 +315,29 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasReviews(t *testing.T) {
 				}),
 			),
 		},
-		nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			aladino.MustWrite(w, `
+			{
+				"data": {
+				  "repository": {
+					"pullRequest": {
+					  "timelineItems": {
+						"nodes": [
+						  {
+							"__typename": "PullRequestCommit",
+							"commit": {
+							  "pushedDate": "2022-01-11T01:01:01Z",
+							  "committedDate": "2022-01-11T01:01:01Z"
+							}
+						  }
+						]
+					  }
+					}
+				  }
+				}
+			  }
+			`)
+		},
 		aladino.MockBuiltIns(),
 		nil,
 	)
@@ -294,6 +362,7 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasApproval(t *testing.T) {
 	authorLogin := "john"
 	reviewerLogin := "mary"
 	wantReviewers := []string{}
+	time := time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC)
 
 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
 		User:               &github.User{Login: github.String(authorLogin)},
@@ -317,7 +386,8 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasApproval(t *testing.T) {
 						User: &github.User{
 							Login: github.String(reviewerLogin),
 						},
-						State: github.String("APPROVED"),
+						State:       github.String("APPROVED"),
+						SubmittedAt: &time,
 					},
 				},
 			),
@@ -333,7 +403,29 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasApproval(t *testing.T) {
 				}),
 			),
 		},
-		nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			aladino.MustWrite(w, `
+			{
+				"data": {
+				  "repository": {
+					"pullRequest": {
+					  "timelineItems": {
+						"nodes": [
+						  {
+							"__typename": "PullRequestCommit",
+							"commit": {
+							  "pushedDate": "2022-01-11T01:01:01Z",
+							  "committedDate": "2022-01-11T01:01:01Z"
+							}
+						  }
+						]
+					  }
+					}
+				  }
+				}
+			  }
+			`)
+		},
 		aladino.MockBuiltIns(),
 		nil,
 	)
@@ -392,7 +484,29 @@ func TestAssignReviewer_WhenPullRequestAlreadyHasRequestedReviewers(t *testing.T
 				}),
 			),
 		},
-		nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			aladino.MustWrite(w, `
+			{
+				"data": {
+				  "repository": {
+					"pullRequest": {
+					  "timelineItems": {
+						"nodes": [
+						  {
+							"__typename": "PullRequestCommit",
+							"commit": {
+							  "pushedDate": "2022-01-11T01:01:01Z",
+							  "committedDate": "2022-01-11T01:01:01Z"
+							}
+						  }
+						]
+					  }
+					}
+				  }
+				}
+			  }
+			`)
+		},
 		aladino.MockBuiltIns(),
 		nil,
 	)
@@ -449,7 +563,29 @@ func TestAssignReviewer_HasNoAvailableReviewers(t *testing.T) {
 				}),
 			),
 		},
-		nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			aladino.MustWrite(w, `
+			{
+				"data": {
+				  "repository": {
+					"pullRequest": {
+					  "timelineItems": {
+						"nodes": [
+						  {
+							"__typename": "PullRequestCommit",
+							"commit": {
+							  "pushedDate": "2022-01-11T01:01:01Z",
+							  "committedDate": "2022-01-11T01:01:01Z"
+							}
+						  }
+						]
+					  }
+					}
+				  }
+				}
+			  }
+			`)
+		},
 		aladino.MockBuiltIns(),
 		nil,
 	)
@@ -481,12 +617,14 @@ func TestAssignReviewer_WhenPullRequestAlreadyApproved(t *testing.T) {
 	})
 	reviewID := int64(1)
 	reviewState := "APPROVED"
+	time := time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC)
 	mockedReviews := []*github.PullRequestReview{
 		{
-			ID:    &reviewID,
-			State: &reviewState,
-			Body:  github.String(""),
-			User:  &github.User{Login: github.String(reviewerA)},
+			ID:          &reviewID,
+			State:       &reviewState,
+			Body:        github.String(""),
+			User:        &github.User{Login: github.String(reviewerA)},
+			SubmittedAt: &time,
 		},
 	}
 	mockedEnv := aladino.MockDefaultEnv(
@@ -510,7 +648,29 @@ func TestAssignReviewer_WhenPullRequestAlreadyApproved(t *testing.T) {
 				}),
 			),
 		},
-		nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			aladino.MustWrite(w, `
+			{
+				"data": {
+				  "repository": {
+					"pullRequest": {
+					  "timelineItems": {
+						"nodes": [
+						  {
+							"__typename": "PullRequestCommit",
+							"commit": {
+							  "pushedDate": "2022-01-11T01:01:01Z",
+							  "committedDate": "2022-01-11T01:01:01Z"
+							}
+						  }
+						]
+					  }
+					}
+				  }
+				}
+			  }
+			`)
+		},
 		aladino.MockBuiltIns(),
 		nil,
 	)
@@ -532,8 +692,9 @@ func TestAssignReviewer_WhenPullRequestAlreadyApproved(t *testing.T) {
 func TestAssignReviewer_ReRequest(t *testing.T) {
 	mockedReviewerLogin := "mary"
 	tests := map[string]struct {
-		shouldRequestReview bool
-		mockedReviews       func() []*github.PullRequestReview
+		shouldRequestReview  bool
+		mockedReviews        func() []*github.PullRequestReview
+		lastPushDateResponse string
 	}{
 		"when reviewer last review is approved": {
 			shouldRequestReview: false,
@@ -549,6 +710,26 @@ func TestAssignReviewer_ReRequest(t *testing.T) {
 					},
 				}
 			},
+			lastPushDateResponse: `
+			{
+				"data": {
+					"repository": {
+						"pullRequest": {
+						  "timelineItems": {
+							"nodes": [
+							  {
+								"__typename": "PullRequestCommit",
+								"commit": {
+								  "pushedDate": "2022-01-11T01:01:01Z",
+								  "committedDate": "2022-01-11T01:01:01Z"
+								}
+							  }
+							]
+						  }
+						}
+					}
+				}
+			}`,
 		},
 		"when reviewer last review is commented": {
 			shouldRequestReview: true,
@@ -564,6 +745,26 @@ func TestAssignReviewer_ReRequest(t *testing.T) {
 					},
 				}
 			},
+			lastPushDateResponse: `
+			{
+				"data": {
+					"repository": {
+						"pullRequest": {
+						  "timelineItems": {
+							"nodes": [
+							  {
+								"__typename": "PullRequestCommit",
+								"commit": {
+								  "pushedDate": "2022-01-11T01:01:01Z",
+								  "committedDate": "2022-01-11T01:01:01Z"
+								}
+							  }
+							]
+						  }
+						}
+					}
+				}
+			}`,
 		},
 		"when reviewer last review is changes requested": {
 			shouldRequestReview: true,
@@ -579,6 +780,26 @@ func TestAssignReviewer_ReRequest(t *testing.T) {
 					},
 				}
 			},
+			lastPushDateResponse: `
+			{
+				"data": {
+					"repository": {
+						"pullRequest": {
+						  "timelineItems": {
+							"nodes": [
+							  {
+								"__typename": "PullRequestCommit",
+								"commit": {
+								  "pushedDate": "2022-01-11T01:01:01Z",
+								  "committedDate": "2022-01-11T01:01:01Z"
+								}
+							  }
+							]
+						  }
+						}
+					}
+				}
+			}`,
 		},
 		"when reviewer has approved and then requested changes": {
 			shouldRequestReview: true,
@@ -602,6 +823,26 @@ func TestAssignReviewer_ReRequest(t *testing.T) {
 					},
 				}
 			},
+			lastPushDateResponse: `
+			{
+				"data": {
+					"repository": {
+						"pullRequest": {
+						  "timelineItems": {
+							"nodes": [
+							  {
+								"__typename": "PullRequestCommit",
+								"commit": {
+								  "pushedDate": "2022-01-11T01:01:01Z",
+								  "committedDate": "2022-01-11T01:01:01Z"
+								}
+							  }
+							]
+						  }
+						}
+					}
+				}
+			}`,
 		},
 		"when reviewer has requested changes and then approved": {
 			shouldRequestReview: false,
@@ -625,6 +866,96 @@ func TestAssignReviewer_ReRequest(t *testing.T) {
 					},
 				}
 			},
+			lastPushDateResponse: `
+			{
+				"data": {
+					"repository": {
+						"pullRequest": {
+						  "timelineItems": {
+							"nodes": [
+							  {
+								"__typename": "PullRequestCommit",
+								"commit": {
+								  "pushedDate": "2022-01-11T01:01:01Z",
+								  "committedDate": "2022-01-11T01:01:01Z"
+								}
+							  }
+							]
+						  }
+						}
+					}
+				}
+			}`,
+		},
+		"when reviewer has requested changes and no commits have been pushed after": {
+			shouldRequestReview: false,
+			mockedReviews: func() []*github.PullRequestReview {
+				timeRequestedChanges := time.Date(2022, 2, 1, 1, 1, 1, 1, time.UTC)
+				return []*github.PullRequestReview{
+					{
+						ID:          github.Int64(1),
+						State:       github.String("CHANGES_REQUESTED"),
+						Body:        github.String(""),
+						SubmittedAt: &timeRequestedChanges,
+						User:        &github.User{Login: github.String(mockedReviewerLogin)},
+					},
+				}
+			},
+			lastPushDateResponse: `
+			{
+				"data": {
+					"repository": {
+						"pullRequest": {
+						  "timelineItems": {
+							"nodes": [
+							  {
+								"__typename": "PullRequestCommit",
+								"commit": {
+								  "pushedDate": "2022-01-11T01:01:01Z",
+								  "committedDate": "2022-01-11T01:01:01Z"
+								}
+							  }
+							]
+						  }
+						}
+					}
+				}
+			}`,
+		},
+		"when reviewer has requested changes and some commits have been pushed after": {
+			shouldRequestReview: true,
+			mockedReviews: func() []*github.PullRequestReview {
+				timeRequestedChanges := time.Date(2022, 2, 1, 1, 1, 1, 1, time.UTC)
+				return []*github.PullRequestReview{
+					{
+						ID:          github.Int64(1),
+						State:       github.String("CHANGES_REQUESTED"),
+						Body:        github.String(""),
+						SubmittedAt: &timeRequestedChanges,
+						User:        &github.User{Login: github.String(mockedReviewerLogin)},
+					},
+				}
+			},
+			lastPushDateResponse: `
+			{
+				"data": {
+					"repository": {
+						"pullRequest": {
+						  "timelineItems": {
+							"nodes": [
+							  {
+								"__typename": "PullRequestCommit",
+								"commit": {
+								  "pushedDate": "2022-03-11T01:01:01Z",
+								  "committedDate": "2022-03-11T01:01:01Z"
+								}
+							  }
+							]
+						  }
+						}
+					}
+				}
+			}`,
 		},
 	}
 
@@ -660,7 +991,9 @@ func TestAssignReviewer_ReRequest(t *testing.T) {
 						}),
 					),
 				},
-				nil,
+				func(w http.ResponseWriter, r *http.Request) {
+					aladino.MustWrite(w, test.lastPushDateResponse)
+				},
 				aladino.MockBuiltIns(),
 				nil,
 			)
@@ -771,7 +1104,29 @@ func TestAssignReviewer_WithPolicy(t *testing.T) {
 					},
 					test.clientOptions...,
 				),
-				nil,
+				func(w http.ResponseWriter, r *http.Request) {
+					aladino.MustWrite(w, `
+					{
+						"data": {
+						  "repository": {
+							"pullRequest": {
+							  "timelineItems": {
+								"nodes": [
+								  {
+									"__typename": "PullRequestCommit",
+									"commit": {
+									  "pushedDate": "2022-01-11T01:01:01Z",
+									  "committedDate": "2022-01-11T01:01:01Z"
+									}
+								  }
+								]
+							  }
+							}
+						  }
+						}
+					  }
+					`)
+				},
 				aladino.MockBuiltIns(),
 				nil,
 			)
@@ -845,7 +1200,29 @@ func TestAssignReviewer_WhenPullRequestAlreadyApprovedBy2Reviewers(t *testing.T)
 				}),
 			),
 		},
-		nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			aladino.MustWrite(w, `
+			{
+				"data": {
+				  "repository": {
+					"pullRequest": {
+					  "timelineItems": {
+						"nodes": [
+						  {
+							"__typename": "PullRequestCommit",
+							"commit": {
+							  "pushedDate": "2022-01-11T01:01:01Z",
+							  "committedDate": "2022-01-11T01:01:01Z"
+							}
+						  }
+						]
+					  }
+					}
+				  }
+				}
+			  }
+			`)
+		},
 		aladino.MockBuiltIns(),
 		nil,
 	)


### PR DESCRIPTION
## Description
This PR updates the `$assignReviewer` built-in action so that it checks the last pushed date before re-requesting a review
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #415 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit tests and manual tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
