### PR TITLE
fix: delete head branch reference does not exist issue

### DIFF
--- a/plugins/aladino/actions/deleteHeadBranch.go
+++ b/plugins/aladino/actions/deleteHeadBranch.go
@@ -27,6 +27,7 @@ func deleteHeadBranch(e aladino.Env, args []aladino.Value) error {
 	}
 
 	if target.PullRequest.GetHead().GetRepo().GetFork() {
+		e.GetLogger().Warnln("$deleteHeadBranch built-in action doesn't work across forks")
 		return nil
 	}
 

--- a/plugins/aladino/actions/deleteHeadBranch.go
+++ b/plugins/aladino/actions/deleteHeadBranch.go
@@ -26,5 +26,9 @@ func deleteHeadBranch(e aladino.Env, args []aladino.Value) error {
 		return nil
 	}
 
+	if target.PullRequest.GetHead().GetRepo().GetFork() {
+		return nil
+	}
+
 	return e.GetGithubClient().DeleteReference(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, "heads/"+*target.PullRequest.Head.Ref)
 }

--- a/plugins/aladino/actions/deleteHeadBranch_test.go
+++ b/plugins/aladino/actions/deleteHeadBranch_test.go
@@ -121,8 +121,7 @@ func TestDeleteHeadBranch(t *testing.T) {
 					mock.GetReposPullsByOwnerByRepoByPullNumber,
 					http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 						utils.MustWriteBytes(w, mock.MustMarshal(aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
-							Merged:   github.Bool(true),
-							ClosedAt: nil,
+							Merged: github.Bool(true),
 							Head: &github.PullRequestBranch{
 								Repo: &github.Repository{
 									Fork: github.Bool(true),

--- a/plugins/aladino/actions/deleteHeadBranch_test.go
+++ b/plugins/aladino/actions/deleteHeadBranch_test.go
@@ -115,6 +115,25 @@ func TestDeleteHeadBranch(t *testing.T) {
 				DocumentationURL: "https://docs.github.com/rest/reference/git#delete-a-reference",
 			},
 		},
+		"when pull request is from fork": {
+			clientOptions: []mock.MockBackendOption{
+				mock.WithRequestMatchHandler(
+					mock.GetReposPullsByOwnerByRepoByPullNumber,
+					http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+						utils.MustWriteBytes(w, mock.MustMarshal(aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
+							Merged:   github.Bool(true),
+							ClosedAt: nil,
+							Head: &github.PullRequestBranch{
+								Repo: &github.Repository{
+									Fork: github.Bool(true),
+								},
+							},
+						})))
+					}),
+				),
+			},
+			err: nil,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
## Description
Checks a pull request isn't from a fork before attempting to delete the head branch on the `$deleteHeadBranch` built-in action. Attempting to delete the head branch of the pull request without checking if it's from a fork causes the `Reference does not exist` error
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #620 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit & Manual tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
