### PR TITLE
feat: trigger workflow and event type built-ins

### DIFF
--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -438,3 +438,15 @@ func (t *PullRequestTarget) GetApprovalsCount() (int, error) {
 
 	return t.githubClient.GetApprovalsCount(ctx, owner, repo, number)
 }
+
+func (t *PullRequestTarget) TriggerWorkflowByFileName(workflowFileName string) error {
+	ctx := t.ctx
+	targetEntity := t.targetEntity
+	owner := targetEntity.Owner
+	repo := targetEntity.Repo
+	head := t.PullRequest.GetHead().GetRef()
+
+	_, err := t.githubClient.TriggerWorkflowByFileName(ctx, owner, repo, head, workflowFileName)
+
+	return err
+}

--- a/codehost/github/workflows.go
+++ b/codehost/github/workflows.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2022 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+
+	"github.com/google/go-github/v48/github"
+)
+
+func (c *GithubClient) TriggerWorkflowByFileName(ctx context.Context, owner, repo, branch, workflowFileName string) (*github.Response, error) {
+	return c.clientREST.Actions.CreateWorkflowDispatchEventByFileName(ctx, owner, repo, workflowFileName,
+		github.CreateWorkflowDispatchEventRequest{
+			Ref: branch,
+		},
+	)
+}

--- a/plugins/aladino/actions/triggerWorkflow.go
+++ b/plugins/aladino/actions/triggerWorkflow.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_actions
+
+import (
+	"github.com/reviewpad/reviewpad/v3/codehost/github/target"
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+)
+
+func TriggerWorkflow() *aladino.BuiltInAction {
+	return &aladino.BuiltInAction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType()}, nil),
+		Code:           triggerWorkflowCode,
+		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest},
+	}
+}
+
+func triggerWorkflowCode(e aladino.Env, args []aladino.Value) error {
+	t := e.GetTarget().(*target.PullRequestTarget)
+
+	fileName := args[0].(*aladino.StringValue).Val
+
+	return t.TriggerWorkflowByFileName(fileName)
+}

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -139,6 +139,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"removeLabels":         actions.RemoveLabels(),
 			"review":               actions.Review(),
 			"titleLint":            actions.TitleLint(),
+			"triggerWorkflow":      actions.TriggerWorkflow(),
 			"warn":                 actions.Warn(),
 		},
 		Services: config.Services,

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -65,6 +65,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"commits":                   functions.Commits(),
 			"createdAt":                 functions.CreatedAt(),
 			"description":               functions.Description(),
+			"eventType":                 functions.EventType(),
 			"fileCount":                 functions.FileCount(),
 			"hasAnnotation":             functions.HasAnnotation(),
 			"hasBinaryFile":             functions.HasBinaryFile(),

--- a/plugins/aladino/functions/eventType.go
+++ b/plugins/aladino/functions/eventType.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"reflect"
+
+	"github.com/google/go-github/v48/github"
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+)
+
+func EventType() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{}, aladino.BuildStringType()),
+		Code:           eventTypeCode,
+		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest},
+	}
+}
+
+func eventTypeCode(e aladino.Env, _ []aladino.Value) (aladino.Value, error) {
+	pullRequestEvent := e.GetEventPayload()
+	if reflect.TypeOf(pullRequestEvent).String() != "*github.PullRequestEvent" {
+		return aladino.BuildStringValue(""), nil
+	}
+
+	pullRequestEventPayload := pullRequestEvent.(*github.PullRequestEvent)
+	if pullRequestEventPayload == nil {
+		return aladino.BuildStringValue(""), nil
+	}
+
+	if pullRequestEventPayload.Action == nil {
+		return aladino.BuildStringValue(""), nil
+	}
+
+	return aladino.BuildStringValue(*pullRequestEventPayload.Action), nil
+}

--- a/plugins/aladino/functions/eventType_test.go
+++ b/plugins/aladino/functions/eventType_test.go
@@ -1,0 +1,97 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v48/github"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var eventType = plugins_aladino.PluginBuiltIns().Functions["eventType"].Code
+
+func TestEventType_WhenEventPayloadIsNotPullRequestEvent(t *testing.T) {
+	wantValue := aladino.BuildStringValue("")
+
+	eventPayload := &github.CheckRunEvent{}
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		nil,
+		nil,
+		aladino.MockBuiltIns(),
+		eventPayload,
+	)
+
+	args := []aladino.Value{}
+	gotValue, err := eventType(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantValue, gotValue)
+}
+
+func TestEventType_WhenPullRequestEventIsNil(t *testing.T) {
+	wantValue := aladino.BuildStringValue("")
+
+	eventPayload := &github.PullRequestEvent{}
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		nil,
+		nil,
+		aladino.MockBuiltIns(),
+		eventPayload,
+	)
+
+	args := []aladino.Value{}
+	gotValue, err := eventType(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantValue, gotValue)
+}
+
+func TestEventType_WhenPullRequestEventActionIsNil(t *testing.T) {
+	wantValue := aladino.BuildStringValue("")
+
+	eventPayload := &github.PullRequestEvent{
+		Action: nil,
+	}
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		nil,
+		nil,
+		aladino.MockBuiltIns(),
+		eventPayload,
+	)
+
+	args := []aladino.Value{}
+	gotValue, err := eventType(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantValue, gotValue)
+}
+
+func TestEventType(t *testing.T) {
+	wantValue := aladino.BuildStringValue("synchronized")
+
+	eventPayload := &github.PullRequestEvent{
+		Action: github.String("synchronized"),
+	}
+
+	mockedEnv := aladino.MockDefaultEnv(
+		t,
+		nil,
+		nil,
+		aladino.MockBuiltIns(),
+		eventPayload,
+	)
+
+	args := []aladino.Value{}
+	gotValue, err := eventType(mockedEnv, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, wantValue, gotValue)
+}


### PR DESCRIPTION
## Description

This pull request introduces two new built-ins:
- $triggerWorkflow(file) that triggers a workflow from the GitHub action file name
- $eventType() that returns the type of pull request event

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Unit tests and functional tests.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
- [x] Show: this pull request can be auto-merged and code review should be done post merge
<!-- - [ ] Ask: this pull request requires a code review before merge -->
