### PR TITLE
fix: ignore extra args to sprintf built-in function

### DIFF
--- a/plugins/aladino/functions/sprintf.go
+++ b/plugins/aladino/functions/sprintf.go
@@ -36,9 +36,9 @@ func sprintfCode(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
 	}
 
 	for _, val := range vals {
-		switch val.(type) {
+		switch v := val.(type) {
 		case *aladino.StringValue:
-			clearVals = append(clearVals, val.(*aladino.StringValue).Val)
+			clearVals = append(clearVals, v.Val)
 		}
 	}
 

--- a/plugins/aladino/functions/sprintf.go
+++ b/plugins/aladino/functions/sprintf.go
@@ -6,9 +6,14 @@ package plugins_aladino_functions
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/reviewpad/reviewpad/v3/handler"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+)
+
+var (
+	verbsRegExp = regexp.MustCompile(`%(\#|\+|\-| |0)?(\[\d+\])?(([1-9])\.([1-9])|([1-9])|([1-9])\.|\.([1-9]))?(\w{1,9})`)
 )
 
 func Sprintf() *aladino.BuiltInFunction {
@@ -23,6 +28,12 @@ func sprintfCode(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
 	var clearVals []interface{}
 	format := args[0].(*aladino.StringValue).Val
 	vals := args[1].(*aladino.ArrayValue).Vals
+
+	verbs := verbsRegExp.FindAllString(format, -1)
+
+	if len(vals) > len(verbs) {
+		vals = vals[0:len(verbs)]
+	}
 
 	for _, val := range vals {
 		switch val.(type) {

--- a/plugins/aladino/functions/sprintf.go
+++ b/plugins/aladino/functions/sprintf.go
@@ -13,6 +13,7 @@ import (
 )
 
 var (
+	// this regexp matches the golang formatting verbs such as %v, %s...
 	verbsRegExp = regexp.MustCompile(`%(\#|\+|\-| |0)?(\[\d+\])?(([1-9])\.([1-9])|([1-9])|([1-9])\.|\.([1-9]))?(\w{1,9})`)
 )
 


### PR DESCRIPTION
## Description
This PR improves the `$sprintf` built-in by ignoring extra args
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #450 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit & Manual tests.
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
