### PR TITLE
refactor: remove event from reviewpad run input

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -125,7 +125,7 @@ func run() error {
 
 	for _, targetEntity := range targetEntities {
 		log.Infof("Processing entity %s/%s#%d", targetEntity.Owner, targetEntity.Repo, targetEntity.Number)
-		_, _, err = reviewpad.Run(ctx, log, gitHubClient, collectorClient, targetEntity, eventDetails, event, file, dryRun, safeModeRun)
+		_, _, err = reviewpad.Run(ctx, log, gitHubClient, collectorClient, targetEntity, eventDetails, file, dryRun, safeModeRun)
 		if err != nil {
 			return fmt.Errorf("error running reviewpad team edition. Details %v", err.Error())
 		}

--- a/runner.go
+++ b/runner.go
@@ -249,7 +249,6 @@ func Run(
 	collector collector.Collector,
 	targetEntity *handler.TargetEntity,
 	eventDetails *handler.EventDetails,
-	eventPayload interface{},
 	reviewpadFile *engine.ReviewpadFile,
 	dryRun bool,
 	safeMode bool,
@@ -261,7 +260,7 @@ func Run(
 
 	defer config.CleanupPluginConfig()
 
-	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, collector, targetEntity, eventPayload, plugins_aladino.PluginBuiltInsWithConfig(config))
+	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, collector, targetEntity, eventDetails.Payload, plugins_aladino.PluginBuiltInsWithConfig(config))
 	if err != nil {
 		return engine.ExitStatusFailure, nil, err
 	}


### PR DESCRIPTION
## Description

This is a basic refactor that removes the event payload as it is already passed in the event details.

## Related issue

Closes #615.

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality) 
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Unit tests.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge 
