### PR TITLE
feat: metrics-on-merge flag

### DIFF
--- a/engine/env.go
+++ b/engine/env.go
@@ -32,7 +32,7 @@ type Interpreter interface {
 	ExecProgram(program *Program) (ExitStatus, error)
 	ExecStatement(statement *Statement) error
 	Report(mode string, safeMode bool) error
-	ReportMetrics(mode string) error
+	ReportMetrics() error
 }
 
 type Env struct {

--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -18,16 +18,18 @@ func inlineRulesNormalizer() *NormalizeRule {
 
 func inlineRulesModificator(file *ReviewpadFile) (*ReviewpadFile, error) {
 	reviewpadFile := &ReviewpadFile{
-		Version:      file.Version,
-		Edition:      file.Edition,
-		Mode:         file.Mode,
-		IgnoreErrors: file.IgnoreErrors,
-		Imports:      file.Imports,
-		Groups:       file.Groups,
-		Rules:        file.Rules,
-		Labels:       file.Labels,
-		Workflows:    file.Workflows,
-		Pipelines:    file.Pipelines,
+		Version:        file.Version,
+		Edition:        file.Edition,
+		Mode:           file.Mode,
+		IgnoreErrors:   file.IgnoreErrors,
+		MetricsOnMerge: file.MetricsOnMerge,
+		Extends:        file.Extends,
+		Imports:        file.Imports,
+		Groups:         file.Groups,
+		Rules:          file.Rules,
+		Labels:         file.Labels,
+		Workflows:      file.Workflows,
+		Pipelines:      file.Pipelines,
 	}
 
 	for i, workflow := range reviewpadFile.Workflows {

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -193,17 +193,18 @@ func (p PadGroup) equals(o PadGroup) bool {
 }
 
 type ReviewpadFile struct {
-	Version      string              `yaml:"api-version"`
-	Edition      string              `yaml:"edition"`
-	Mode         string              `yaml:"mode"`
-	IgnoreErrors *bool               `yaml:"ignore-errors"`
-	Imports      []PadImport         `yaml:"imports"`
-	Extends      []string            `yaml:"extends"`
-	Groups       []PadGroup          `yaml:"groups"`
-	Rules        []PadRule           `yaml:"rules"`
-	Labels       map[string]PadLabel `yaml:"labels"`
-	Workflows    []PadWorkflow       `yaml:"workflows"`
-	Pipelines    []PadPipeline       `yaml:"pipelines"`
+	Version        string              `yaml:"api-version"`
+	Edition        string              `yaml:"edition"`
+	Mode           string              `yaml:"mode"`
+	IgnoreErrors   *bool               `yaml:"ignore-errors"`
+	MetricsOnMerge *bool               `yaml:"metrics-on-merge"`
+	Imports        []PadImport         `yaml:"imports"`
+	Extends        []string            `yaml:"extends"`
+	Groups         []PadGroup          `yaml:"groups"`
+	Rules          []PadRule           `yaml:"rules"`
+	Labels         map[string]PadLabel `yaml:"labels"`
+	Workflows      []PadWorkflow       `yaml:"workflows"`
+	Pipelines      []PadPipeline       `yaml:"pipelines"`
 }
 
 type PadPipeline struct {
@@ -232,6 +233,10 @@ func (r *ReviewpadFile) equals(o *ReviewpadFile) bool {
 	}
 
 	if r.IgnoreErrors != o.IgnoreErrors {
+		return false
+	}
+
+	if r.MetricsOnMerge != o.MetricsOnMerge {
 		return false
 	}
 
@@ -372,6 +377,10 @@ func (r *ReviewpadFile) extend(o *ReviewpadFile) {
 
 	if o.IgnoreErrors != nil {
 		r.IgnoreErrors = o.IgnoreErrors
+	}
+
+	if o.MetricsOnMerge != nil {
+		r.MetricsOnMerge = o.MetricsOnMerge
 	}
 
 	r.appendLabels(o)

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -150,17 +150,18 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 	}
 
 	return &ReviewpadFile{
-		Version:      file.Version,
-		Edition:      file.Edition,
-		Mode:         file.Mode,
-		IgnoreErrors: file.IgnoreErrors,
-		Imports:      file.Imports,
-		Extends:      file.Extends,
-		Groups:       file.Groups,
-		Rules:        transformedRules,
-		Labels:       file.Labels,
-		Workflows:    transformedWorkflows,
-		Pipelines:    transformedPipelines,
+		Version:        file.Version,
+		Edition:        file.Edition,
+		Mode:           file.Mode,
+		IgnoreErrors:   file.IgnoreErrors,
+		MetricsOnMerge: file.MetricsOnMerge,
+		Imports:        file.Imports,
+		Extends:        file.Extends,
+		Groups:         file.Groups,
+		Rules:          transformedRules,
+		Labels:         file.Labels,
+		Workflows:      transformedWorkflows,
+		Pipelines:      transformedPipelines,
 	}
 }
 

--- a/engine/loader_internal_test.go
+++ b/engine/loader_internal_test.go
@@ -16,6 +16,7 @@ api-version: reviewpad.com/v3.x
 
 mode: silent
 edition: professional
+metrics-on-merge: true
 
 pipelines:
   - name: assign-reviewers
@@ -30,10 +31,12 @@ pipelines:
 `
 	gotFile, err := parse([]byte(contents))
 
+	metricsOnMerge := true
 	wantFile := &ReviewpadFile{
-		Version: "reviewpad.com/v3.x",
-		Edition: "professional",
-		Mode:    "silent",
+		Version:        "reviewpad.com/v3.x",
+		Edition:        "professional",
+		Mode:           "silent",
+		MetricsOnMerge: &metricsOnMerge,
 		Pipelines: []PadPipeline{
 			{
 				Name:        "assign-reviewers",

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -78,11 +78,14 @@ func TestLoadWithAST(t *testing.T) {
 	}
 
 	noIgnoreErrors := true
+	noMetricsOnMerge := true
 	wantReviewpadFile := &engine.ReviewpadFile{
-		Version:      "reviewpad.com/v3.x",
-		Edition:      "enterprise",
-		Mode:         "verbose",
-		IgnoreErrors: &noIgnoreErrors,
+		Version:        "reviewpad.com/v3.x",
+		Edition:        "enterprise",
+		Mode:           "verbose",
+		IgnoreErrors:   &noIgnoreErrors,
+		MetricsOnMerge: &noMetricsOnMerge,
+		Extends:        []string{},
 		Labels: map[string]engine.PadLabel{
 			"small": {
 				Color: "#aa12ab",

--- a/engine/testdata/loader/process/reviewpad_with_extends_after_processing.yml
+++ b/engine/testdata/loader/process/reviewpad_with_extends_after_processing.yml
@@ -3,12 +3,10 @@
 # found in the LICENSE file.
 
 api-version: reviewpad.com/v3.x
-
 mode: verbose
-
 edition: enterprise
-
 ignore-errors: true
+metrics-on-merge: true
 
 labels:
   small:

--- a/engine/testdata/loader/reviewpad_with_no_extends_a.yml
+++ b/engine/testdata/loader/reviewpad_with_no_extends_a.yml
@@ -6,6 +6,8 @@ api-version: reviewpad.com/v3.x
 
 mode: verbose
 
+metrics-on-merge: true
+
 labels:
   small:
     color: '#aaf1aa'

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -198,7 +198,7 @@ func (i *Interpreter) Report(mode string, safeMode bool) error {
 
 }
 
-func (i *Interpreter) ReportMetrics(mode string) error {
+func (i *Interpreter) ReportMetrics() error {
 	targetEntity := i.Env.GetTarget().GetTargetEntity()
 	owner := targetEntity.Owner
 	prNum := targetEntity.Number
@@ -206,7 +206,7 @@ func (i *Interpreter) ReportMetrics(mode string) error {
 	ctx := i.Env.GetCtx()
 	pr := i.Env.GetTarget().(*target.PullRequestTarget).PullRequest
 
-	if mode != engine.VERBOSE_MODE || !*pr.Merged {
+	if !*pr.Merged {
 		return nil
 	}
 

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -758,15 +758,13 @@ func TestReportMetric(t *testing.T) {
 		graphQLHandler         func(res http.ResponseWriter, req *http.Request)
 		commentShouldBeCreated bool
 		commentShouldBeUpdated bool
-		mode                   string
 		err                    error
 	}{
 		"when getting first commit and review date failed": {
 			graphQLHandler: func(res http.ResponseWriter, req *http.Request) {
 				res.WriteHeader(http.StatusBadRequest)
 			},
-			err:  errors.New("non-200 OK status code: 400 Bad Request body: \"\""),
-			mode: "verbose",
+			err: errors.New("non-200 OK status code: 400 Bad Request body: \"\""),
 		},
 		"when find report comment failed": {
 			graphQLHandler: func(res http.ResponseWriter, req *http.Request) {
@@ -802,8 +800,7 @@ func TestReportMetric(t *testing.T) {
 					}),
 				),
 			},
-			err:  errors.New("[report] error getting issues "),
-			mode: "verbose",
+			err: errors.New("[report] error getting issues "),
 		},
 		"when create comment failed": {
 			graphQLHandler: func(res http.ResponseWriter, req *http.Request) {
@@ -843,8 +840,7 @@ func TestReportMetric(t *testing.T) {
 					[]*github.IssueComment{},
 				),
 			},
-			err:  errors.New("[report] error on creating report comment "),
-			mode: "verbose",
+			err: errors.New("[report] error on creating report comment "),
 		},
 		"when update comment failed": {
 			graphQLHandler: func(res http.ResponseWriter, req *http.Request) {
@@ -889,8 +885,7 @@ func TestReportMetric(t *testing.T) {
 					},
 				),
 			},
-			err:  errors.New("[report] error on updating report comment "),
-			mode: "verbose",
+			err: errors.New("[report] error on updating report comment "),
 		},
 		"when successfully created report comment": {
 			graphQLHandler: func(res http.ResponseWriter, req *http.Request) {
@@ -932,7 +927,6 @@ func TestReportMetric(t *testing.T) {
 			},
 			commentShouldBeCreated: true,
 			err:                    nil,
-			mode:                   "verbose",
 		},
 		"when successfully updated report comment": {
 			graphQLHandler: func(res http.ResponseWriter, req *http.Request) {
@@ -979,12 +973,6 @@ func TestReportMetric(t *testing.T) {
 			},
 			commentShouldBeUpdated: true,
 			err:                    nil,
-			mode:                   "verbose",
-		},
-		"when mode is silent": {
-			commentShouldBeUpdated: false,
-			err:                    nil,
-			mode:                   "silent",
 		},
 	}
 
@@ -1003,7 +991,7 @@ func TestReportMetric(t *testing.T) {
 
 			assert.Nil(t, err)
 
-			err = interpreter.ReportMetrics(test.mode)
+			err = interpreter.ReportMetrics()
 
 			assert.Equal(t, test.err, err)
 			assert.Equal(t, test.commentShouldBeCreated, commentCreated)

--- a/runner.go
+++ b/runner.go
@@ -88,10 +88,12 @@ func Run(
 	}
 
 	if utils.IsPullRequestReadyForReportMetrics(eventData) {
-		err = aladinoInterpreter.ReportMetrics(reviewpadFile.Mode)
-		if err != nil {
-			engine.CollectError(evalEnv, err)
-			return engine.ExitStatusFailure, nil, err
+		if reviewpadFile.MetricsOnMerge != nil && *reviewpadFile.MetricsOnMerge {
+			err = aladinoInterpreter.ReportMetrics()
+			if err != nil {
+				engine.CollectError(evalEnv, err)
+				return engine.ExitStatusFailure, nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

This pull request introduces the `metrics-on-merge` flag that controls if the metrics report is presented when a pull request is merged.

## Related issue

Closes #532

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Unit tests.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
- [x] Show: this pull request can be auto-merged and code review should be done post merge 
<!-- - [ ] Ask: this pull request requires a code review before merge -->
