### PR TITLE
feat: merge built-in is only enabled on open and non-draft prs

### DIFF
--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -6,6 +6,7 @@ package plugins_aladino_actions
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/reviewpad/reviewpad/v3/codehost/github/target"
 	"github.com/reviewpad/reviewpad/v3/handler"
@@ -22,6 +23,11 @@ func Merge() *aladino.BuiltInAction {
 
 func mergeCode(e aladino.Env, args []aladino.Value) error {
 	t := e.GetTarget().(*target.PullRequestTarget)
+
+	if t.PullRequest.GetState() != "open" || t.PullRequest.GetDraft() {
+		log.Println("merge: skipping action because pull request is not open or is a draft")
+		return nil
+	}
 
 	mergeMethod, err := parseMergeMethod(args)
 	if err != nil {

--- a/plugins/aladino/actions/merge_test.go
+++ b/plugins/aladino/actions/merge_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/go-github/v48/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
 	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
@@ -23,7 +24,23 @@ type MergeRequestPostBody struct {
 }
 
 func TestMerge_WhenMergeMethodIsUnsupported(t *testing.T) {
-	mockedEnv := aladino.MockDefaultEnv(t, nil, nil, aladino.MockBuiltIns(), nil)
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
+		State: github.String("open"),
+	})
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					utils.MustWriteBytes(w, mock.MustMarshal(mockedPullRequest))
+				}),
+			),
+		},
+		nil,
+		aladino.MockBuiltIns(),
+		nil,
+	)
 
 	args := []aladino.Value{aladino.BuildStringValue("INVALID")}
 	err := merge(mockedEnv, args)
@@ -34,6 +51,12 @@ func TestMerge_WhenMergeMethodIsUnsupported(t *testing.T) {
 func TestMerge_WhenNoMergeMethodIsProvided(t *testing.T) {
 	wantMergeMethod := "merge"
 	var gotMergeMethod string
+
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
+		State:  github.String("open"),
+		Merged: github.Bool(false),
+	})
+
 	mockedEnv := aladino.MockDefaultEnv(
 		t,
 		[]mock.MockBackendOption{
@@ -46,6 +69,12 @@ func TestMerge_WhenNoMergeMethodIsProvided(t *testing.T) {
 					utils.MustUnmarshal(rawBody, &body)
 
 					gotMergeMethod = body.MergeMethod
+				}),
+			),
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					utils.MustWriteBytes(w, mock.MustMarshal(mockedPullRequest))
 				}),
 			),
 		},
@@ -64,6 +93,12 @@ func TestMerge_WhenNoMergeMethodIsProvided(t *testing.T) {
 func TestMerge_WhenMergeMethodIsProvided(t *testing.T) {
 	wantMergeMethod := "rebase"
 	var gotMergeMethod string
+
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
+		State:  github.String("open"),
+		Merged: github.Bool(false),
+	})
+
 	mockedEnv := aladino.MockDefaultEnv(
 		t,
 		[]mock.MockBackendOption{
@@ -78,6 +113,12 @@ func TestMerge_WhenMergeMethodIsProvided(t *testing.T) {
 					gotMergeMethod = body.MergeMethod
 				}),
 			),
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					utils.MustWriteBytes(w, mock.MustMarshal(mockedPullRequest))
+				}),
+			),
 		},
 		nil,
 		aladino.MockBuiltIns(),
@@ -89,4 +130,59 @@ func TestMerge_WhenMergeMethodIsProvided(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, wantMergeMethod, gotMergeMethod)
+}
+
+func TestMerge_WhenMergeIsOnDraftPullRequest(t *testing.T) {
+	wantMergeMethod := "rebase"
+
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
+		State: github.String("open"),
+		Draft: github.Bool(true),
+	})
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					utils.MustWriteBytes(w, mock.MustMarshal(mockedPullRequest))
+				}),
+			),
+		},
+		nil,
+		aladino.MockBuiltIns(),
+		nil,
+	)
+
+	args := []aladino.Value{aladino.BuildStringValue(wantMergeMethod)}
+	err := merge(mockedEnv, args)
+
+	assert.Nil(t, err)
+}
+
+func TestMerge_WhenMergeIsClosedPullRequest(t *testing.T) {
+	wantMergeMethod := "rebase"
+
+	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
+		State: github.String("closed"),
+	})
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsByOwnerByRepoByPullNumber,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					utils.MustWriteBytes(w, mock.MustMarshal(mockedPullRequest))
+				}),
+			),
+		},
+		nil,
+		aladino.MockBuiltIns(),
+		nil,
+	)
+
+	args := []aladino.Value{aladino.BuildStringValue(wantMergeMethod)}
+	err := merge(mockedEnv, args)
+
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
## Description

This pull request refines the $merge() built-in to only be enabled on open and non-draft pull requests.

## Related issue

Closes #525

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Unit tests.

Functional validation with canary version of GitHub Action.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge 
