### PR TITLE
feat: add annotation to ignore comment

### DIFF
--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -224,7 +224,7 @@ func (i *Interpreter) ReportMetrics() error {
 			return err
 		}
 
-		r := ReviewpadMetricReportCommentAnnotation + "\n## 📈 Pull Request Metrics\n" + report.String()
+		r := fmt.Sprintf("%s%s\n## 📈 Pull Request Metrics\n%s", ReviewpadMetricReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation, report.String())
 
 		if comment == nil {
 			err = AddReportComment(i.Env, r)

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -559,7 +559,7 @@ func TestReport_OnSilentMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 				[]*github.IssueComment{
 					{
 						ID:   github.Int64(1234),
-						Body: github.String("<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated"),
+						Body: github.String(fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)),
 					},
 				},
 			),
@@ -620,7 +620,7 @@ func TestReport_OnSilentMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 
 func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 	var addedComment string
-	commentToBeAdded := "<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\n```\n"
+	commentToBeAdded := fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\n```\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
 	mockedEnv := MockDefaultEnv(
 		t,
 		[]mock.MockBackendOption{
@@ -657,7 +657,7 @@ func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 
 func TestReport_OnVerboseMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 	var updatedComment string
-	commentUpdated := "<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\n```\n"
+	commentUpdated := fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\n```\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
 	mockedEnv := MockDefaultEnv(
 		t,
 		[]mock.MockBackendOption{
@@ -666,7 +666,7 @@ func TestReport_OnVerboseMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) 
 				[]*github.IssueComment{
 					{
 						ID:   github.Int64(1234),
-						Body: github.String("<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n**:information_source: Messages**\n* Changes the README.md"),
+						Body: github.String(fmt.Sprintf("%s%s\n**Reviewpad Report**\n**:information_source: Messages**\n* Changes the README.md", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)),
 					},
 				},
 			),

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -559,7 +559,7 @@ func TestReport_OnSilentMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 				[]*github.IssueComment{
 					{
 						ID:   github.Int64(1234),
-						Body: github.String("<!--@annotation-reviewpad-report-->\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated"),
+						Body: github.String("<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated"),
 					},
 				},
 			),
@@ -620,7 +620,7 @@ func TestReport_OnSilentMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 
 func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 	var addedComment string
-	commentToBeAdded := "<!--@annotation-reviewpad-report-->\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\n```\n"
+	commentToBeAdded := "<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\n```\n"
 	mockedEnv := MockDefaultEnv(
 		t,
 		[]mock.MockBackendOption{
@@ -657,7 +657,7 @@ func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 
 func TestReport_OnVerboseMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 	var updatedComment string
-	commentUpdated := "<!--@annotation-reviewpad-report-->\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\n```\n"
+	commentUpdated := "<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\n```\n"
 	mockedEnv := MockDefaultEnv(
 		t,
 		[]mock.MockBackendOption{
@@ -666,7 +666,7 @@ func TestReport_OnVerboseMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) 
 				[]*github.IssueComment{
 					{
 						ID:   github.Int64(1234),
-						Body: github.String("<!--@annotation-reviewpad-report-->\n**Reviewpad Report**\n**:information_source: Messages**\n* Changes the README.md"),
+						Body: github.String("<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n**:information_source: Messages**\n* Changes the README.md"),
 					},
 				},
 			),

--- a/lang/aladino/report.go
+++ b/lang/aladino/report.go
@@ -17,6 +17,7 @@ type Report struct {
 	Actions []string
 }
 
+const ReviewpadIgnoreCommentAnnotation = "<!--@annotation-reviewpad-ignore-->"
 const ReviewpadReportCommentAnnotation = "<!--@annotation-reviewpad-report-->"
 const ReviewpadMetricReportCommentAnnotation = "<!--@annotation-reviewpad-metric-report-->"
 
@@ -27,8 +28,8 @@ func (report *Report) addToReport(statement *engine.Statement) {
 func ReportHeader(safeMode bool) string {
 	var sb strings.Builder
 
-	// Annotation
-	sb.WriteString(fmt.Sprintf("%v\n", ReviewpadReportCommentAnnotation))
+	// Annotations
+	sb.WriteString(fmt.Sprintf("%v%v\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation))
 	// Header
 	if safeMode {
 		sb.WriteString("**Reviewpad Report** (Reviewpad ran in dry-run mode because configuration has changed)\n\n")

--- a/lang/aladino/report.go
+++ b/lang/aladino/report.go
@@ -29,7 +29,7 @@ func ReportHeader(safeMode bool) string {
 	var sb strings.Builder
 
 	// Annotations
-	sb.WriteString(fmt.Sprintf("%v%v\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation))
+	sb.WriteString(fmt.Sprintf("%s%s\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation))
 	// Header
 	if safeMode {
 		sb.WriteString("**Reviewpad Report** (Reviewpad ran in dry-run mode because configuration has changed)\n\n")

--- a/lang/aladino/report_internal_test.go
+++ b/lang/aladino/report_internal_test.go
@@ -49,7 +49,7 @@ func TestAddToReport(t *testing.T) {
 }
 
 func TestReportHeader(t *testing.T) {
-	wantReportHeader := "<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n\n"
+	wantReportHeader := fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
 
 	gotReportHeader := ReportHeader(false)
 
@@ -57,7 +57,7 @@ func TestReportHeader(t *testing.T) {
 }
 
 func TestReportHeader_WhenSafeMode(t *testing.T) {
-	wantReportHeader := "<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report** (Reviewpad ran in dry-run mode because configuration has changed)\n\n"
+	wantReportHeader := fmt.Sprintf("%s%s\n**Reviewpad Report** (Reviewpad ran in dry-run mode because configuration has changed)\n\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
 
 	gotReportHeader := ReportHeader(true)
 
@@ -69,11 +69,11 @@ func TestBuildReport(t *testing.T) {
 		Actions: []string{"$addLabel(\"test\")"},
 	}
 
-	wantReport := `<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->
+	wantReport := fmt.Sprintf(`%s%s
 **Reviewpad Report**
 
 :scroll: **Executed actions**
-` + "```yaml\n$addLabel(\"test\")\n```\n"
+`, ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation) + "```yaml\n$addLabel(\"test\")\n```\n"
 
 	gotReport := buildReport(engine.VERBOSE_MODE, false, make(map[Severity][]string), &report)
 
@@ -317,7 +317,7 @@ func TestFindReportComment_WhenPullRequestCommentsListingFails(t *testing.T) {
 
 func TestFindReportComment_WhenThereIsReviewpadComment(t *testing.T) {
 	wantComment := &github.IssueComment{
-		Body: github.String("<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated"),
+		Body: github.String(fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)),
 	}
 	mockedEnv := MockDefaultEnv(
 		t,

--- a/lang/aladino/report_internal_test.go
+++ b/lang/aladino/report_internal_test.go
@@ -49,7 +49,7 @@ func TestAddToReport(t *testing.T) {
 }
 
 func TestReportHeader(t *testing.T) {
-	wantReportHeader := "<!--@annotation-reviewpad-report-->\n**Reviewpad Report**\n\n"
+	wantReportHeader := "<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n\n"
 
 	gotReportHeader := ReportHeader(false)
 
@@ -57,7 +57,7 @@ func TestReportHeader(t *testing.T) {
 }
 
 func TestReportHeader_WhenSafeMode(t *testing.T) {
-	wantReportHeader := "<!--@annotation-reviewpad-report-->\n**Reviewpad Report** (Reviewpad ran in dry-run mode because configuration has changed)\n\n"
+	wantReportHeader := "<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report** (Reviewpad ran in dry-run mode because configuration has changed)\n\n"
 
 	gotReportHeader := ReportHeader(true)
 
@@ -69,7 +69,7 @@ func TestBuildReport(t *testing.T) {
 		Actions: []string{"$addLabel(\"test\")"},
 	}
 
-	wantReport := `<!--@annotation-reviewpad-report-->
+	wantReport := `<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->
 **Reviewpad Report**
 
 :scroll: **Executed actions**
@@ -317,7 +317,7 @@ func TestFindReportComment_WhenPullRequestCommentsListingFails(t *testing.T) {
 
 func TestFindReportComment_WhenThereIsReviewpadComment(t *testing.T) {
 	wantComment := &github.IssueComment{
-		Body: github.String("<!--@annotation-reviewpad-report-->\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated"),
+		Body: github.String("<!--@annotation-reviewpad-report--><!--@annotation-reviewpad-ignore-->\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated"),
 	}
 	mockedEnv := MockDefaultEnv(
 		t,

--- a/plugins/aladino/actions/comment.go
+++ b/plugins/aladino/actions/comment.go
@@ -5,6 +5,8 @@
 package plugins_aladino_actions
 
 import (
+	"fmt"
+
 	"github.com/reviewpad/reviewpad/v3/handler"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
 )
@@ -20,6 +22,7 @@ func Comment() *aladino.BuiltInAction {
 func commentCode(e aladino.Env, args []aladino.Value) error {
 	t := e.GetTarget()
 	commentBody := args[0].(*aladino.StringValue).Val
+	commentBodyWithReviewpadAnnotation := fmt.Sprintf("%s\n%s", aladino.ReviewpadIgnoreCommentAnnotation, commentBody)
 
-	return t.Comment(commentBody)
+	return t.Comment(commentBodyWithReviewpadAnnotation)
 }

--- a/plugins/aladino/actions/commentOnce.go
+++ b/plugins/aladino/actions/commentOnce.go
@@ -26,7 +26,7 @@ func commentOnceCode(e aladino.Env, args []aladino.Value) error {
 	t := e.GetTarget()
 
 	commentBody := args[0].(*aladino.StringValue).Val
-	commentBodyWithReviewpadAnnotation := fmt.Sprintf("%v%v", ReviewpadCommentAnnotation, commentBody)
+	commentBodyWithReviewpadAnnotation := fmt.Sprintf("%s%s\n%s", ReviewpadCommentAnnotation, aladino.ReviewpadIgnoreCommentAnnotation, commentBody)
 	commentBodyWithReviewpadAnnotationHash := sha256.Sum256([]byte(commentBodyWithReviewpadAnnotation))
 
 	comments, err := t.GetComments()

--- a/plugins/aladino/actions/commentOnce_test.go
+++ b/plugins/aladino/actions/commentOnce_test.go
@@ -61,7 +61,7 @@ func TestCommentOnce_WhenCommentAlreadyExists(t *testing.T) {
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 				[]*github.IssueComment{
 					{
-						Body: github.String(fmt.Sprintf("%v%v", ReviewpadCommentAnnotation, existingComment)),
+						Body: github.String(fmt.Sprintf("%v<!--@annotation-reviewpad-ignore-->\n%v", ReviewpadCommentAnnotation, existingComment)),
 					},
 				},
 			),
@@ -117,5 +117,5 @@ func TestCommentOnce_WhenFirstTime(t *testing.T) {
 	err := commentOnce(mockedEnv, args)
 
 	assert.Nil(t, err)
-	assert.Equal(t, fmt.Sprintf("%v%v", ReviewpadCommentAnnotation, commentToAdd), addedComment)
+	assert.Equal(t, fmt.Sprintf("%v<!--@annotation-reviewpad-ignore-->\n%v", ReviewpadCommentAnnotation, commentToAdd), addedComment)
 }

--- a/plugins/aladino/actions/commentOnce_test.go
+++ b/plugins/aladino/actions/commentOnce_test.go
@@ -44,7 +44,7 @@ func TestCommentOnce_WhenGetCommentsRequestFails(t *testing.T) {
 		nil,
 	)
 
-	args := []aladino.Value{aladino.BuildStringValue(fmt.Sprintf("%v%v", ReviewpadCommentAnnotation, comment))}
+	args := []aladino.Value{aladino.BuildStringValue(fmt.Sprintf("%s%s", ReviewpadCommentAnnotation, comment))}
 	err := commentOnce(mockedEnv, args)
 
 	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
@@ -61,7 +61,7 @@ func TestCommentOnce_WhenCommentAlreadyExists(t *testing.T) {
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 				[]*github.IssueComment{
 					{
-						Body: github.String(fmt.Sprintf("%v<!--@annotation-reviewpad-ignore-->\n%v", ReviewpadCommentAnnotation, existingComment)),
+						Body: github.String(fmt.Sprintf("%s%s\n%s", ReviewpadCommentAnnotation, aladino.ReviewpadIgnoreCommentAnnotation, existingComment)),
 					},
 				},
 			),
@@ -117,5 +117,5 @@ func TestCommentOnce_WhenFirstTime(t *testing.T) {
 	err := commentOnce(mockedEnv, args)
 
 	assert.Nil(t, err)
-	assert.Equal(t, fmt.Sprintf("%v<!--@annotation-reviewpad-ignore-->\n%v", ReviewpadCommentAnnotation, commentToAdd), addedComment)
+	assert.Equal(t, fmt.Sprintf("%s%s\n%s", ReviewpadCommentAnnotation, aladino.ReviewpadIgnoreCommentAnnotation, commentToAdd), addedComment)
 }

--- a/plugins/aladino/actions/comment_test.go
+++ b/plugins/aladino/actions/comment_test.go
@@ -22,7 +22,7 @@ var comment = plugins_aladino.PluginBuiltIns().Actions["comment"].Code
 
 func TestComment(t *testing.T) {
 	rawComment := "Lorem Ipsum"
-	wantComment := fmt.Sprintf("<!--@annotation-reviewpad-ignore-->\n%v", rawComment)
+	wantComment := fmt.Sprintf("%s\n%s", aladino.ReviewpadIgnoreCommentAnnotation, rawComment)
 	gotComment := ""
 
 	mockedEnv := aladino.MockDefaultEnv(

--- a/plugins/aladino/actions/comment_test.go
+++ b/plugins/aladino/actions/comment_test.go
@@ -5,6 +5,7 @@
 package plugins_aladino_actions_test
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -20,7 +21,8 @@ import (
 var comment = plugins_aladino.PluginBuiltIns().Actions["comment"].Code
 
 func TestComment(t *testing.T) {
-	wantComment := "Lorem Ipsum"
+	rawComment := "Lorem Ipsum"
+	wantComment := fmt.Sprintf("<!--@annotation-reviewpad-ignore-->\n%v", rawComment)
 	gotComment := ""
 
 	mockedEnv := aladino.MockDefaultEnv(
@@ -47,7 +49,7 @@ func TestComment(t *testing.T) {
 		nil,
 	)
 
-	args := []aladino.Value{aladino.BuildStringValue(wantComment)}
+	args := []aladino.Value{aladino.BuildStringValue(rawComment)}
 	err := comment(mockedEnv, args)
 
 	assert.Nil(t, err)


### PR DESCRIPTION
## Description

This pull request introduces the annotation comment `<!--@annotation-reviewpad-ignore-->` with the purpose of ignoring Reviewpad comments.

## Related issue

Closes #645 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Manual tests.
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
