### PR TITLE
fix: ignore reviewpad check runs by default

### DIFF
--- a/plugins/aladino/functions/haveAllChecksRunCompleted.go
+++ b/plugins/aladino/functions/haveAllChecksRunCompleted.go
@@ -41,7 +41,10 @@ func haveAllChecksRunCompleted(e aladino.Env, args []aladino.Value) (aladino.Val
 		return nil, err
 	}
 
-	ignoredRuns := map[string]bool{}
+	ignoredRuns := map[string]bool{
+		// By default, ignore Reviewpad's own check runs
+		"reviewpad": true,
+	}
 	for _, item := range checkRunsToIgnore.Vals {
 		ignoredRuns[item.(*aladino.StringValue).Val] = true
 	}


### PR DESCRIPTION
## Description

This pull request introduces the fix to the built-in `haveAllChecksRunCompleted` by ignoring the Reviewpad check by default.

## Related issue

Closes #655

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Manuel tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge -->
- [x] Ask: this pull request requires a code review before merge
