### PR TITLE
feat: state built-in for issues and pull requests

### DIFF
--- a/codehost/github/target/issue_target.go
+++ b/codehost/github/target/issue_target.go
@@ -134,6 +134,10 @@ func (t *IssueTarget) GetDescription() (string, error) {
 	return t.issue.GetBody(), nil
 }
 
+func (t *IssueTarget) GetState() string {
+	return t.issue.GetState()
+}
+
 func (t *IssueTarget) GetTitle() string {
 	return t.issue.GetTitle()
 }

--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -370,6 +370,10 @@ func (t *PullRequestTarget) IsDraft() (bool, error) {
 	return t.PullRequest.GetDraft(), nil
 }
 
+func (t *PullRequestTarget) GetState() string {
+	return t.PullRequest.GetState()
+}
+
 func (t *PullRequestTarget) GetTitle() string {
 	return t.PullRequest.GetTitle()
 }

--- a/codehost/target.go
+++ b/codehost/target.go
@@ -32,6 +32,7 @@ type Target interface {
 	GetNodeID() string
 	GetProjectByName(name string) (*Project, error)
 	GetProjectFieldsByProjectNumber(projectNumber uint64) ([]*ProjectField, error)
+	GetState() string
 	GetTargetEntity() *handler.TargetEntity
 	GetTitle() string
 	RemoveLabel(labelName string) error

--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -212,6 +212,10 @@ func GetDefaultMockPullRequestDetailsWith(pr *github.PullRequest) *github.PullRe
 		defaultPullRequest.ClosedAt = pr.ClosedAt
 	}
 
+	if pr.State != nil {
+		defaultPullRequest.State = pr.State
+	}
+
 	return defaultPullRequest
 }
 

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -85,6 +85,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"reviewers":             functions.Reviewers(),
 			"reviewerStatus":        functions.ReviewerStatus(),
 			"size":                  functions.Size(),
+			"state":                 functions.State(),
 			"title":                 functions.Title(),
 			"workflowStatus":        functions.WorkflowStatus(),
 			// Organization

--- a/plugins/aladino/functions/state.go
+++ b/plugins/aladino/functions/state.go
@@ -1,0 +1,22 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+)
+
+func State() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{}, aladino.BuildStringType()),
+		Code:           stateCode,
+		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest, handler.Issue},
+	}
+}
+
+func stateCode(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
+	return aladino.BuildStringValue(e.GetTarget().GetState()), nil
+}

--- a/plugins/aladino/functions/state_test.go
+++ b/plugins/aladino/functions/state_test.go
@@ -1,0 +1,47 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v48/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var state = plugins_aladino.PluginBuiltIns().Functions["state"].Code
+
+func TestStatus(t *testing.T) {
+	prState := "open"
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
+		State: github.String(prState),
+	})
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Write(mock.MustMarshal(mockedPullRequest))
+				}),
+			),
+		},
+		nil,
+		aladino.MockBuiltIns(),
+		nil,
+	)
+
+	wantState := aladino.BuildStringValue(prState)
+
+	args := []aladino.Value{}
+	gotState, err := state(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantState, gotState)
+}


### PR DESCRIPTION
## Description

This pull request introduces a new built-in $state() that retrieves the state of a pull request.

According to the GitHub API, this can be either "open" or "closed".

## Related issue

Closes #444

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Locally tested.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
- [x] Show: this pull request can be auto-merged and code review should be done post merge 
<!-- - [ ] Ask: this pull request requires a code review before merge -->
