### PR TITLE
feat: dryRun action built-in and command

### DIFF
--- a/engine/commands/commands.go
+++ b/engine/commands/commands.go
@@ -35,6 +35,7 @@ func NewCommands(out io.Writer, args []string) *cobra.Command {
 
 	root.AddCommand(AssignReviewerCmd())
 	root.AddCommand(AssignRandomReviewerCmd())
+	root.AddCommand(DryRunCmd())
 
 	return root
 }

--- a/engine/commands/dryRun.go
+++ b/engine/commands/dryRun.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func DryRunCmd() *cobra.Command {
+	dryRunCmd := &cobra.Command{
+		Use:           "dry-run",
+		Short:         "Runs the reviewpad configuration in dry-run mode",
+		Long:          "Runs the reviewpad configuration in the root repository in dry-run mode and adds the result as a comment.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("accepts no args, received %d", len(args))
+			}
+
+			return nil
+		},
+		RunE: DryRun,
+	}
+
+	return dryRunCmd
+}
+
+func DryRun(cmd *cobra.Command, args []string) error {
+	action := "$dryRun()"
+
+	cmd.Print(action)
+
+	return nil
+}

--- a/engine/commands/dryRun_test.go
+++ b/engine/commands/dryRun_test.go
@@ -1,0 +1,48 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package commands_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/reviewpad/reviewpad/v3/engine/commands"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDryRun(t *testing.T) {
+	testCases := map[string]struct {
+		args       []string
+		wantAction string
+		wantErr    error
+	}{
+		"when invalid number of arguments": {
+			args: []string{
+				"john",
+			},
+			wantErr: errors.New("accepts no args, received 1"),
+		},
+		"when command is fully executed": {
+			args:       []string{},
+			wantAction: "$dryRun()",
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			cmd := commands.DryRunCmd()
+
+			cmd.SetOut(out)
+			cmd.SetArgs(test.args)
+
+			err := cmd.Execute()
+
+			assert.Equal(t, test.wantErr, err)
+			assert.Equal(t, test.wantAction, out.String())
+		})
+	}
+}

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -33,7 +33,7 @@ func EvalCommand(command string, env *Env) (*Program, error) {
 		return nil, err
 	}
 
-	program.append([]string{out.String()})
+	program.Append([]string{out.String()})
 
 	return program, nil
 }
@@ -182,10 +182,10 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 		}
 
 		if len(ruleActivatedQueue) > 0 {
-			program.append(workflow.Actions)
+			program.Append(workflow.Actions)
 
 			for _, activatedRule := range ruleActivatedQueue {
-				program.append(activatedRule.ExtraActions)
+				program.Append(activatedRule.ExtraActions)
 			}
 
 			if !workflow.AlwaysRun {
@@ -214,7 +214,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 			for num, stage := range pipeline.Stages {
 				pipelineLog.Infof("evaluating pipeline stage '%v'", num)
 				if stage.Until == "" {
-					program.append(stage.Actions)
+					program.Append(stage.Actions)
 					break
 				}
 
@@ -224,7 +224,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 				}
 
 				if !isDone {
-					program.append(stage.Actions)
+					program.Append(stage.Actions)
 					break
 				}
 			}

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -452,6 +452,7 @@ func mockAladinoInterpreter(githubClient *gh.GithubClient) (engine.Interpreter, 
 		engine.DefaultMockTargetEntity,
 		engine.DefaultMockEventPayload,
 		aladino.MockBuiltIns(),
+		nil,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("aladino NewInterpreter returned unexpected error: %v", err)

--- a/engine/program.go
+++ b/engine/program.go
@@ -32,7 +32,7 @@ func (p *Program) GetProgramStatements() []*Statement {
 	return p.statements
 }
 
-func (program *Program) append(workflowActions []string) {
+func (program *Program) Append(workflowActions []string) {
 	for _, workflowAction := range workflowActions {
 		statement := BuildStatement(workflowAction)
 

--- a/engine/program_internal_test.go
+++ b/engine/program_internal_test.go
@@ -32,7 +32,7 @@ func TestAppend(t *testing.T) {
 		addedStat,
 	})
 
-	programUnderTest.append(workflow.Actions)
+	programUnderTest.Append(workflow.Actions)
 
 	assert.Equal(t, wantProgram, programUnderTest)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0
 	github.com/dukex/mixpanel v1.0.1
 	github.com/golang/mock v1.6.0
+	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v49 v49.1.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v41 v41.0.0 h1:HseJrM2JFf2vfiZJ8anY2hqBjdfY1Vlj/K27ueww4gg=
 github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
 github.com/google/go-github/v45 v45.2.0 h1:5oRLszbrkvxDDqBCNj2hjDZMKmvexaZ1xw/FCD+K3FI=

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -11,6 +11,7 @@ import (
 	gh "github.com/reviewpad/reviewpad/v3/codehost/github"
 	"github.com/reviewpad/reviewpad/v3/codehost/github/target"
 	"github.com/reviewpad/reviewpad/v3/collector"
+	"github.com/reviewpad/reviewpad/v3/engine"
 	"github.com/reviewpad/reviewpad/v3/handler"
 	"github.com/sirupsen/logrus"
 )
@@ -33,6 +34,7 @@ type Env interface {
 	GetBuiltInsReportedMessages() map[Severity][]string
 	GetGithubClient() *gh.GithubClient
 	GetCollector() collector.Collector
+	GetConfigFile() *engine.ReviewpadFile
 	GetCtx() context.Context
 	GetDryRun() bool
 	GetEventPayload() interface{}
@@ -47,6 +49,7 @@ type BaseEnv struct {
 	BuiltInsReportedMessages map[Severity][]string
 	GithubClient             *gh.GithubClient
 	Collector                collector.Collector
+	ConfigFile               *engine.ReviewpadFile
 	Ctx                      context.Context
 	DryRun                   bool
 	EventPayload             interface{}
@@ -70,6 +73,10 @@ func (e *BaseEnv) GetGithubClient() *gh.GithubClient {
 
 func (e *BaseEnv) GetCollector() collector.Collector {
 	return e.Collector
+}
+
+func (e *BaseEnv) GetConfigFile() *engine.ReviewpadFile {
+	return e.ConfigFile
 }
 
 func (e *BaseEnv) GetCtx() context.Context {
@@ -122,6 +129,7 @@ func NewEvalEnv(
 	targetEntity *handler.TargetEntity,
 	eventPayload interface{},
 	builtIns *BuiltIns,
+	configFile *engine.ReviewpadFile,
 ) (Env, error) {
 	registerMap := RegisterMap(make(map[string]Value))
 	report := &Report{Actions: make([]string, 0)}
@@ -131,6 +139,7 @@ func NewEvalEnv(
 		BuiltInsReportedMessages: make(map[Severity][]string),
 		GithubClient:             githubClient,
 		Collector:                collector,
+		ConfigFile:               configFile,
 		Ctx:                      ctx,
 		DryRun:                   dryRun,
 		EventPayload:             eventPayload,

--- a/lang/aladino/env_test.go
+++ b/lang/aladino/env_test.go
@@ -71,6 +71,7 @@ func TestNewEvalEnv_WhenGetPullRequestFilesFails(t *testing.T) {
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 	)
 
 	assert.Nil(t, env)
@@ -109,6 +110,7 @@ func TestNewEvalEnv_WhenNewFileFails(t *testing.T) {
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 	)
 
 	assert.Nil(t, env)
@@ -158,6 +160,7 @@ func TestNewEvalEnv(t *testing.T) {
 		aladino.DefaultMockTargetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 	)
 
 	mockedTarget, _ := target.NewPullRequestTarget(ctx, aladino.DefaultMockTargetEntity, mockedGithubClient, mockedPullRequest)
@@ -231,6 +234,7 @@ func TestNewEvalEnv_WhenGetPullRequestFails(t *testing.T) {
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 	)
 
 	assert.Nil(t, env)

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -252,8 +252,9 @@ func NewInterpreter(
 	targetEntity *handler.TargetEntity,
 	eventPayload interface{},
 	builtIns *BuiltIns,
+	configFile *engine.ReviewpadFile,
 ) (engine.Interpreter, error) {
-	evalEnv, err := NewEvalEnv(ctx, logger, dryRun, githubClient, collector, targetEntity, eventPayload, builtIns)
+	evalEnv, err := NewEvalEnv(ctx, logger, dryRun, githubClient, collector, targetEntity, eventPayload, builtIns, configFile)
 	if err != nil {
 		return nil, err
 	}

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -732,7 +732,7 @@ func TestNewInterpreter_WhenNewEvalEnvFails(t *testing.T) {
 }
 
 func TestNewInterpreter(t *testing.T) {
-	mockedEnv := MockDefaultEnv(t, nil, nil, MockBuiltIns(), nil)
+	mockedEnv := MockDefaultEnvWithReviewpadFile(t, nil, nil, MockBuiltIns(), nil, &engine.ReviewpadFile{})
 
 	wantInterpreter := &Interpreter{
 		Env: mockedEnv,
@@ -747,7 +747,7 @@ func TestNewInterpreter(t *testing.T) {
 		DefaultMockTargetEntity,
 		mockedEnv.GetEventPayload(),
 		mockedEnv.GetBuiltIns(),
-		nil,
+		&engine.ReviewpadFile{},
 	)
 
 	assert.Nil(t, err)

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -724,6 +724,7 @@ func TestNewInterpreter_WhenNewEvalEnvFails(t *testing.T) {
 		DefaultMockTargetEntity,
 		GetDefaultMockPullRequestDetails(),
 		nil,
+		nil,
 	)
 
 	assert.Nil(t, gotInterpreter)
@@ -746,6 +747,7 @@ func TestNewInterpreter(t *testing.T) {
 		DefaultMockTargetEntity,
 		mockedEnv.GetEventPayload(),
 		mockedEnv.GetBuiltIns(),
+		nil,
 	)
 
 	assert.Nil(t, err)
@@ -988,6 +990,7 @@ func TestReportMetric(t *testing.T) {
 				env.GetGithubClient(),
 				env.GetCollector(),
 				env.GetTarget().GetTargetEntity(),
+				nil,
 				nil,
 				nil,
 			)

--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -317,6 +317,7 @@ func mockEnvWith(prOwner string, prRepoName string, prNum int, githubClient *gh.
 		targetEntity,
 		eventPayload,
 		builtIns,
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -16,6 +16,7 @@ import (
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	gh "github.com/reviewpad/reviewpad/v3/codehost/github"
 	"github.com/reviewpad/reviewpad/v3/collector"
+	"github.com/reviewpad/reviewpad/v3/engine"
 	"github.com/reviewpad/reviewpad/v3/handler"
 	"github.com/reviewpad/reviewpad/v3/utils"
 	"github.com/shurcooL/githubv4"
@@ -305,7 +306,7 @@ func mockHttpClientWith(clientOptions ...mock.MockBackendOption) *http.Client {
 	return mock.NewMockedHTTPClient(clientOptions...)
 }
 
-func mockEnvWith(prOwner string, prRepoName string, prNum int, githubClient *gh.GithubClient, eventPayload interface{}, builtIns *BuiltIns, targetEntity *handler.TargetEntity) (Env, error) {
+func mockEnvWith(prOwner string, prRepoName string, prNum int, githubClient *gh.GithubClient, eventPayload interface{}, builtIns *BuiltIns, targetEntity *handler.TargetEntity, configFile *engine.ReviewpadFile) (Env, error) {
 	ctx := context.Background()
 
 	env, err := NewEvalEnv(
@@ -317,7 +318,7 @@ func mockEnvWith(prOwner string, prRepoName string, prNum int, githubClient *gh.
 		targetEntity,
 		eventPayload,
 		builtIns,
-		nil,
+		configFile,
 	)
 	if err != nil {
 		return nil, err
@@ -404,7 +405,7 @@ func MockDefaultEnv(
 	prNum := DefaultMockPrNum
 	githubClient := MockDefaultGithubClient(ghApiClientOptions, ghGraphQLHandler)
 
-	mockedEnv, err := mockEnvWith(prOwner, prRepoName, prNum, githubClient, eventPayload, builtIns, DefaultMockTargetEntity)
+	mockedEnv, err := mockEnvWith(prOwner, prRepoName, prNum, githubClient, eventPayload, builtIns, DefaultMockTargetEntity, nil)
 	if err != nil {
 		t.Fatalf("[MockDefaultEnv] failed to create mock env: %v", err)
 	}
@@ -426,9 +427,31 @@ func MockDefaultEnvWithTargetEntity(
 	prNum := DefaultMockPrNum
 	githubClient := MockDefaultGithubClient(ghApiClientOptions, ghGraphQLHandler)
 
-	mockedEnv, err := mockEnvWith(prOwner, prRepoName, prNum, githubClient, eventPayload, builtIns, targetEntity)
+	mockedEnv, err := mockEnvWith(prOwner, prRepoName, prNum, githubClient, eventPayload, builtIns, targetEntity, nil)
 	if err != nil {
 		t.Fatalf("[MockDefaultEnvWithTargetEntity] failed to create mock env: %v", err)
+	}
+
+	return mockedEnv
+}
+
+// MockDefaultEnvWithReviewpadFile mocks an Aladino Env with default values and a custom Reviewpad config file.
+func MockDefaultEnvWithReviewpadFile(
+	t *testing.T,
+	ghApiClientOptions []mock.MockBackendOption,
+	ghGraphQLHandler func(http.ResponseWriter, *http.Request),
+	builtIns *BuiltIns,
+	eventPayload interface{},
+	configFile *engine.ReviewpadFile,
+) Env {
+	prOwner := DefaultMockPrOwner
+	prRepoName := DefaultMockPrRepoName
+	prNum := DefaultMockPrNum
+	githubClient := MockDefaultGithubClient(ghApiClientOptions, ghGraphQLHandler)
+
+	mockedEnv, err := mockEnvWith(prOwner, prRepoName, prNum, githubClient, eventPayload, builtIns, DefaultMockTargetEntity, configFile)
+	if err != nil {
+		t.Fatalf("[MockDefaultEnvWithReviewpadFile] failed to create mock env: %v", err)
 	}
 
 	return mockedEnv

--- a/plugins/aladino/actions/dryRun.go
+++ b/plugins/aladino/actions/dryRun.go
@@ -153,7 +153,7 @@ func buildReport(e aladino.Env, program *engine.Program) (string, error) {
 	}
 
 	// Annotation
-	report.WriteString("<!--@annotation-reviewpad-report-triggered-by-dry-run-command-->")
+	report.WriteString("<!--@annotation-reviewpad-report-triggered-by-dry-run-command-->\n")
 	// Header
 	report.WriteString("**Reviewpad Report** (Reviewpad ran in dry-run mode because the `$dryRun() action was triggered`)\n\n")
 

--- a/plugins/aladino/actions/dryRun.go
+++ b/plugins/aladino/actions/dryRun.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/reviewpad/reviewpad/v3/engine"
 	"github.com/reviewpad/reviewpad/v3/handler"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
@@ -23,7 +24,7 @@ func DryRun() *aladino.BuiltInAction {
 
 func dryRunCode(e aladino.Env, args []aladino.Value) error {
 	configFile := e.GetConfigFile()
-	if configFile == nil {
+	if cmp.Equal(configFile, &engine.ReviewpadFile{}) {
 		return nil
 	}
 
@@ -161,8 +162,12 @@ func buildReport(e aladino.Env, program *engine.Program) (string, error) {
 	report.WriteString("```yaml\n")
 
 	// Report
-	for _, action := range executedActions {
-		report.WriteString(fmt.Sprintf("%v\n", action))
+	if len(executedActions) == 0 {
+		report.WriteString("No action triggered")
+	} else {
+		for _, action := range executedActions {
+			report.WriteString(fmt.Sprintf("%v\n", action))
+		}
 	}
 
 	report.WriteString("```\n")

--- a/plugins/aladino/actions/dryRun.go
+++ b/plugins/aladino/actions/dryRun.go
@@ -155,7 +155,7 @@ func buildReport(e aladino.Env, program *engine.Program) (string, error) {
 	// Annotation
 	report.WriteString("<!--@annotation-reviewpad-report-triggered-by-dry-run-command-->\n")
 	// Header
-	report.WriteString("**Reviewpad Report** (Reviewpad ran in dry-run mode because the `$dryRun() action was triggered`)\n\n")
+	report.WriteString("**Reviewpad Report** (Reviewpad ran in dry-run mode because the `$dryRun()` action was triggered)\n\n")
 
 	report.WriteString(":scroll: **Executed actions**\n")
 	report.WriteString("```yaml\n")

--- a/plugins/aladino/actions/dryRun.go
+++ b/plugins/aladino/actions/dryRun.go
@@ -1,0 +1,171 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_actions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/reviewpad/reviewpad/v3/engine"
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+)
+
+func DryRun() *aladino.BuiltInAction {
+	return &aladino.BuiltInAction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{}, nil),
+		Code:           dryRunCode,
+		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest},
+	}
+}
+
+func dryRunCode(e aladino.Env, args []aladino.Value) error {
+	configFile := e.GetConfigFile()
+	if configFile == nil {
+		return nil
+	}
+
+	program, err := buildProgram(e, configFile)
+	if err != nil {
+		return err
+	}
+
+	report, err := buildReport(e, program)
+	if err != nil {
+		return err
+	}
+
+	return aladino.AddReportComment(e, report)
+}
+
+func buildProgram(e aladino.Env, file *engine.ReviewpadFile) (*engine.Program, error) {
+	// a program is a list of statements to be executed based on the command, workflow rules and actions.
+	program := engine.BuildProgram(make([]*engine.Statement, 0))
+
+	rules := make(map[string]engine.PadRule)
+	for _, rule := range file.Rules {
+		rules[rule.Name] = rule
+	}
+
+	// triggeredExclusiveWorkflow is a control variable to denote if a workflow `always-run: false` has been triggered.
+	triggeredExclusiveWorkflow := false
+
+	for _, workflow := range file.Workflows {
+		if !workflow.AlwaysRun && triggeredExclusiveWorkflow {
+			continue
+		}
+
+		ruleActivatedQueue := make([]engine.PadWorkflowRule, 0)
+		ruleDefinitionQueue := make(map[string]engine.PadRule)
+
+		shouldRun := false
+		for _, eventKind := range workflow.On {
+			if eventKind == e.GetTarget().GetTargetEntity().Kind {
+				shouldRun = true
+				break
+			}
+		}
+
+		if !shouldRun {
+			continue
+		}
+
+		for _, rule := range workflow.Rules {
+			ruleName := rule.Rule
+			ruleDefinition := rules[ruleName]
+
+			activated, err := aladino.EvalExpr(e, ruleDefinition.Kind, ruleDefinition.Spec)
+			if err != nil {
+				return nil, err
+			}
+
+			if activated {
+				ruleActivatedQueue = append(ruleActivatedQueue, rule)
+				ruleDefinitionQueue[ruleName] = ruleDefinition
+			}
+		}
+
+		if len(ruleActivatedQueue) > 0 {
+			program.Append(workflow.Actions)
+
+			for _, activatedRule := range ruleActivatedQueue {
+				program.Append(activatedRule.ExtraActions)
+			}
+
+			if !workflow.AlwaysRun {
+				triggeredExclusiveWorkflow = true
+			}
+		}
+	}
+
+	for _, pipeline := range file.Pipelines {
+		var err error
+		activated := pipeline.Trigger == ""
+		if !activated {
+			activated, err = aladino.EvalExpr(e, "patch", pipeline.Trigger)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if activated {
+			for _, stage := range pipeline.Stages {
+				if stage.Until == "" {
+					program.Append(stage.Actions)
+					break
+				}
+
+				isDone, err := aladino.EvalExpr(e, "patch", stage.Until)
+				if err != nil {
+					return nil, err
+				}
+
+				if !isDone {
+					program.Append(stage.Actions)
+					break
+				}
+			}
+		}
+	}
+
+	return program, nil
+}
+
+func buildReport(e aladino.Env, program *engine.Program) (string, error) {
+	var report strings.Builder
+	executedActions := []string{}
+
+	for _, statement := range program.GetProgramStatements() {
+		statRaw := statement.GetStatementCode()
+		statAST, err := aladino.Parse(statRaw)
+		if err != nil {
+			return "", err
+		}
+
+		_, err = aladino.TypeCheckExec(e, statAST)
+		if err != nil {
+			return "", err
+		}
+
+		executedActions = append(executedActions, statement.GetStatementCode())
+	}
+
+	// Annotation
+	report.WriteString("<!--@annotation-reviewpad-report-triggered-by-dry-run-command-->")
+	// Header
+	report.WriteString("**Reviewpad Report** (Reviewpad ran in dry-run mode because the `$dryRun() action was triggered`)\n\n")
+
+	report.WriteString(":scroll: **Executed actions**\n")
+	report.WriteString("```yaml\n")
+
+	// Report
+	for _, action := range executedActions {
+		report.WriteString(fmt.Sprintf("%v\n", action))
+	}
+
+	report.WriteString("```\n")
+
+	return report.String(), nil
+}

--- a/plugins/aladino/actions/dryRun_test.go
+++ b/plugins/aladino/actions/dryRun_test.go
@@ -1,0 +1,240 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_actions_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v49/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v3/engine"
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+	"github.com/reviewpad/reviewpad/v3/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var dryRun = plugins_aladino.PluginBuiltIns().Actions["dryRun"].Code
+
+func TestDryRun(t *testing.T) {
+	var gotReport string
+	tests := map[string]struct {
+		clientOptions []mock.MockBackendOption
+		reviewpadFile *engine.ReviewpadFile
+		wantReport    string
+		wantErr       error
+	}{
+		"when there is no reviewpad file": {
+			reviewpadFile: &engine.ReviewpadFile{},
+			wantErr:       nil,
+		},
+		"when program fails to build due to bad rule syntax": {
+			reviewpadFile: &engine.ReviewpadFile{
+				Rules: []engine.PadRule{
+					{
+						Name: "tautology",
+						Spec: "1 == ",
+					},
+				},
+				Workflows: []engine.PadWorkflow{
+					{
+						Name: "test",
+						On: []handler.TargetEntityKind{
+							"pull_request",
+						},
+						Rules: []engine.PadWorkflowRule{
+							{
+								Rule:         "tautology",
+								ExtraActions: []string{"$addLabel(\"test\")"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: fmt.Errorf("parse error: failed to build AST on input 1 == "),
+		},
+		"when program fails to build due to bad pipeline trigger syntax": {
+			reviewpadFile: &engine.ReviewpadFile{
+				Rules: []engine.PadRule{
+					{
+						Name: "tautology",
+						Spec: "1 == 1",
+					},
+				},
+				Workflows: []engine.PadWorkflow{
+					{
+						Name: "test",
+						On: []handler.TargetEntityKind{
+							"pull_request",
+						},
+						Rules: []engine.PadWorkflowRule{
+							{
+								Rule:         "tautology",
+								ExtraActions: []string{"$addLabel(\"test\")"},
+							},
+						},
+					},
+				},
+				Pipelines: []engine.PadPipeline{
+					{
+						Name:    "test",
+						Trigger: "1 == ",
+						Stages: []engine.PadStage{
+							{
+								Actions: []string{
+									"$addLabel(\"test\")",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: fmt.Errorf("parse error: failed to build AST on input 1 == "),
+		},
+		"when program fails to build due to bad pipeline stage actions syntax": {
+			reviewpadFile: &engine.ReviewpadFile{
+				Pipelines: []engine.PadPipeline{
+					{
+						Name:    "test",
+						Trigger: "1 == 1",
+						Stages: []engine.PadStage{
+							{
+								Actions: []string{
+									"$dummy()",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: fmt.Errorf("no type for built-in dummy. Please check if the mode in the reviewpad.yml file supports it"),
+		},
+		"when program fails to build due to bad pipeline stage until syntax": {
+			reviewpadFile: &engine.ReviewpadFile{
+				Pipelines: []engine.PadPipeline{
+					{
+						Name:    "test",
+						Trigger: "1 == 1",
+						Stages: []engine.PadStage{
+							{
+								Actions: []string{
+									"$addLabel(\"test\")",
+								},
+								Until: "1 ==",
+							},
+						},
+					},
+				},
+			},
+			wantErr: fmt.Errorf("parse error: failed to build AST on input 1 =="),
+		},
+		"when report fails to be posted": {
+			clientOptions: []mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						mock.WriteError(
+							w,
+							http.StatusInternalServerError,
+							"CreateCommentRequestFailed",
+						)
+					}),
+				),
+			},
+			reviewpadFile: &engine.ReviewpadFile{
+				Pipelines: []engine.PadPipeline{
+					{
+						Name:    "test",
+						Trigger: "1 == 1",
+						Stages: []engine.PadStage{
+							{
+								Actions: []string{
+									"$addLabel(\"test\")",
+								},
+								Until: "1 == 1",
+							},
+						},
+					},
+				},
+			},
+			wantErr: fmt.Errorf("error on creating report comment "),
+		},
+		"when dry run is performed successfully": {
+			clientOptions: []mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						rawBody, _ := io.ReadAll(r.Body)
+						body := github.IssueComment{}
+
+						utils.MustUnmarshal(rawBody, &body)
+
+						gotReport = *body.Body
+					}),
+				),
+			},
+			reviewpadFile: &engine.ReviewpadFile{
+				Rules: []engine.PadRule{
+					{
+						Name: "tautology",
+						Spec: "1 == 1",
+					},
+				},
+				Workflows: []engine.PadWorkflow{
+					{
+						Name: "test",
+						On: []handler.TargetEntityKind{
+							"pull_request",
+						},
+						Rules: []engine.PadWorkflowRule{
+							{
+								Rule: "tautology",
+							},
+						},
+						Actions: []string{"$addLabel(\"test-1\")"},
+					},
+				},
+				Pipelines: []engine.PadPipeline{
+					{
+						Name:    "test",
+						Trigger: "1 == 1",
+						Stages: []engine.PadStage{
+							{
+								Actions: []string{
+									"$addLabel(\"test-2\")",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantReport: "<!--@annotation-reviewpad-report-triggered-by-dry-run-command-->\n**Reviewpad Report** (Reviewpad ran in dry-run mode because the `$dryRun()` action was triggered)\n\n:scroll: **Executed actions**\n```yaml\n$addLabel(\"test-1\")\n$addLabel(\"test-2\")\n```\n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedEnv := aladino.MockDefaultEnvWithReviewpadFile(
+				t,
+				test.clientOptions,
+				nil,
+				plugins_aladino.PluginBuiltIns(),
+				nil,
+				test.reviewpadFile,
+			)
+			args := []aladino.Value{}
+			gotErr := dryRun(mockedEnv, args)
+
+			assert.Equal(t, test.wantReport, gotReport)
+			assert.Equal(t, test.wantErr, gotErr)
+
+			gotReport = ""
+		})
+	}
+}

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -141,6 +141,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"commitLint":           actions.CommitLint(),
 			"deleteHeadBranch":     actions.DeleteHeadBranch(),
 			"disableActions":       actions.DisableActions(),
+			"dryRun":               actions.DryRun(),
 			"error":                actions.ErrorMsg(),
 			"fail":                 actions.Fail(),
 			"info":                 actions.Info(),

--- a/runner.go
+++ b/runner.go
@@ -261,7 +261,7 @@ func Run(
 
 	defer config.CleanupPluginConfig()
 
-	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, collector, targetEntity, eventPayload, plugins_aladino.PluginBuiltInsWithConfig(config))
+	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, collector, targetEntity, eventPayload, plugins_aladino.PluginBuiltInsWithConfig(config), reviewpadFile)
 	if err != nil {
 		return engine.ExitStatusFailure, nil, err
 	}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request introduces the `dry-run` command which in order to be executed needed the `$dryRun()` built-in.
During the development of the tests for the `$dryRun()` built-in, a new `MockDefaultEnv` function was added to create a mock env with a custom reviewpad config file. However, this mocked env creation should happen on the `MockDefaultEnv` main function with a new argument in its signature which would be the custom reviewpad config file; nevertheless, this change would introduce many other changes since this function is used in almost all the test files. Said that I would propose we do those changes in a separate PR since it is unrelated to the main feature of this PR.

## Related issue

<!-- Closes # (issue) -->
Closes #617 

## Type of change

<!-- Uncomment the suitable types of change from the options below: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality not to work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Manual tests in the Reviewpad GitHub Action and in the Reviewpad GitHub App as well as the execution of the `task check` command.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have run `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post-merge --> 
- [x] Ask: this pull request requires a code review before the merge
