### PR TITLE
feat: provide command error feedback as comment

### DIFF
--- a/engine/exec.go
+++ b/engine/exec.go
@@ -269,12 +269,12 @@ func processCommand(env *Env, comment string) (string, error) {
 
 	err = root.Execute()
 	if err != nil {
-		comment := fmt.Sprintf("%s\n```\n🚫 error\n\n%s\n```", *env.EventData.Comment.Body, err.Error())
+		comment := fmt.Sprintf("```\n🚫 error\n\n%s```", err.Error())
 
-		if _, _, errEditComment := env.GithubClient.EditComment(env.Ctx, env.TargetEntity.Owner, env.TargetEntity.Repo, *env.EventData.Comment.ID, &github.IssueComment{
+		if _, _, errCreateComment := env.GithubClient.CreateComment(env.Ctx, env.TargetEntity.Owner, env.TargetEntity.Repo, env.TargetEntity.Number, &github.IssueComment{
 			Body: github.String(comment),
-		}); errEditComment != nil {
-			return "", errEditComment
+		}); errCreateComment != nil {
+			return "", errCreateComment
 		}
 
 		return "", err

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -255,7 +255,7 @@ func TestEval(t *testing.T) {
 			},
 			clientOptions: []mock.MockBackendOption{
 				mock.WithRequestMatch(
-					mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
+					mock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
 					&github.IssueComment{},
 				),
 			},
@@ -284,7 +284,7 @@ func TestEval(t *testing.T) {
 			},
 			clientOptions: []mock.MockBackendOption{
 				mock.WithRequestMatch(
-					mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
+					mock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
 					&github.IssueComment{},
 				),
 			},

--- a/utils/pr.go
+++ b/utils/pr.go
@@ -17,6 +17,7 @@ func IsPullRequestReadyForReportMetrics(eventData *handler.EventData) bool {
 func IsReviewpadCommand(eventData *handler.EventData) bool {
 	return eventData != nil &&
 		eventData.EventName == "issue_comment" &&
+		eventData.EventAction == "created" &&
 		eventData.Comment.Body != nil &&
 		strings.HasPrefix(*eventData.Comment.Body, "/reviewpad")
 }

--- a/utils/pr_test.go
+++ b/utils/pr_test.go
@@ -83,10 +83,21 @@ func TestIsReviewPadCommand(t *testing.T) {
 				},
 			},
 		},
+		"when event action is not created": {
+			wantVal: false,
+			eventData: &handler.EventData{
+				EventName:   "issue_comment",
+				EventAction: "updated",
+				Comment: &github.IssueComment{
+					Body: github.String("some comment"),
+				},
+			},
+		},
 		"when event name is issue comment and body has /reviewpad prefix": {
 			wantVal: true,
 			eventData: &handler.EventData{
-				EventName: "issue_comment",
+				EventName:   "issue_comment",
+				EventAction: "created",
 				Comment: &github.IssueComment{
 					Body: github.String("/reviewpad"),
 				},


### PR DESCRIPTION
## Description
Currently, when command errors such as syntax or invalid flag errors happen, we edit the user's comment to provide feedback, this PR modifies reviewpad so instead of editing the comment, feedback is provided as a new comment.
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #472 
Closes #473 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit & Manual Tests.
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
