### PR TITLE
feat: toBool built-in function

### DIFF
--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -119,6 +119,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"selectFromJSON":    functions.SelectFromJSON(),
 			"sprintf":           functions.Sprintf(),
 			"startsWith":        functions.StartsWith(),
+			"toBool":            functions.ToBool(),
 			// Engine
 			"group": functions.Group(),
 			"rule":  functions.Rule(),

--- a/plugins/aladino/functions/toBool.go
+++ b/plugins/aladino/functions/toBool.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+)
+
+func ToBool() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType()}, aladino.BuildBoolType()),
+		Code:           toBoolCode,
+		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest, handler.Issue},
+	}
+}
+
+func toBoolCode(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
+	str := args[0].(*aladino.StringValue).Val
+
+	val, err := strconv.ParseBool(str)
+	if err != nil {
+		return nil, fmt.Errorf(`error converting "%s" to boolean: %w`, str, err)
+	}
+
+	return aladino.BuildBoolValue(val), nil
+}

--- a/plugins/aladino/functions/toBool_test.go
+++ b/plugins/aladino/functions/toBool_test.go
@@ -1,0 +1,102 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var toBool = plugins_aladino.PluginBuiltIns().Functions["toBool"].Code
+
+func TestToBool(t *testing.T) {
+	tests := map[string]struct {
+		str     string
+		wantRes aladino.Value
+		wantErr error
+	}{
+		"when empty": {
+			str: "",
+			wantErr: fmt.Errorf(`error converting "" to boolean: %w`, &strconv.NumError{
+				Func: "ParseBool",
+				Num:  "",
+				Err:  errors.New("invalid syntax"),
+			}),
+		},
+		"when 1": {
+			str:     "1",
+			wantRes: aladino.BuildBoolValue(true),
+		},
+		"when 0": {
+			str:     "0",
+			wantRes: aladino.BuildBoolValue(false),
+		},
+		"when t": {
+			str:     "t",
+			wantRes: aladino.BuildBoolValue(true),
+		},
+		"when f": {
+			str:     "f",
+			wantRes: aladino.BuildBoolValue(false),
+		},
+		"when T": {
+			str:     "T",
+			wantRes: aladino.BuildBoolValue(true),
+		},
+		"when F": {
+			str:     "F",
+			wantRes: aladino.BuildBoolValue(false),
+		},
+		"when TRUE": {
+			str:     "TRUE",
+			wantRes: aladino.BuildBoolValue(true),
+		},
+		"when FALSE": {
+			str:     "FALSE",
+			wantRes: aladino.BuildBoolValue(false),
+		},
+		"when true": {
+			str:     "true",
+			wantRes: aladino.BuildBoolValue(true),
+		},
+		"when false": {
+			str:     "false",
+			wantRes: aladino.BuildBoolValue(false),
+		},
+		"when True": {
+			str:     "True",
+			wantRes: aladino.BuildBoolValue(true),
+		},
+		"when False": {
+			str:     "False",
+			wantRes: aladino.BuildBoolValue(false),
+		},
+		"when other": {
+			str: "other",
+			wantErr: fmt.Errorf(`error converting "other" to boolean: %w`, &strconv.NumError{
+				Func: "ParseBool",
+				Num:  "other",
+				Err:  errors.New("invalid syntax"),
+			}),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := aladino.MockDefaultEnv(t, nil, nil, aladino.MockBuiltIns(), nil)
+
+			res, err := toBool(env, []aladino.Value{aladino.BuildStringValue(test.str)})
+
+			assert.Equal(t, test.wantRes, res)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Adds a new `$toBool` built-in function. this built-in is basically a wrapper of `strconv.ParseBool` and  It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False. Any other value returns an error

### Examples
- `$toBool("true")`
- `$toBool("false")`
- `$toBool($selectFromContext("$.locked"))`
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #586 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit tests and manual tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
