### PR TITLE
fix: randomly failing filesPath tests

### DIFF
--- a/plugins/aladino/functions/filesPath_test.go
+++ b/plugins/aladino/functions/filesPath_test.go
@@ -30,19 +30,9 @@ func TestFilesPath(t *testing.T) {
 					Filename: github.String("go.mod"),
 					Patch:    nil,
 				},
-				{
-					Filename: github.String("go.sum"),
-					Patch:    nil,
-				},
-				{
-					Filename: github.String("cmd/main.go"),
-					Patch:    nil,
-				},
 			},
 			wantResult: aladino.BuildArrayValue([]aladino.Value{
 				aladino.BuildStringValue("go.mod"),
-				aladino.BuildStringValue("go.sum"),
-				aladino.BuildStringValue("cmd/main.go"),
 			}),
 		},
 		"when successful with nil file": {


### PR DESCRIPTION
## Description
Fixes intermittently failing test cases for `$filesPath` built-in function, the issue was since the patch is a map and iterating over it is non-deterministic.
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #575 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Running the tests with a count of 10 and make sure it didn't fail.
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
