### PR TITLE
refactor: rebase token from client

### DIFF
--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -18,6 +18,7 @@ import (
 type GithubClient struct {
 	clientREST *github.Client
 	clientGQL  *githubv4.Client
+	token      string
 }
 
 type GithubAppClient struct {
@@ -43,6 +44,7 @@ func NewGithubClientFromToken(ctx context.Context, token string) *GithubClient {
 	return &GithubClient{
 		clientREST: clientREST,
 		clientGQL:  clientGQL,
+		token:      token,
 	}
 }
 
@@ -53,6 +55,10 @@ func (c *GithubClient) GetClientREST() *github.Client {
 
 func (c *GithubClient) GetClientGraphQL() *githubv4.Client {
 	return c.clientGQL
+}
+
+func (c *GithubClient) GetToken() string {
+	return c.token
 }
 
 func NewGithubAppClient(gitHubAppID int64, gitHubAppPrivateKey []byte) (*GithubAppClient, error) {

--- a/codehost/github/repo.go
+++ b/codehost/github/repo.go
@@ -31,7 +31,7 @@ func CloneRepository(log *logrus.Entry, url string, token string, path string, o
 	// TODO: Validate url has the correct format
 	splitted := strings.Split(url, "https://")
 	if token != "" {
-		url = fmt.Sprintf("https://x-access-token:%v@%v", token, splitted[1])
+		url = fmt.Sprintf("https://%v@%v", token, splitted[1])
 	}
 
 	log.Infof("cloning %s to %s", url, dir)

--- a/codehost/github/repo.go
+++ b/codehost/github/repo.go
@@ -31,7 +31,7 @@ func CloneRepository(log *logrus.Entry, url string, token string, path string, o
 	// TODO: Validate url has the correct format
 	splitted := strings.Split(url, "https://")
 	if token != "" {
-		url = fmt.Sprintf("https://%v@%v", token, splitted[1])
+		url = fmt.Sprintf("https://x-access-token:%v@%v", token, splitted[1])
 	}
 
 	log.Infof("cloning %s to %s", url, dir)

--- a/plugins/aladino/actions/rebase.go
+++ b/plugins/aladino/actions/rebase.go
@@ -24,7 +24,7 @@ func Rebase() *aladino.BuiltInAction {
 }
 
 func rebaseCode(e aladino.Env, args []aladino.Value) error {
-	githubToken := os.Getenv("INPUT_TOKEN")
+	githubToken := e.GetGithubClient().GetToken()
 	log := e.GetLogger().WithField("builtin", "rebase")
 	t := e.GetTarget().(*target.PullRequestTarget)
 	pr := t.PullRequest


### PR DESCRIPTION
## Description
Currently, we are getting the github token for the `rebase` built-in through the `INPUT_TOKEN` env variable, the problem is the `$rebase` built-in will fail if that env isn't present, this PR updates the built-in so it can get it's token from the github client.
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #633 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Manual tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
