### PR TITLE
fix: extends for all properties of reviewpad file

### DIFF
--- a/engine/lang.go
+++ b/engine/lang.go
@@ -196,7 +196,7 @@ type ReviewpadFile struct {
 	Version      string              `yaml:"api-version"`
 	Edition      string              `yaml:"edition"`
 	Mode         string              `yaml:"mode"`
-	IgnoreErrors bool                `yaml:"ignore-errors"`
+	IgnoreErrors *bool               `yaml:"ignore-errors"`
 	Imports      []PadImport         `yaml:"imports"`
 	Extends      []string            `yaml:"extends"`
 	Groups       []PadGroup          `yaml:"groups"`
@@ -358,6 +358,22 @@ func (r *ReviewpadFile) appendPipelines(o *ReviewpadFile) {
 }
 
 func (r *ReviewpadFile) extend(o *ReviewpadFile) {
+	if o.Version != "" {
+		r.Version = o.Version
+	}
+
+	if o.Edition != "" {
+		r.Edition = o.Edition
+	}
+
+	if o.Mode != "" {
+		r.Mode = o.Mode
+	}
+
+	if o.IgnoreErrors != nil {
+		r.IgnoreErrors = o.IgnoreErrors
+	}
+
 	r.appendLabels(o)
 	r.appendGroups(o)
 	r.appendRules(o)

--- a/engine/lang_internal_test.go
+++ b/engine/lang_internal_test.go
@@ -15,7 +15,7 @@ var mockedReviewpadFile = &ReviewpadFile{
 	Version:      "reviewpad.com/v3.x",
 	Edition:      "professional",
 	Mode:         "silent",
-	IgnoreErrors: false,
+	IgnoreErrors: nil,
 	Imports: []PadImport{
 		{Url: "https://foo.bar/draft-rule.yml"},
 	},
@@ -764,7 +764,8 @@ func TestEquals_WhenReviewpadFilesHaveDiffIgnoreErrors(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	otherReviewpadFile.IgnoreErrors = true
+	ignoreErrors := true
+	otherReviewpadFile.IgnoreErrors = &ignoreErrors
 
 	assert.False(t, mockedReviewpadFile.equals(otherReviewpadFile))
 }

--- a/engine/testdata/loader/process/reviewpad_with_extends_after_processing.yml
+++ b/engine/testdata/loader/process/reviewpad_with_extends_after_processing.yml
@@ -4,6 +4,12 @@
 
 api-version: reviewpad.com/v3.x
 
+mode: verbose
+
+edition: enterprise
+
+ignore-errors: true
+
 labels:
   small:
     color: '#aa12ab'

--- a/engine/testdata/loader/reviewpad_with_no_extends_a.yml
+++ b/engine/testdata/loader/reviewpad_with_no_extends_a.yml
@@ -4,6 +4,8 @@
 
 api-version: reviewpad.com/v3.x
 
+mode: verbose
+
 labels:
   small:
     color: '#aaf1aa'

--- a/engine/testdata/loader/reviewpad_with_no_extends_b.yml
+++ b/engine/testdata/loader/reviewpad_with_no_extends_b.yml
@@ -4,6 +4,10 @@
 
 api-version: reviewpad.com/v3.x
 
+ignore-errors: true
+
+edition: enterprise
+
 groups:
   - name: owners
     kind: developers


### PR DESCRIPTION
## Description

This pull request introduces the following changes:
- Unit tests to compare that the loader does not 'default' fields in the Reviewpad file;
- Use a pointer to represent the ignore errors field;
- Extend the `extends` functionality for the rest of the ReviewpadFile fields.

## Related issue

Closes #523

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Unit tests.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge 
