### PR TITLE
feat: extend sprintf to support other types

### DIFF
--- a/lang/aladino/type.go
+++ b/lang/aladino/type.go
@@ -10,13 +10,14 @@ type Type interface {
 }
 
 const (
-	BOOL_TYPE     string = "BoolType"
-	INT_TYPE      string = "IntType"
-	STRING_TYPE   string = "StringType"
-	FUNCTION_TYPE string = "FunctionType"
-	ARRAY_TYPE    string = "ArrayType"
-	ARRAY_OF_TYPE string = "ArrayOfType"
-	JSON_TYPE     string = "JSONType"
+	BOOL_TYPE          string = "BoolType"
+	INT_TYPE           string = "IntType"
+	STRING_TYPE        string = "StringType"
+	FUNCTION_TYPE      string = "FunctionType"
+	ARRAY_TYPE         string = "ArrayType"
+	ARRAY_OF_TYPE      string = "ArrayOfType"
+	JSON_TYPE          string = "JSONType"
+	DYNAMIC_ARRAY_TYPE string = "DynamicArrayType"
 )
 
 type StringType struct{}
@@ -39,6 +40,8 @@ type ArrayType struct {
 	elemsType []Type
 }
 
+type DynamicArrayType struct{}
+
 type JSONType struct{}
 
 func BuildStringType() *StringType { return &StringType{} }
@@ -58,6 +61,8 @@ func BuildArrayType(elemsTypes []Type) *ArrayType {
 }
 
 func BuildJSONType() *JSONType { return &JSONType{} }
+
+func BuildDynamicArrayType() *DynamicArrayType { return &DynamicArrayType{} }
 
 func (bTy *BoolType) Kind() string {
 	return BOOL_TYPE
@@ -85,6 +90,10 @@ func (aTy *ArrayOfType) Kind() string {
 
 func (jTy *JSONType) Kind() string {
 	return JSON_TYPE
+}
+
+func (dATy *DynamicArrayType) Kind() string {
+	return DYNAMIC_ARRAY_TYPE
 }
 
 // Equals
@@ -141,6 +150,8 @@ func (thisTy *ArrayType) equals(thatTy Type) bool {
 			elems[i] = thatTyArrayOf.elemType
 		}
 		return equals(elems, thisTy.elemsType)
+	case DYNAMIC_ARRAY_TYPE:
+		return true
 	}
 	return false
 }
@@ -152,10 +163,16 @@ func (thisTy *ArrayOfType) equals(thatTy Type) bool {
 	case ARRAY_OF_TYPE:
 		thatTyArrayOf := thatTy.(*ArrayOfType)
 		return thisTy.elemType.equals(thatTyArrayOf.elemType)
+	case DYNAMIC_ARRAY_TYPE:
+		return true
 	}
 	return false
 }
 
 func (thisTy *JSONType) equals(thatTy Type) bool {
 	return thisTy.Kind() == thatTy.Kind()
+}
+
+func (thisTy *DynamicArrayType) equals(thatTy Type) bool {
+	return thisTy.Kind() == thatTy.Kind() || thatTy.Kind() == ARRAY_OF_TYPE || thatTy.Kind() == ARRAY_TYPE
 }

--- a/lang/aladino/type.go
+++ b/lang/aladino/type.go
@@ -174,5 +174,5 @@ func (thisTy *JSONType) equals(thatTy Type) bool {
 }
 
 func (thisTy *DynamicArrayType) equals(thatTy Type) bool {
-	return thisTy.Kind() == thatTy.Kind() || thatTy.Kind() == ARRAY_OF_TYPE || thatTy.Kind() == ARRAY_TYPE
+	return thisTy.Kind() == thatTy.Kind()
 }

--- a/lang/aladino/type_internal_test.go
+++ b/lang/aladino/type_internal_test.go
@@ -240,3 +240,17 @@ func TestEquals_WhenArrayOfTypeComparedToStringType(t *testing.T) {
 
 	assert.False(t, arrayOfType.equals(otherType))
 }
+
+func TestEquals_WhenArrayTypeComparedToDynamicArrayType(t *testing.T) {
+	arrayType := BuildArrayType([]Type{BuildStringType(), BuildIntType()})
+	dynamicArrayType := BuildDynamicArrayType()
+
+	assert.True(t, arrayType.equals(dynamicArrayType))
+}
+
+func TestEquals_WhenArrayOfTypeComparedToDynamicArrayType(t *testing.T) {
+	arrayOfType := BuildArrayOfType(BuildStringType())
+	dynamicArrayType := BuildDynamicArrayType()
+
+	assert.True(t, arrayOfType.equals(dynamicArrayType))
+}

--- a/plugins/aladino/functions/sprintf.go
+++ b/plugins/aladino/functions/sprintf.go
@@ -19,7 +19,7 @@ var (
 
 func Sprintf() *aladino.BuiltInFunction {
 	return &aladino.BuiltInFunction{
-		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType(), aladino.BuildArrayOfType(aladino.BuildStringType())}, aladino.BuildStringType()),
+		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType(), aladino.BuildDynamicArrayType()}, aladino.BuildStringType()),
 		Code:           sprintfCode,
 		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest, handler.Issue},
 	}
@@ -39,6 +39,10 @@ func sprintfCode(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
 	for _, val := range vals {
 		switch v := val.(type) {
 		case *aladino.StringValue:
+			clearVals = append(clearVals, v.Val)
+		case *aladino.IntValue:
+			clearVals = append(clearVals, v.Val)
+		case *aladino.BoolValue:
 			clearVals = append(clearVals, v.Val)
 		}
 	}

--- a/plugins/aladino/functions/sprintf_test.go
+++ b/plugins/aladino/functions/sprintf_test.go
@@ -68,6 +68,23 @@ func TestSprintf(t *testing.T) {
 			}),
 			wantString: aladino.BuildStringValue("Hello world"),
 		},
+		"when formatting with numbers": {
+			format: "Hello %s, You've added %d comments",
+			args: aladino.BuildArrayValue([]aladino.Value{
+				aladino.BuildStringValue("test"),
+				aladino.BuildIntValue(10),
+			}),
+			wantString: aladino.BuildStringValue("Hello test, You've added 10 comments"),
+		},
+		"when formatting with numbers and booleans": {
+			format: "hello %s, You've added %d comments, profile is locked: %t",
+			args: aladino.BuildArrayValue([]aladino.Value{
+				aladino.BuildStringValue("test"),
+				aladino.BuildIntValue(10),
+				aladino.BuildBoolValue(true),
+			}),
+			wantString: aladino.BuildStringValue("hello test, You've added 10 comments, profile is locked: true"),
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
## Description
Extends the `$sprintf` built-in function to support integers and booleans.
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #579 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit tests and manual tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
