### PR TITLE
fix: log unused rules instead returning error

### DIFF
--- a/engine/linter.go
+++ b/engine/linter.go
@@ -200,7 +200,7 @@ func lintRulesMentions(rules []PadRule, groups []PadGroup, workflows []PadWorkfl
 
 	for ruleName, totalUses := range totalUsesByRule {
 		if totalUses == 0 {
-			return lintError("unused rule %v", ruleName)
+			lintLog("unused rule %v", ruleName)
 		}
 	}
 


### PR DESCRIPTION
## Description

This pull request lowers the severity of unused rules in the linter from error to log. 

## Related issue

Closes #531.

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality) 
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Functional testing using GitHub action.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

- [x] Ship: this pull request can be automatically merged and does not require code review 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
<!-- - [ ] Ask: this pull request requires a code review before merge -->
