### PR TITLE
feat: add isLinkedToProject built-in

### DIFF
--- a/codehost/github/issues_test.go
+++ b/codehost/github/issues_test.go
@@ -1,0 +1,171 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file
+
+package github_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	host "github.com/reviewpad/reviewpad/v3/codehost/github"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	"github.com/reviewpad/reviewpad/v3/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLinkedProjects_WhenRequestFails(t *testing.T) {
+	mockedGithubClient := aladino.MockDefaultGithubClient(
+		nil,
+		func(w http.ResponseWriter, req *http.Request) {
+			http.Error(w, "404 Not Found", http.StatusNotFound)
+		},
+	)
+
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetails()
+
+	mockOwner := host.GetPullRequestBaseOwnerName(mockedPullRequest)
+	mockRepo := host.GetPullRequestBaseRepoName(mockedPullRequest)
+	mockIssuerNumber := 10
+
+	projects, err := mockedGithubClient.GetLinkedProjects(context.Background(), mockOwner, mockRepo, mockIssuerNumber, 3)
+
+	assert.NotNil(t, err)
+
+	assert.Nil(t, projects)
+}
+
+func TestGetLinkedProjects_WhenProjectItemsNotFound(t *testing.T) {
+	mockedGetLinkedProjectsQuery := `{
+        "query": "query($issueNumber:Int! $projectItemsCursor:String! $repositoryName:String! $repositoryOwner:String!) {
+            repository(owner: $repositoryOwner, name: $repositoryName) {
+                issue(number: $issueNumber) {
+                    projectItems(first: 10, after: $projectItemsCursor) {
+                        nodes {
+                            project {id,number,title}
+                        },
+                        pageInfo {endCursor,hasNextPage}
+                    }
+                }
+            }
+        }",
+        "variables": {
+            "issueNumber":10,
+            "projectItemsCursor": "",
+            "repositoryName":"default-mock-repo",
+            "repositoryOwner":"foobar"
+        }
+    }`
+	mockedGetProjectByNameQueryBody := `{
+        "data": {
+            "repository":{
+                "issue":{
+                }
+            }
+        }
+    }`
+	mockedGithubClient := aladino.MockDefaultGithubClient(
+		nil,
+		func(res http.ResponseWriter, req *http.Request) {
+			query := utils.MinifyQuery(aladino.MustRead(req.Body))
+			mockedQuery := utils.MinifyQuery(mockedGetLinkedProjectsQuery)
+			switch query {
+			case mockedQuery:
+				aladino.MustWrite(
+					res,
+					mockedGetProjectByNameQueryBody,
+				)
+			}
+		},
+	)
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetails()
+
+	mockOwner := host.GetPullRequestBaseOwnerName(mockedPullRequest)
+	mockRepo := host.GetPullRequestBaseRepoName(mockedPullRequest)
+	mockIssuerNumber := 10
+
+	projects, err := mockedGithubClient.GetLinkedProjects(context.Background(), mockOwner, mockRepo, mockIssuerNumber, 3)
+
+	assert.NotNil(t, err)
+
+	assert.Nil(t, projects)
+}
+
+func TestGetLinkedProjects_WhenProjectFound(t *testing.T) {
+	mockedGetLinkedProjectsQuery := `{
+        "query": "query($issueNumber:Int! $projectItemsCursor:String! $repositoryName:String! $repositoryOwner:String!) {
+            repository(owner: $repositoryOwner, name: $repositoryName) {
+                issue(number: $issueNumber) {
+                    projectItems(first: 10, after: $projectItemsCursor) {
+                        nodes {
+                            project {id,number,title}
+                        },
+                        pageInfo {endCursor,hasNextPage}
+                    }
+                }
+            }
+        }",
+        "variables": {
+            "issueNumber":10,
+            "projectItemsCursor": "",
+            "repositoryName":"default-mock-repo",
+            "repositoryOwner":"foobar"
+        }
+    }`
+	mockedGetProjectByNameQueryBody := `{
+        "data": {
+            "repository":{
+                "issue":{
+                    "projectItems":{
+                        "nodes":[
+                            {
+                                "project":{
+                                    "id": "1",
+                                    "number": 1,
+                                    "title": "Project 1"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }`
+	mockedGithubClient := aladino.MockDefaultGithubClient(
+		nil,
+		func(res http.ResponseWriter, req *http.Request) {
+			query := utils.MinifyQuery(aladino.MustRead(req.Body))
+			mockedQuery := utils.MinifyQuery(mockedGetLinkedProjectsQuery)
+			switch query {
+			case mockedQuery:
+				aladino.MustWrite(
+					res,
+					mockedGetProjectByNameQueryBody,
+				)
+			}
+		},
+	)
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetails()
+
+	mockOwner := host.GetPullRequestBaseOwnerName(mockedPullRequest)
+	mockRepo := host.GetPullRequestBaseRepoName(mockedPullRequest)
+	mockIssuerNumber := 10
+
+	gotProjects, err := mockedGithubClient.GetLinkedProjects(context.Background(), mockOwner, mockRepo, mockIssuerNumber, 3)
+
+	wantProjects := []host.GQLProjectV2Item{
+		{
+			Project: host.ProjectV2{
+				ID:     "1",
+				Number: 1,
+				Title:  "Project 1",
+			},
+		},
+	}
+
+	assert.Nil(t, err)
+
+	assert.NotNil(t, gotProjects)
+	assert.Equal(t, wantProjects, gotProjects)
+}

--- a/codehost/github/repo.go
+++ b/codehost/github/repo.go
@@ -147,9 +147,9 @@ func RebaseOnto(repo *git.Repository, branchName string, rebaseOptions *git.Reba
 	// Iterate over rebase operations based on operation count
 	opCount := int(rebase.OperationCount())
 	for op := 0; op < opCount; op++ {
-		operation, err := rebase.Next()
-		if err != nil {
-			return err
+		operation, errRebaseNext := rebase.Next()
+		if errRebaseNext != nil {
+			return errRebaseNext
 		}
 
 		// Verify that operation index is correct
@@ -167,9 +167,9 @@ func RebaseOnto(repo *git.Repository, branchName string, rebaseOptions *git.Reba
 		}
 
 		// Get current rebase operation created commit
-		commit, err := repo.LookupCommit(operation.Id)
-		if err != nil {
-			return err
+		commit, errCommitLookup := repo.LookupCommit(operation.Id)
+		if errCommitLookup != nil {
+			return errCommitLookup
 		}
 		defer commit.Free()
 

--- a/codehost/github/target/common_target.go
+++ b/codehost/github/target/common_target.go
@@ -134,6 +134,28 @@ func (t *CommonTarget) GetTargetEntity() *handler.TargetEntity {
 	return t.targetEntity
 }
 
+func (t *CommonTarget) IsLinkedToProject(name string) (bool, error) {
+	ctx := t.ctx
+	targetEntity := t.targetEntity
+	owner := targetEntity.Owner
+	repo := targetEntity.Repo
+	number := targetEntity.Number
+	totalRetries := 2
+
+	projects, err := t.githubClient.GetLinkedProjects(ctx, owner, repo, number, totalRetries)
+	if err != nil {
+		return false, err
+	}
+
+	for _, project := range projects {
+		if project.Project.Title == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func (t *CommonTarget) RemoveLabel(labelName string) error {
 	ctx := t.ctx
 	targetEntity := t.targetEntity

--- a/codehost/github/target/common_target.go
+++ b/codehost/github/target/common_target.go
@@ -134,7 +134,7 @@ func (t *CommonTarget) GetTargetEntity() *handler.TargetEntity {
 	return t.targetEntity
 }
 
-func (t *CommonTarget) IsLinkedToProject(name string) (bool, error) {
+func (t *CommonTarget) IsLinkedToProject(title string) (bool, error) {
 	ctx := t.ctx
 	targetEntity := t.targetEntity
 	owner := targetEntity.Owner
@@ -148,7 +148,7 @@ func (t *CommonTarget) IsLinkedToProject(name string) (bool, error) {
 	}
 
 	for _, project := range projects {
-		if project.Project.Title == name {
+		if project.Project.Title == title {
 			return true, nil
 		}
 	}

--- a/codehost/github/target/issue_target.go
+++ b/codehost/github/target/issue_target.go
@@ -58,8 +58,8 @@ func (t *IssueTarget) Close(comment string, stateReason string) error {
 	}
 
 	if comment != "" {
-		if err := t.Comment(comment); err != nil {
-			return err
+		if errComment := t.Comment(comment); errComment != nil {
+			return errComment
 		}
 	}
 

--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -87,8 +87,8 @@ func (t *PullRequestTarget) Close(comment string, _ string) error {
 	}
 
 	if comment != "" {
-		if err := t.Comment(comment); err != nil {
-			return err
+		if errComment := t.Comment(comment); errComment != nil {
+			return errComment
 		}
 	}
 

--- a/codehost/target.go
+++ b/codehost/target.go
@@ -35,7 +35,7 @@ type Target interface {
 	GetState() string
 	GetTargetEntity() *handler.TargetEntity
 	GetTitle() string
-	IsLinkedToProject(name string) (bool, error)
+	IsLinkedToProject(title string) (bool, error)
 	RemoveLabel(labelName string) error
 }
 

--- a/codehost/target.go
+++ b/codehost/target.go
@@ -89,6 +89,7 @@ type ProjectField struct {
 		Name string
 	}
 }
+
 type Commit struct {
 	Message      string
 	ParentsCount int

--- a/codehost/target.go
+++ b/codehost/target.go
@@ -35,6 +35,7 @@ type Target interface {
 	GetState() string
 	GetTargetEntity() *handler.TargetEntity
 	GetTitle() string
+	IsLinkedToProject(name string) (bool, error)
 	RemoveLabel(labelName string) error
 }
 

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -89,10 +89,10 @@ func Eval(file *ReviewpadFile, env *Env) (*Program, error) {
 			}
 
 			if ghLabel != nil {
-				labelHasUpdates, err := checkLabelHasUpdates(env, &label, ghLabel)
-				if err != nil {
-					CollectError(env, err)
-					return nil, err
+				labelHasUpdates, errCheckUpdates := checkLabelHasUpdates(env, &label, ghLabel)
+				if errCheckUpdates != nil {
+					CollectError(env, errCheckUpdates)
+					return nil, errCheckUpdates
 				}
 
 				if labelHasUpdates {
@@ -271,10 +271,10 @@ func processCommand(env *Env, comment string) (string, error) {
 	if err != nil {
 		comment := fmt.Sprintf("%s\n```\n🚫 error\n\n%s\n```", *env.EventData.Comment.Body, err.Error())
 
-		if _, _, err := env.GithubClient.EditComment(env.Ctx, env.TargetEntity.Owner, env.TargetEntity.Repo, *env.EventData.Comment.ID, &github.IssueComment{
+		if _, _, errEditComment := env.GithubClient.EditComment(env.Ctx, env.TargetEntity.Owner, env.TargetEntity.Repo, *env.EventData.Comment.ID, &github.IssueComment{
 			Body: github.String(comment),
-		}); err != nil {
-			return "", err
+		}); errEditComment != nil {
+			return "", errEditComment
 		}
 
 		return "", err

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -79,6 +79,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"haveAllChecksRunCompleted": functions.HaveAllChecksRunCompleted(),
 			"head":                      functions.Head(),
 			"isDraft":                   functions.IsDraft(),
+			"isLinkedToProject":         functions.IsLinkedToProject(),
 			"isWaitingForReview":        functions.IsWaitingForReview(),
 			"labels":                    functions.Labels(),
 			"lastEventAt":               functions.LastEventAt(),

--- a/plugins/aladino/functions/isLinkedToProject.go
+++ b/plugins/aladino/functions/isLinkedToProject.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+)
+
+func IsLinkedToProject() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType()}, aladino.BuildBoolType()),
+		Code:           isLinkedToProject,
+		SupportedKinds: []handler.TargetEntityKind{handler.Issue, handler.PullRequest},
+	}
+}
+
+func isLinkedToProject(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
+	projectTitle := args[0].(*aladino.StringValue).Val
+
+	result, err := e.GetTarget().IsLinkedToProject(projectTitle)
+	if err != nil {
+		return nil, err
+	}
+
+	return aladino.BuildBoolValue(result), nil
+}

--- a/plugins/aladino/functions/isLinkedToProject_test.go
+++ b/plugins/aladino/functions/isLinkedToProject_test.go
@@ -1,0 +1,117 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var isLinkedToProject = plugins_aladino.PluginBuiltIns().Functions["isLinkedToProject"].Code
+
+func TestIsLinkedToProject(t *testing.T) {
+	tests := map[string]struct {
+		args           []aladino.Value
+		wantResult     aladino.Value
+		wantErr        error
+		graphqlHandler func(http.ResponseWriter, *http.Request)
+	}{
+		"when graphql query errors": {
+			args:       []aladino.Value{aladino.BuildStringValue("project title")},
+			wantResult: (aladino.Value)(nil),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: errors.New(`non-200 OK status code: 500 Internal Server Error body: ""`),
+		},
+		"when graphql query errors with project items not found": {
+			args:       []aladino.Value{aladino.BuildStringValue("project title")},
+			wantResult: (aladino.Value)(nil),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				aladino.MustWrite(w, `{
+					"data": {
+						"repository":{
+							"issue":{
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: errors.New(`project items not found`),
+		},
+		"when linked project is false": {
+			args:       []aladino.Value{aladino.BuildStringValue("project title")},
+			wantResult: aladino.BuildBoolValue(false),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				aladino.MustWrite(w, `{
+					"data": {
+						"repository":{
+							"issue":{
+								"projectItems":{
+									"nodes":[
+										{
+											"project":{
+												"id": "1",
+												"number": 1,
+												"title": "Project 1"
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
+			},
+		},
+		"when linked project is true": {
+			args:       []aladino.Value{aladino.BuildStringValue("project title")},
+			wantResult: aladino.BuildBoolValue(true),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				aladino.MustWrite(w, `{
+					"data": {
+						"repository":{
+							"issue":{
+								"projectItems":{
+									"nodes":[
+										{
+											"project":{
+												"id": "1",
+												"number": 1,
+												"title": "project"
+											},
+											"project":{
+												"id": "2",
+												"number": 2,
+												"title": "project title"
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := aladino.MockDefaultEnv(t, []mock.MockBackendOption{}, test.graphqlHandler, aladino.MockBuiltIns(), nil)
+
+			res, err := isLinkedToProject(env, test.args)
+
+			assert.Equal(t, test.wantResult, res)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This pull request introduces the built-in $isLinkedToProject that receives a project name and returns true/false depending on whether the issue or pull request is already associated with the project.

## Related issue

Closes #483 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Unit tests for GetLinkedProjects GraphQL.

This built-in was functionally tested with success in the GitHub action with branch: https://github.com/reviewpad/action/tree/dev/add-to-project-usecase

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [ ] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge 
