### PR TITLE
feat: review only if pull request has updates

### DIFF
--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -57,6 +57,7 @@ func GetDefaultMockPullRequestDetails() *github.PullRequest {
 		ID:     &prId,
 		NodeID: github.String(DefaultMockEntityNodeID),
 		User:   &github.User{Login: github.String("john")},
+		State:  github.String("open"),
 		Assignees: []*github.User{
 			{Login: github.String("jane")},
 		},

--- a/plugins/aladino/actions/review.go
+++ b/plugins/aladino/actions/review.go
@@ -30,6 +30,11 @@ func reviewCode(e aladino.Env, args []aladino.Value) error {
 	clientGraphQL := e.GetGithubClient().GetClientGraphQL()
 	log := e.GetLogger().WithField("builtin", "review")
 
+	if t.GetState() == "closed" {
+		log.Infof("skipping review because the pull request is closed")
+		return nil
+	}
+
 	reviewEvent, err := parseReviewEvent(args[0].(*aladino.StringValue).Val)
 	if err != nil {
 		return err

--- a/plugins/aladino/actions/review.go
+++ b/plugins/aladino/actions/review.go
@@ -50,7 +50,18 @@ func reviewCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
+	lastPushDate, err := t.GetPullRequestLastPushDate()
+	if err != nil {
+		return err
+	}
+
 	if latestReview != nil {
+		// The last push was made before the last review so a new review is not needed
+		if lastPushDate.Before(*latestReview.SubmittedAt) {
+			log.Infof("skipping review because there were no updates since the last review")
+			return nil
+		}
+
 		latestReviewEvent, err := mapReviewStateToEvent(latestReview.State)
 		if err != nil {
 			return err

--- a/plugins/aladino/actions/review.go
+++ b/plugins/aladino/actions/review.go
@@ -30,7 +30,7 @@ func reviewCode(e aladino.Env, args []aladino.Value) error {
 	clientGraphQL := e.GetGithubClient().GetClientGraphQL()
 	log := e.GetLogger().WithField("builtin", "review")
 
-	if t.GetState() == "closed" {
+	if *t.PullRequest.State == "closed" {
 		log.Infof("skipping review because the pull request is closed")
 		return nil
 	}

--- a/plugins/aladino/functions/context_test.go
+++ b/plugins/aladino/functions/context_test.go
@@ -20,6 +20,7 @@ func TestContext(t *testing.T) {
 	mockPRJSON, err := utils.CompactJSONString(`{
         "id": 1234,
         "number": 6,
+        "state": "open",
         "title": "Amazing new feature",
         "body": "Please pull these awesome changes in!",
         "created_at": "2009-11-17T20:34:58.651387237Z",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request improves the `$review` built-in functionality by only submitting a review when the last review made by the bot was made before the last pull request push. Besides this, reviews are only performed on open pull requests.

## Related issue

<!-- Closes # (issue) -->
Closes #577 

## Type of change

<!-- Uncomment the right types of change from the options below: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Manual tests and ran `task check` cmd.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have run `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post-merge --> 
- [x] Ask: this pull request requires a code review before the merge
