### PR TITLE
feat: add logging info for overrides

### DIFF
--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestEval_WhenGitHubRequestsFail(t *testing.T) {
+	logger := logrus.NewEntry(logrus.New())
 	tests := map[string]struct {
 		inputReviewpadFilePath string
 		inputContext           context.Context
@@ -98,7 +99,7 @@ func TestEval_WhenGitHubRequestsFail(t *testing.T) {
 				assert.FailNow(t, fmt.Sprintf("Error reading reviewpad file: %v", err))
 			}
 
-			reviewpadFile, err := engine.Load(test.inputContext, test.inputGitHubClient, reviewpadFileData)
+			reviewpadFile, err := engine.Load(test.inputContext, logger, test.inputGitHubClient, reviewpadFileData)
 			if err != nil {
 				assert.FailNow(t, "Error parsing reviewpad file: %v", err)
 			}
@@ -271,6 +272,7 @@ func TestEvalCommand(t *testing.T) {
 }
 
 func TestEvalConfigurationFile(t *testing.T) {
+	logger := logrus.NewEntry(logrus.New())
 	tests := map[string]struct {
 		inputReviewpadFilePath string
 		inputContext           context.Context
@@ -425,7 +427,7 @@ func TestEvalConfigurationFile(t *testing.T) {
 				assert.FailNow(t, fmt.Sprintf("Error reading reviewpad file: %v", err))
 			}
 
-			reviewpadFile, err := engine.Load(test.inputContext, test.inputGitHubClient, reviewpadFileData)
+			reviewpadFile, err := engine.Load(test.inputContext, logger, test.inputGitHubClient, reviewpadFileData)
 			if err != nil {
 				assert.FailNow(t, fmt.Sprintf("Error parsing reviewpad file: %v", err))
 			}

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -224,6 +224,44 @@ type PadStage struct {
 	Until   string   `yaml:"until"`
 }
 
+func (p PadPipeline) equals(o PadPipeline) bool {
+	if p.Name != o.Name {
+		return false
+	}
+
+	if p.Description != o.Description {
+		return false
+	}
+
+	if p.Trigger != o.Trigger {
+		return false
+	}
+
+	for i, pS := range p.Stages {
+		oS := o.Stages[i]
+		if !pS.equals(oS) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (p PadStage) equals(o PadStage) bool {
+	if p.Until != o.Until {
+		return false
+	}
+
+	for i, pA := range p.Actions {
+		oA := o.Actions[i]
+		if pA != oA {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (r *ReviewpadFile) equals(o *ReviewpadFile) bool {
 	if r.Version != o.Version {
 		return false

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 
 	gh "github.com/reviewpad/reviewpad/v3/codehost/github"
@@ -25,6 +26,8 @@ type LoadEnv struct {
 
 func logExtendedProperties(logger *logrus.Entry, fileA *ReviewpadFile, fileAUri string, fileB *ReviewpadFile, fileBUri string, resultFile *ReviewpadFile) {
 	// Extended labels
+	log.Printf("FILE A: %s", fileAUri)
+	log.Printf("FILE B: %s", fileBUri)
 	for labelKeyName, label := range resultFile.Labels {
 		if _, ok := fileA.Labels[labelKeyName]; ok {
 			if _, ok := fileB.Labels[labelKeyName]; ok {

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -38,16 +38,16 @@ func logExtendedProperties(logger *logrus.Entry, extensionUri string, extensionF
 	// Extended groups
 	for _, group := range resultFile.Groups {
 		var extensionFileGroup, previousResultFileGroup PadGroup
-		for _, groupA := range extensionFile.Groups {
-			if groupA.Name == group.Name {
-				extensionFileGroup = groupA
+		for _, eGroup := range extensionFile.Groups {
+			if eGroup.Name == group.Name {
+				extensionFileGroup = eGroup
 				break
 			}
 		}
 
-		for _, groupB := range previousResultFile.Groups {
-			if groupB.Name == group.Name {
-				previousResultFileGroup = groupB
+		for _, pGroup := range previousResultFile.Groups {
+			if pGroup.Name == group.Name {
+				previousResultFileGroup = pGroup
 				break
 			}
 		}
@@ -62,16 +62,16 @@ func logExtendedProperties(logger *logrus.Entry, extensionUri string, extensionF
 	// Extended rules
 	for _, rule := range resultFile.Rules {
 		var extensionFileRule, previousResultFileRule PadRule
-		for _, ruleA := range extensionFile.Rules {
-			if ruleA.Name == rule.Name {
-				extensionFileRule = ruleA
+		for _, eRule := range extensionFile.Rules {
+			if eRule.Name == rule.Name {
+				extensionFileRule = eRule
 				break
 			}
 		}
 
-		for _, ruleB := range previousResultFile.Rules {
-			if ruleB.Name == rule.Name {
-				previousResultFileRule = ruleB
+		for _, pRule := range previousResultFile.Rules {
+			if pRule.Name == rule.Name {
+				previousResultFileRule = pRule
 				break
 			}
 		}
@@ -86,16 +86,16 @@ func logExtendedProperties(logger *logrus.Entry, extensionUri string, extensionF
 	// Extended workflows
 	for _, workflow := range resultFile.Workflows {
 		var extensionFileWorkflow, previousResultFileWorkflow PadWorkflow
-		for _, workflowA := range extensionFile.Workflows {
-			if workflowA.Name == workflow.Name {
-				extensionFileWorkflow = workflowA
+		for _, eWorkflow := range extensionFile.Workflows {
+			if eWorkflow.Name == workflow.Name {
+				extensionFileWorkflow = eWorkflow
 				break
 			}
 		}
 
-		for _, workflowB := range previousResultFile.Workflows {
-			if workflowB.Name == workflow.Name {
-				previousResultFileWorkflow = workflowB
+		for _, pWorkflow := range previousResultFile.Workflows {
+			if pWorkflow.Name == workflow.Name {
+				previousResultFileWorkflow = pWorkflow
 				break
 			}
 		}
@@ -110,16 +110,16 @@ func logExtendedProperties(logger *logrus.Entry, extensionUri string, extensionF
 	// Extended pipelines
 	for _, pipeline := range resultFile.Pipelines {
 		var extensionFilePipeline, previousResultFilePipeline PadPipeline
-		for _, pipelineA := range extensionFile.Pipelines {
-			if pipelineA.Name == pipeline.Name {
-				extensionFilePipeline = pipelineA
+		for _, ePipeline := range extensionFile.Pipelines {
+			if ePipeline.Name == pipeline.Name {
+				extensionFilePipeline = ePipeline
 				break
 			}
 		}
 
-		for _, pipelineB := range previousResultFile.Pipelines {
-			if pipelineB.Name == pipeline.Name {
-				previousResultFilePipeline = pipelineB
+		for _, pPipeline := range previousResultFile.Pipelines {
+			if pPipeline.Name == pipeline.Name {
+				previousResultFilePipeline = pPipeline
 				break
 			}
 		}

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 
 	gh "github.com/reviewpad/reviewpad/v3/codehost/github"
@@ -26,16 +25,13 @@ type LoadEnv struct {
 
 func logExtendedProperties(logger *logrus.Entry, fileA *ReviewpadFile, fileAUri string, fileB *ReviewpadFile, fileBUri string, resultFile *ReviewpadFile) {
 	// Extended labels
-	log.Printf("RESULT FILE LABELS: %+v", resultFile.Labels)
-	log.Printf("A FILE LABELS: %+v", fileA.Labels)
-	log.Printf("B FILE LABELS: %+v", fileB.Labels)
-	for _, label := range resultFile.Labels {
-		if _, ok := fileA.Labels[label.Name]; ok {
-			if _, ok := fileB.Labels[label.Name]; ok {
-				if fileA.Labels[label.Name].equals(label) {
-					logger.Warnf("label %s has been overridden by %s", label.Name, fileAUri)
+	for labelKeyName, label := range resultFile.Labels {
+		if _, ok := fileA.Labels[labelKeyName]; ok {
+			if _, ok := fileB.Labels[labelKeyName]; ok {
+				if fileA.Labels[labelKeyName].equals(label) {
+					logger.Warnf("label %s has been overridden by %s", labelKeyName, fileAUri)
 				} else {
-					logger.Warnf("label %s has been overridden by %s", label.Name, fileBUri)
+					logger.Warnf("label %s has been overridden by %s", labelKeyName, fileBUri)
 				}
 			}
 		}

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/reviewpad/reviewpad/v3/handler"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
 	"github.com/reviewpad/reviewpad/v3/utils"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,6 +29,7 @@ type httpMockResponder struct {
 }
 
 func TestLoadWithAST(t *testing.T) {
+	logger := logrus.NewEntry(logrus.New())
 	inputContext := context.Background()
 	inputGitHubClient := aladino.MockDefaultGithubClient(
 		[]mock.MockBackendOption{
@@ -72,7 +74,7 @@ func TestLoadWithAST(t *testing.T) {
 		assert.FailNow(t, "Error reading reviewpad file: %v", err)
 	}
 
-	gotReviewpadFile, err := engine.Load(inputContext, inputGitHubClient, reviewpadFileData)
+	gotReviewpadFile, err := engine.Load(inputContext, logger, inputGitHubClient, reviewpadFileData)
 	if err != nil {
 		assert.FailNow(t, "Error parsing reviewpad file: %v", err)
 	}
@@ -192,6 +194,7 @@ func TestLoadWithAST(t *testing.T) {
 }
 
 func TestLoad(t *testing.T) {
+	logger := logrus.NewEntry(logrus.New())
 	tests := map[string]struct {
 		httpMockResponders     []httpMockResponder
 		inputReviewpadFilePath string
@@ -413,7 +416,7 @@ func TestLoad(t *testing.T) {
 					assert.FailNow(t, "Error reading reviewpad file: %v", err)
 				}
 
-				wantReviewpadFile, err = engine.Load(test.inputContext, test.inputGitHubClient, wantReviewpadFileData)
+				wantReviewpadFile, err = engine.Load(test.inputContext, logger, test.inputGitHubClient, wantReviewpadFileData)
 				if err != nil {
 					assert.FailNow(t, "Error parsing reviewpad file: %v", err)
 				}
@@ -424,7 +427,7 @@ func TestLoad(t *testing.T) {
 				assert.FailNow(t, "Error reading reviewpad file: %v", err)
 			}
 
-			gotReviewpadFile, gotErr := engine.Load(test.inputContext, test.inputGitHubClient, reviewpadFileData)
+			gotReviewpadFile, gotErr := engine.Load(test.inputContext, logger, test.inputGitHubClient, reviewpadFileData)
 
 			if gotErr != nil {
 				githubError := &github.ErrorResponse{}

--- a/runner.go
+++ b/runner.go
@@ -37,7 +37,7 @@ func logErrorAndCollect(logger *logrus.Entry, collector collector.Collector, mes
 }
 
 func Load(ctx context.Context, log *logrus.Entry, githubClient *gh.GithubClient, buf *bytes.Buffer) (*engine.ReviewpadFile, error) {
-	file, err := engine.Load(ctx, githubClient, buf.Bytes())
+	file, err := engine.Load(ctx, log, githubClient, buf.Bytes())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request introduces the logging for overridden reviewpad properties by the extend property.
This logging says which properties were overridden and the property type.

## Related issue

<!-- Closes # (issue) -->
Closes #517

## Type of change

<!-- Uncomment the right types of change from the options below: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Ran manual tests with `reviewpad-cli`.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have run `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post-merge --> 
- [x] Ask: this pull request requires a code review before the merge
