### PR TITLE
feat: extend config unauthorized err handling

### DIFF
--- a/engine/loader.go
+++ b/engine/loader.go
@@ -354,8 +354,8 @@ func loadExtension(ctx context.Context, githubClient *gh.GithubClient, extension
 	content, err := githubClient.DownloadContents(ctx, filePath, branch)
 	if err != nil {
 		if responseErr, ok := err.(*github.ErrorResponse); ok && responseErr.Response.StatusCode == 404 {
-			if responseErr.Message == "Repository access blocked" {
-				return nil, "", fmt.Errorf("We were unable to load the Reviewpad configuration due to an authorization error. If you are using extends please make sure you have Reviewpad installed in all extended repositories.")
+			if responseErr.Message == "Not Found" {
+				return nil, "", fmt.Errorf("We encountered an error while loading the Reviewpad configuration. This may be due to reasons such as incorrect file path, invalid URL, or unauthenticated access. Please verify that you have installed Reviewpad in all extended repositories and that the file name and path are correct. If you still encounter this error, reach out to us at #help on https://reviewpad.com/discord for additional support.")
 			} else {
 				return nil, "", err
 			}

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -7,6 +7,7 @@ package engine
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -354,13 +355,9 @@ func loadExtension(ctx context.Context, githubClient *gh.GithubClient, extension
 	content, err := githubClient.DownloadContents(ctx, filePath, branch)
 	if err != nil {
 		if responseErr, ok := err.(*github.ErrorResponse); ok && responseErr.Response.StatusCode == 404 {
-			contactUs := "If you still encounter this error, please reach out to us at #help on https://reviewpad.com/discord for additional support."
-			switch responseErr.Message {
-			case "Repository access blocked":
-				return nil, "", fmt.Errorf("we encountered an authorization error while processing the 'extends' property in your Reviewpad configuration. Please ensure that you have the Reviewpad GitHub App installed in all repositories you are trying to extend from. %s", contactUs)
-			default:
-				return nil, "", fmt.Errorf("we encountered an error while processing the 'extends' property in your Reviewpad configuration. This problem may be due to an incorrect URL or unauthenticated access. Please ensure that you have Reviewpad GitHub App installed in all repositories you are trying to extend from and that the file URL is correct. %s", contactUs)
-			}
+			return nil, "", errors.New("we encountered an error while processing the 'extends' property in your Reviewpad configuration. This problem may be due to an incorrect URL or unauthenticated access. Please ensure that you have Reviewpad GitHub App installed in all repositories you are trying to extend from and that the file URL is correct. If you still encounter this error, please reach out to us at #help on https://reviewpad.com/discord for additional support.")
+		} else {
+			return nil, "", err
 		}
 	}
 

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -354,9 +354,12 @@ func loadExtension(ctx context.Context, githubClient *gh.GithubClient, extension
 	content, err := githubClient.DownloadContents(ctx, filePath, branch)
 	if err != nil {
 		if responseErr, ok := err.(*github.ErrorResponse); ok && responseErr.Response.StatusCode == 404 {
-			if responseErr.Message == "Not Found" {
+			switch responseErr.Message {
+			case "Not Found":
 				return nil, "", fmt.Errorf("We encountered an error while loading the Reviewpad configuration. This may be due to reasons such as incorrect file path, invalid URL, or unauthenticated access. Please verify that you have installed Reviewpad in all extended repositories and that the file name and path are correct. If you still encounter this error, reach out to us at #help on https://reviewpad.com/discord for additional support.")
-			} else {
+			case "Repository access blocked":
+				return nil, "", fmt.Errorf("We encountered an authorization error while trying to load the Reviewpad configuration. Please ensure that Reviewpad is installed in all extended repositories if you are using the 'extends' feature. If the issue persists, kindly reach out to us at #help on https://reviewpad.com/discord for further assistance.")
+			default:
 				return nil, "", err
 			}
 		}

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -354,13 +354,12 @@ func loadExtension(ctx context.Context, githubClient *gh.GithubClient, extension
 	content, err := githubClient.DownloadContents(ctx, filePath, branch)
 	if err != nil {
 		if responseErr, ok := err.(*github.ErrorResponse); ok && responseErr.Response.StatusCode == 404 {
+			contactUs := "If you still encounter this error, please reach out to us at #help on https://reviewpad.com/discord for additional support."
 			switch responseErr.Message {
-			case "Not Found":
-				return nil, "", fmt.Errorf("We encountered an error while loading the Reviewpad configuration. This may be due to reasons such as incorrect file path, invalid URL, or unauthenticated access. Please verify that you have installed Reviewpad in all extended repositories and that the file name and path are correct. If you still encounter this error, reach out to us at #help on https://reviewpad.com/discord for additional support.")
 			case "Repository access blocked":
-				return nil, "", fmt.Errorf("We encountered an authorization error while trying to load the Reviewpad configuration. Please ensure that Reviewpad is installed in all extended repositories if you are using the 'extends' feature. If the issue persists, kindly reach out to us at #help on https://reviewpad.com/discord for further assistance.")
+				return nil, "", fmt.Errorf("we encountered an authorization error while processing the 'extends' property in your Reviewpad configuration. Please ensure that you have the Reviewpad GitHub App installed in all repositories you are trying to extend from. %s", contactUs)
 			default:
-				return nil, "", err
+				return nil, "", fmt.Errorf("we encountered an error while processing the 'extends' property in your Reviewpad configuration. This problem may be due to an incorrect URL or unauthenticated access. Please ensure that you have Reviewpad GitHub App installed in all repositories you are trying to extend from and that the file URL is correct. %s", contactUs)
 			}
 		}
 	}

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -7,7 +7,6 @@ package engine_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -203,95 +202,117 @@ func TestLoad(t *testing.T) {
 		wantReviewpadFilePath  string
 		wantErr                string
 	}{
-		"when the file has a parsing error": {
-			inputReviewpadFilePath: "testdata/loader/reviewpad_with_parse_error.yml",
-			wantErr:                "yaml: unmarshal errors:\n  line 5: cannot unmarshal !!str `parse-e...` into engine.ReviewpadFile",
-		},
-		"when the file imports a nonexistent file": {
-			inputReviewpadFilePath: "testdata/loader/reviewpad_with_import_of_nonexistent_file.yml",
-			httpMockResponders: []httpMockResponder{
-				{
-					url:       "https://foo.bar/nonexistent_file",
-					responder: httpmock.NewErrorResponder(fmt.Errorf("file doesn't exist")),
-				},
-			},
-			wantErr: "Get \"https://foo.bar/nonexistent_file\": file doesn't exist",
-		},
-		"when the file imports a file that has a parsing error": {
-			inputReviewpadFilePath: "testdata/loader/reviewpad_with_import_file_with_parse_error.yml",
-			httpMockResponders: []httpMockResponder{
-				{
-					url:       "https://foo.bar/reviewpad_with_parse_error.yml",
-					responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_parse_error.yml").Bytes()),
-				},
-			},
-			wantErr: "yaml: unmarshal errors:\n  line 5: cannot unmarshal !!str `parse-e...` into engine.ReviewpadFile",
-		},
-		"when the file has cyclic imports": {
-			inputReviewpadFilePath: "testdata/loader/reviewpad_with_cyclic_dependency_a.yml",
-			httpMockResponders: []httpMockResponder{
-				{
-					url:       "https://foo.bar/reviewpad_with_cyclic_dependency_b.yml",
-					responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_cyclic_dependency_b.yml").Bytes()),
-				},
-				{
-					url:       "https://foo.bar/reviewpad_with_cyclic_dependency_a.yml",
-					responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_cyclic_dependency_a.yml").Bytes()),
-				},
-			},
-			wantErr: "loader: cyclic dependency",
-		},
-		"when the file has import chains": {
-			inputReviewpadFilePath: "testdata/loader/reviewpad_with_imports_chain.yml",
-			httpMockResponders: []httpMockResponder{
-				{
-					url:       "https://foo.bar/reviewpad_with_no_imports.yml",
-					responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_no_imports.yml").Bytes()),
-				},
-				{
-					url:       "https://foo.bar/reviewpad_with_one_import.yml",
-					responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_one_import.yml").Bytes()),
-				},
-			},
-			wantReviewpadFilePath: "testdata/loader/reviewpad_appended.yml",
-		},
-		"when the file has no issues": {
-			inputReviewpadFilePath: "testdata/loader/reviewpad_with_no_imports.yml",
-			wantReviewpadFilePath:  "testdata/loader/reviewpad_with_no_imports.yml",
-		},
-		"when the file requires action transformation": {
-			inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_action_transform.yml",
-			wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_action_transform.yml",
-		},
-		"when the file requires extra action transformation": {
-			inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_extra_action_transform.yml",
-			wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_extra_action_transform.yml",
-		},
-		"when the file has no on field": {
-			inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_on_transform.yml",
-			wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_on_transform.yml",
-		},
-		"when the file has a rule with no kind": {
-			inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_kind_transform.yml",
-			wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_kind_transform.yml",
-		},
-		"when the file has inline rules": {
-			inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_inline_rules.yml",
-			wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_inline_rules_after_processing.yml",
-		},
-		"when the file has invalid inline rule": {
-			inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_invalid_inline_rule.yml",
-			wantErr:                "unknown rule type int",
-		},
-		"when the file has an inline rule with extra actions": {
-			inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_inline_rules_with_extra_actions.yml",
-			wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_inline_rules_with_extra_actions_after_processing.yml",
-		},
-		"when the file has multiple inline rules": {
-			inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_multiple_inline_rules.yml",
-			wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_multiple_inline_rules_after_processing.yml",
-		},
-		"when the file has non-existing extends": {
+		// "when the file has a parsing error": {
+		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_parse_error.yml",
+		// 	wantErr:                "yaml: unmarshal errors:\n  line 5: cannot unmarshal !!str `parse-e...` into engine.ReviewpadFile",
+		// },
+		// "when the file imports a nonexistent file": {
+		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_import_of_nonexistent_file.yml",
+		// 	httpMockResponders: []httpMockResponder{
+		// 		{
+		// 			url:       "https://foo.bar/nonexistent_file",
+		// 			responder: httpmock.NewErrorResponder(fmt.Errorf("file doesn't exist")),
+		// 		},
+		// 	},
+		// 	wantErr: "Get \"https://foo.bar/nonexistent_file\": file doesn't exist",
+		// },
+		// "when the file imports a file that has a parsing error": {
+		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_import_file_with_parse_error.yml",
+		// 	httpMockResponders: []httpMockResponder{
+		// 		{
+		// 			url:       "https://foo.bar/reviewpad_with_parse_error.yml",
+		// 			responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_parse_error.yml").Bytes()),
+		// 		},
+		// 	},
+		// 	wantErr: "yaml: unmarshal errors:\n  line 5: cannot unmarshal !!str `parse-e...` into engine.ReviewpadFile",
+		// },
+		// "when the file has cyclic imports": {
+		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_cyclic_dependency_a.yml",
+		// 	httpMockResponders: []httpMockResponder{
+		// 		{
+		// 			url:       "https://foo.bar/reviewpad_with_cyclic_dependency_b.yml",
+		// 			responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_cyclic_dependency_b.yml").Bytes()),
+		// 		},
+		// 		{
+		// 			url:       "https://foo.bar/reviewpad_with_cyclic_dependency_a.yml",
+		// 			responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_cyclic_dependency_a.yml").Bytes()),
+		// 		},
+		// 	},
+		// 	wantErr: "loader: cyclic dependency",
+		// },
+		// "when the file has import chains": {
+		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_imports_chain.yml",
+		// 	httpMockResponders: []httpMockResponder{
+		// 		{
+		// 			url:       "https://foo.bar/reviewpad_with_no_imports.yml",
+		// 			responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_no_imports.yml").Bytes()),
+		// 		},
+		// 		{
+		// 			url:       "https://foo.bar/reviewpad_with_one_import.yml",
+		// 			responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_one_import.yml").Bytes()),
+		// 		},
+		// 	},
+		// 	wantReviewpadFilePath: "testdata/loader/reviewpad_appended.yml",
+		// },
+		// "when the file has no issues": {
+		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_no_imports.yml",
+		// 	wantReviewpadFilePath:  "testdata/loader/reviewpad_with_no_imports.yml",
+		// },
+		// "when the file requires action transformation": {
+		// 	inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_action_transform.yml",
+		// 	wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_action_transform.yml",
+		// },
+		// "when the file requires extra action transformation": {
+		// 	inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_extra_action_transform.yml",
+		// 	wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_extra_action_transform.yml",
+		// },
+		// "when the file has no on field": {
+		// 	inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_on_transform.yml",
+		// 	wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_on_transform.yml",
+		// },
+		// "when the file has a rule with no kind": {
+		// 	inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_kind_transform.yml",
+		// 	wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_kind_transform.yml",
+		// },
+		// "when the file has inline rules": {
+		// 	inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_inline_rules.yml",
+		// 	wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_inline_rules_after_processing.yml",
+		// },
+		// "when the file has invalid inline rule": {
+		// 	inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_invalid_inline_rule.yml",
+		// 	wantErr:                "unknown rule type int",
+		// },
+		// "when the file has an inline rule with extra actions": {
+		// 	inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_inline_rules_with_extra_actions.yml",
+		// 	wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_inline_rules_with_extra_actions_after_processing.yml",
+		// },
+		// "when the file has multiple inline rules": {
+		// 	inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_multiple_inline_rules.yml",
+		// 	wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_multiple_inline_rules_after_processing.yml",
+		// },
+		// "when the file has non-existing extends due to non-existing file": {
+		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",
+		// 	inputContext:           context.Background(),
+		// 	inputGitHubClient: aladino.MockDefaultGithubClient(
+		// 		[]mock.MockBackendOption{
+		// 			mock.WithRequestMatchHandler(
+		// 				mock.GetReposContentsByOwnerByRepoByPath,
+		// 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 					w.WriteHeader(http.StatusInternalServerError)
+		// 					engine.MustWriteBytes(w, mock.MustMarshal(github.ErrorResponse{
+		// 						Response: &http.Response{
+		// 							StatusCode: 404,
+		// 						},
+		// 						Message: "loader: extends file not found",
+		// 					}))
+		// 				}),
+		// 			),
+		// 		},
+		// 		nil,
+		// 	),
+		// 	wantErr: "loader: extends file not found",
+		// },
+		"when the file has non-existing extends due to file being from private repo without reviewpad installed": {
 			inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",
 			inputContext:           context.Background(),
 			inputGitHubClient: aladino.MockDefaultGithubClient(
@@ -299,105 +320,107 @@ func TestLoad(t *testing.T) {
 					mock.WithRequestMatchHandler(
 						mock.GetReposContentsByOwnerByRepoByPath,
 						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							mock.WriteError(
-								w,
-								http.StatusInternalServerError,
-								"loader: extends file not found",
-							)
-						}),
-					),
-				},
-				nil,
-			),
-			wantErr: "loader: extends file not found",
-		},
-		"when the file has invalid extends": {
-			inputReviewpadFilePath: "testdata/loader/reviewpad_with_invalid_extends.yml",
-			inputContext:           context.Background(),
-			wantErr:                "fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/action/blob/main/main.go",
-		},
-		"when the file has an extends": {
-			inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",
-			wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_extends_after_processing.yml",
-			inputContext:           context.Background(),
-			inputGitHubClient: aladino.MockDefaultGithubClient(
-				[]mock.MockBackendOption{
-					mock.WithRequestMatchHandler(
-						mock.GetReposContentsByOwnerByRepoByPath,
-						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							utils.MustWriteBytes(w, mock.MustMarshal(
-								[]github.RepositoryContent{
-									{
-										Name:        github.String("reviewpad_with_no_extends_a.yml"),
-										DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_no_extends_a.yml"),
-									},
-									{
-										Name:        github.String("reviewpad_with_no_extends_b.yml"),
-										DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_no_extends_b.yml"),
-									},
+							w.WriteHeader(http.StatusInternalServerError)
+							engine.MustWriteBytes(w, mock.MustMarshal(github.ErrorResponse{
+								Response: &http.Response{
+									StatusCode: 404,
 								},
-							))
+								Message: "Repository access blocked",
+							}))
 						}),
-					),
-					mock.WithRequestMatch(
-						mock.EndpointPattern{
-							Pattern: "/reviewpad_with_no_extends_a.yml",
-							Method:  "GET",
-						},
-						httpmock.File("testdata/loader/reviewpad_with_no_extends_a.yml").Bytes(),
-					),
-					mock.WithRequestMatch(
-						mock.EndpointPattern{
-							Pattern: "/reviewpad_with_no_extends_b.yml",
-							Method:  "GET",
-						},
-						httpmock.File("testdata/loader/reviewpad_with_no_extends_b.yml").Bytes(),
 					),
 				},
 				nil,
 			),
+			wantErr: "We were unable to load the Reviewpad configuration due to an authorization error. If you are using extends please make sure you have Reviewpad installed in all extended repositories.",
 		},
-		"when the file has cyclic extends": {
-			inputReviewpadFilePath: "testdata/loader/reviewpad_with_cyclic_extends_dependency_a.yml",
-			inputContext:           context.Background(),
-			inputGitHubClient: aladino.MockDefaultGithubClient(
-				[]mock.MockBackendOption{
-					mock.WithRequestMatchHandler(
-						mock.GetReposContentsByOwnerByRepoByPath,
-						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							utils.MustWriteBytes(w, mock.MustMarshal(
-								[]github.RepositoryContent{
-									{
-										Name:        github.String("reviewpad_with_cyclic_extends_dependency_a.yml"),
-										DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_cyclic_extends_dependency_a.yml"),
-									},
-									{
-										Name:        github.String("reviewpad_with_cyclic_extends_dependency_b.yml"),
-										DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_cyclic_extends_dependency_b.yml"),
-									},
-								},
-							))
-						}),
-					),
-					mock.WithRequestMatch(
-						mock.EndpointPattern{
-							Pattern: "/reviewpad_with_cyclic_extends_dependency_a.yml",
-							Method:  "GET",
-						},
-						httpmock.File("testdata/loader/reviewpad_with_cyclic_extends_dependency_a.yml").Bytes(),
-					),
-					mock.WithRequestMatch(
-						mock.EndpointPattern{
-							Pattern: "/reviewpad_with_cyclic_extends_dependency_b.yml",
-							Method:  "GET",
-						},
-						httpmock.File("testdata/loader/reviewpad_with_cyclic_extends_dependency_b.yml").Bytes(),
-					),
-				},
-				nil,
-			),
-			wantErr: "loader: cyclic extends dependency",
-		},
+		// "when the file has invalid extends": {
+		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_invalid_extends.yml",
+		// 	inputContext:           context.Background(),
+		// 	wantErr:                "fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/action/blob/main/main.go",
+		// },
+		// "when the file has an extends": {
+		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",
+		// 	wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_extends_after_processing.yml",
+		// 	inputContext:           context.Background(),
+		// 	inputGitHubClient: aladino.MockDefaultGithubClient(
+		// 		[]mock.MockBackendOption{
+		// 			mock.WithRequestMatchHandler(
+		// 				mock.GetReposContentsByOwnerByRepoByPath,
+		// 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 					utils.MustWriteBytes(w, mock.MustMarshal(
+		// 						[]github.RepositoryContent{
+		// 							{
+		// 								Name:        github.String("reviewpad_with_no_extends_a.yml"),
+		// 								DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_no_extends_a.yml"),
+		// 							},
+		// 							{
+		// 								Name:        github.String("reviewpad_with_no_extends_b.yml"),
+		// 								DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_no_extends_b.yml"),
+		// 							},
+		// 						},
+		// 					))
+		// 				}),
+		// 			),
+		// 			mock.WithRequestMatch(
+		// 				mock.EndpointPattern{
+		// 					Pattern: "/reviewpad_with_no_extends_a.yml",
+		// 					Method:  "GET",
+		// 				},
+		// 				httpmock.File("testdata/loader/reviewpad_with_no_extends_a.yml").Bytes(),
+		// 			),
+		// 			mock.WithRequestMatch(
+		// 				mock.EndpointPattern{
+		// 					Pattern: "/reviewpad_with_no_extends_b.yml",
+		// 					Method:  "GET",
+		// 				},
+		// 				httpmock.File("testdata/loader/reviewpad_with_no_extends_b.yml").Bytes(),
+		// 			),
+		// 		},
+		// 		nil,
+		// 	),
+		// },
+		// "when the file has cyclic extends": {
+		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_cyclic_extends_dependency_a.yml",
+		// 	inputContext:           context.Background(),
+		// 	inputGitHubClient: aladino.MockDefaultGithubClient(
+		// 		[]mock.MockBackendOption{
+		// 			mock.WithRequestMatchHandler(
+		// 				mock.GetReposContentsByOwnerByRepoByPath,
+		// 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 					utils.MustWriteBytes(w, mock.MustMarshal(
+		// 						[]github.RepositoryContent{
+		// 							{
+		// 								Name:        github.String("reviewpad_with_cyclic_extends_dependency_a.yml"),
+		// 								DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_cyclic_extends_dependency_a.yml"),
+		// 							},
+		// 							{
+		// 								Name:        github.String("reviewpad_with_cyclic_extends_dependency_b.yml"),
+		// 								DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_cyclic_extends_dependency_b.yml"),
+		// 							},
+		// 						},
+		// 					))
+		// 				}),
+		// 			),
+		// 			mock.WithRequestMatch(
+		// 				mock.EndpointPattern{
+		// 					Pattern: "/reviewpad_with_cyclic_extends_dependency_a.yml",
+		// 					Method:  "GET",
+		// 				},
+		// 				httpmock.File("testdata/loader/reviewpad_with_cyclic_extends_dependency_a.yml").Bytes(),
+		// 			),
+		// 			mock.WithRequestMatch(
+		// 				mock.EndpointPattern{
+		// 					Pattern: "/reviewpad_with_cyclic_extends_dependency_b.yml",
+		// 					Method:  "GET",
+		// 				},
+		// 				httpmock.File("testdata/loader/reviewpad_with_cyclic_extends_dependency_b.yml").Bytes(),
+		// 			),
+		// 		},
+		// 		nil,
+		// 	),
+		// 	wantErr: "loader: cyclic extends dependency",
+		// },
 	}
 
 	for name, test := range tests {
@@ -433,11 +456,11 @@ func TestLoad(t *testing.T) {
 				githubError := &github.ErrorResponse{}
 				if errors.As(gotErr, &githubError) {
 					if githubError.Message != test.wantErr {
-						assert.FailNow(t, "Load() error = %v, wantErr %v", gotErr, test.wantErr)
+						assert.FailNow(t, "Load() error = %v, wantErr %v", gotErr.Error(), test.wantErr)
 					}
 				} else {
 					if gotErr.Error() != test.wantErr {
-						assert.FailNow(t, "Load() error = %v, wantErr %v", gotErr, test.wantErr)
+						assert.FailNow(t, "Load() error = %v, wantErr %v", gotErr.Error(), test.wantErr)
 					}
 				}
 			}

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -457,7 +457,7 @@ func TestLoad(t *testing.T) {
 				githubError := &github.ErrorResponse{}
 				if errors.As(gotErr, &githubError) {
 					if githubError.Message != test.wantErr {
-						assert.FailNow(t, "Load() error = %v, wantErr %v", gotErr.Error(), test.wantErr)
+						assert.FailNow(t, "Load() error = %v, wantErr %v", githubError.Message, test.wantErr)
 					}
 				} else {
 					if gotErr.Error() != test.wantErr {

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -313,28 +313,6 @@ func TestLoad(t *testing.T) {
 			),
 			wantErr: "we encountered an error while processing the 'extends' property in your Reviewpad configuration. This problem may be due to an incorrect URL or unauthenticated access. Please ensure that you have Reviewpad GitHub App installed in all repositories you are trying to extend from and that the file URL is correct. If you still encounter this error, please reach out to us at #help on https://reviewpad.com/discord for additional support.",
 		},
-		"when the file has an extends from a repository with blocked access": {
-			inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",
-			inputContext:           context.Background(),
-			inputGitHubClient: aladino.MockDefaultGithubClient(
-				[]mock.MockBackendOption{
-					mock.WithRequestMatchHandler(
-						mock.GetReposContentsByOwnerByRepoByPath,
-						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							w.WriteHeader(http.StatusInternalServerError)
-							engine.MustWriteBytes(w, mock.MustMarshal(github.ErrorResponse{
-								Response: &http.Response{
-									StatusCode: 404,
-								},
-								Message: "Repository access blocked",
-							}))
-						}),
-					),
-				},
-				nil,
-			),
-			wantErr: "we encountered an authorization error while processing the 'extends' property in your Reviewpad configuration. Please ensure that you have the Reviewpad GitHub App installed in all repositories you are trying to extend from. If you still encounter this error, please reach out to us at #help on https://reviewpad.com/discord for additional support.",
-		},
 		"when the file has invalid extends": {
 			inputReviewpadFilePath: "testdata/loader/reviewpad_with_invalid_extends.yml",
 			inputContext:           context.Background(),

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -311,7 +311,7 @@ func TestLoad(t *testing.T) {
 				},
 				nil,
 			),
-			wantErr: "We encountered an error while loading the Reviewpad configuration. This may be due to reasons such as incorrect file path, invalid URL, or unauthenticated access. Please verify that you have installed Reviewpad in all extended repositories and that the file name and path are correct. If you still encounter this error, reach out to us at #help on https://reviewpad.com/discord for additional support.",
+			wantErr: "we encountered an error while processing the 'extends' property in your Reviewpad configuration. This problem may be due to an incorrect URL or unauthenticated access. Please ensure that you have Reviewpad GitHub App installed in all repositories you are trying to extend from and that the file URL is correct. If you still encounter this error, please reach out to us at #help on https://reviewpad.com/discord for additional support.",
 		},
 		"when the file has an extends from a repository with blocked access": {
 			inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",
@@ -333,7 +333,7 @@ func TestLoad(t *testing.T) {
 				},
 				nil,
 			),
-			wantErr: "We encountered an authorization error while trying to load the Reviewpad configuration. Please ensure that Reviewpad is installed in all extended repositories if you are using the 'extends' feature. If the issue persists, kindly reach out to us at #help on https://reviewpad.com/discord for further assistance.",
+			wantErr: "we encountered an authorization error while processing the 'extends' property in your Reviewpad configuration. Please ensure that you have the Reviewpad GitHub App installed in all repositories you are trying to extend from. If you still encounter this error, please reach out to us at #help on https://reviewpad.com/discord for additional support.",
 		},
 		"when the file has invalid extends": {
 			inputReviewpadFilePath: "testdata/loader/reviewpad_with_invalid_extends.yml",
@@ -457,11 +457,11 @@ func TestLoad(t *testing.T) {
 				githubError := &github.ErrorResponse{}
 				if errors.As(gotErr, &githubError) {
 					if githubError.Message != test.wantErr {
-						assert.FailNow(t, "Load() error = %v, wantErr %v", githubError.Message, test.wantErr)
+						assert.FailNow(t, fmt.Sprintf("Load() error = %v, wantErr %v", githubError.Message, test.wantErr))
 					}
 				} else {
 					if gotErr.Error() != test.wantErr {
-						assert.FailNow(t, "Load() error = %v, wantErr %v", gotErr.Error(), test.wantErr)
+						assert.FailNow(t, fmt.Sprintf("Load() error = %v, wantErr %v", gotErr.Error(), test.wantErr))
 					}
 				}
 			}

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -7,6 +7,7 @@ package engine_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -202,116 +203,94 @@ func TestLoad(t *testing.T) {
 		wantReviewpadFilePath  string
 		wantErr                string
 	}{
-		// "when the file has a parsing error": {
-		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_parse_error.yml",
-		// 	wantErr:                "yaml: unmarshal errors:\n  line 5: cannot unmarshal !!str `parse-e...` into engine.ReviewpadFile",
-		// },
-		// "when the file imports a nonexistent file": {
-		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_import_of_nonexistent_file.yml",
-		// 	httpMockResponders: []httpMockResponder{
-		// 		{
-		// 			url:       "https://foo.bar/nonexistent_file",
-		// 			responder: httpmock.NewErrorResponder(fmt.Errorf("file doesn't exist")),
-		// 		},
-		// 	},
-		// 	wantErr: "Get \"https://foo.bar/nonexistent_file\": file doesn't exist",
-		// },
-		// "when the file imports a file that has a parsing error": {
-		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_import_file_with_parse_error.yml",
-		// 	httpMockResponders: []httpMockResponder{
-		// 		{
-		// 			url:       "https://foo.bar/reviewpad_with_parse_error.yml",
-		// 			responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_parse_error.yml").Bytes()),
-		// 		},
-		// 	},
-		// 	wantErr: "yaml: unmarshal errors:\n  line 5: cannot unmarshal !!str `parse-e...` into engine.ReviewpadFile",
-		// },
-		// "when the file has cyclic imports": {
-		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_cyclic_dependency_a.yml",
-		// 	httpMockResponders: []httpMockResponder{
-		// 		{
-		// 			url:       "https://foo.bar/reviewpad_with_cyclic_dependency_b.yml",
-		// 			responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_cyclic_dependency_b.yml").Bytes()),
-		// 		},
-		// 		{
-		// 			url:       "https://foo.bar/reviewpad_with_cyclic_dependency_a.yml",
-		// 			responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_cyclic_dependency_a.yml").Bytes()),
-		// 		},
-		// 	},
-		// 	wantErr: "loader: cyclic dependency",
-		// },
-		// "when the file has import chains": {
-		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_imports_chain.yml",
-		// 	httpMockResponders: []httpMockResponder{
-		// 		{
-		// 			url:       "https://foo.bar/reviewpad_with_no_imports.yml",
-		// 			responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_no_imports.yml").Bytes()),
-		// 		},
-		// 		{
-		// 			url:       "https://foo.bar/reviewpad_with_one_import.yml",
-		// 			responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_one_import.yml").Bytes()),
-		// 		},
-		// 	},
-		// 	wantReviewpadFilePath: "testdata/loader/reviewpad_appended.yml",
-		// },
-		// "when the file has no issues": {
-		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_no_imports.yml",
-		// 	wantReviewpadFilePath:  "testdata/loader/reviewpad_with_no_imports.yml",
-		// },
-		// "when the file requires action transformation": {
-		// 	inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_action_transform.yml",
-		// 	wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_action_transform.yml",
-		// },
-		// "when the file requires extra action transformation": {
-		// 	inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_extra_action_transform.yml",
-		// 	wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_extra_action_transform.yml",
-		// },
-		// "when the file has no on field": {
-		// 	inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_on_transform.yml",
-		// 	wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_on_transform.yml",
-		// },
-		// "when the file has a rule with no kind": {
-		// 	inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_kind_transform.yml",
-		// 	wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_kind_transform.yml",
-		// },
-		// "when the file has inline rules": {
-		// 	inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_inline_rules.yml",
-		// 	wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_inline_rules_after_processing.yml",
-		// },
-		// "when the file has invalid inline rule": {
-		// 	inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_invalid_inline_rule.yml",
-		// 	wantErr:                "unknown rule type int",
-		// },
-		// "when the file has an inline rule with extra actions": {
-		// 	inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_inline_rules_with_extra_actions.yml",
-		// 	wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_inline_rules_with_extra_actions_after_processing.yml",
-		// },
-		// "when the file has multiple inline rules": {
-		// 	inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_multiple_inline_rules.yml",
-		// 	wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_multiple_inline_rules_after_processing.yml",
-		// },
-		// "when the file has non-existing extends due to non-existing file": {
-		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",
-		// 	inputContext:           context.Background(),
-		// 	inputGitHubClient: aladino.MockDefaultGithubClient(
-		// 		[]mock.MockBackendOption{
-		// 			mock.WithRequestMatchHandler(
-		// 				mock.GetReposContentsByOwnerByRepoByPath,
-		// 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 					w.WriteHeader(http.StatusInternalServerError)
-		// 					engine.MustWriteBytes(w, mock.MustMarshal(github.ErrorResponse{
-		// 						Response: &http.Response{
-		// 							StatusCode: 404,
-		// 						},
-		// 						Message: "loader: extends file not found",
-		// 					}))
-		// 				}),
-		// 			),
-		// 		},
-		// 		nil,
-		// 	),
-		// 	wantErr: "loader: extends file not found",
-		// },
+		"when the file has a parsing error": {
+			inputReviewpadFilePath: "testdata/loader/reviewpad_with_parse_error.yml",
+			wantErr:                "yaml: unmarshal errors:\n  line 5: cannot unmarshal !!str `parse-e...` into engine.ReviewpadFile",
+		},
+		"when the file imports a nonexistent file": {
+			inputReviewpadFilePath: "testdata/loader/reviewpad_with_import_of_nonexistent_file.yml",
+			httpMockResponders: []httpMockResponder{
+				{
+					url:       "https://foo.bar/nonexistent_file",
+					responder: httpmock.NewErrorResponder(fmt.Errorf("file doesn't exist")),
+				},
+			},
+			wantErr: "Get \"https://foo.bar/nonexistent_file\": file doesn't exist",
+		},
+		"when the file imports a file that has a parsing error": {
+			inputReviewpadFilePath: "testdata/loader/reviewpad_with_import_file_with_parse_error.yml",
+			httpMockResponders: []httpMockResponder{
+				{
+					url:       "https://foo.bar/reviewpad_with_parse_error.yml",
+					responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_parse_error.yml").Bytes()),
+				},
+			},
+			wantErr: "yaml: unmarshal errors:\n  line 5: cannot unmarshal !!str `parse-e...` into engine.ReviewpadFile",
+		},
+		"when the file has cyclic imports": {
+			inputReviewpadFilePath: "testdata/loader/reviewpad_with_cyclic_dependency_a.yml",
+			httpMockResponders: []httpMockResponder{
+				{
+					url:       "https://foo.bar/reviewpad_with_cyclic_dependency_b.yml",
+					responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_cyclic_dependency_b.yml").Bytes()),
+				},
+				{
+					url:       "https://foo.bar/reviewpad_with_cyclic_dependency_a.yml",
+					responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_cyclic_dependency_a.yml").Bytes()),
+				},
+			},
+			wantErr: "loader: cyclic dependency",
+		},
+		"when the file has import chains": {
+			inputReviewpadFilePath: "testdata/loader/reviewpad_with_imports_chain.yml",
+			httpMockResponders: []httpMockResponder{
+				{
+					url:       "https://foo.bar/reviewpad_with_no_imports.yml",
+					responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_no_imports.yml").Bytes()),
+				},
+				{
+					url:       "https://foo.bar/reviewpad_with_one_import.yml",
+					responder: httpmock.NewBytesResponder(200, httpmock.File("testdata/loader/reviewpad_with_one_import.yml").Bytes()),
+				},
+			},
+			wantReviewpadFilePath: "testdata/loader/reviewpad_appended.yml",
+		},
+		"when the file has no issues": {
+			inputReviewpadFilePath: "testdata/loader/reviewpad_with_no_imports.yml",
+			wantReviewpadFilePath:  "testdata/loader/reviewpad_with_no_imports.yml",
+		},
+		"when the file requires action transformation": {
+			inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_action_transform.yml",
+			wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_action_transform.yml",
+		},
+		"when the file requires extra action transformation": {
+			inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_extra_action_transform.yml",
+			wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_extra_action_transform.yml",
+		},
+		"when the file has no on field": {
+			inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_on_transform.yml",
+			wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_on_transform.yml",
+		},
+		"when the file has a rule with no kind": {
+			inputReviewpadFilePath: "testdata/loader/transform/reviewpad_before_kind_transform.yml",
+			wantReviewpadFilePath:  "testdata/loader/transform/reviewpad_after_kind_transform.yml",
+		},
+		"when the file has inline rules": {
+			inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_inline_rules.yml",
+			wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_inline_rules_after_processing.yml",
+		},
+		"when the file has invalid inline rule": {
+			inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_invalid_inline_rule.yml",
+			wantErr:                "unknown rule type int",
+		},
+		"when the file has an inline rule with extra actions": {
+			inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_inline_rules_with_extra_actions.yml",
+			wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_inline_rules_with_extra_actions_after_processing.yml",
+		},
+		"when the file has multiple inline rules": {
+			inputReviewpadFilePath: "testdata/loader/process/reviewpad_with_multiple_inline_rules.yml",
+			wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_multiple_inline_rules_after_processing.yml",
+		},
 		"when the file has non-existing extends due to file being from private repo without reviewpad installed": {
 			inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",
 			inputContext:           context.Background(),
@@ -325,102 +304,102 @@ func TestLoad(t *testing.T) {
 								Response: &http.Response{
 									StatusCode: 404,
 								},
-								Message: "Repository access blocked",
+								Message: "Not Found",
 							}))
 						}),
 					),
 				},
 				nil,
 			),
-			wantErr: "We were unable to load the Reviewpad configuration due to an authorization error. If you are using extends please make sure you have Reviewpad installed in all extended repositories.",
+			wantErr: "We encountered an error while loading the Reviewpad configuration. This may be due to reasons such as incorrect file path, invalid URL, or unauthenticated access. Please verify that you have installed Reviewpad in all extended repositories and that the file name and path are correct. If you still encounter this error, reach out to us at #help on https://reviewpad.com/discord for additional support.",
 		},
-		// "when the file has invalid extends": {
-		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_invalid_extends.yml",
-		// 	inputContext:           context.Background(),
-		// 	wantErr:                "fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/action/blob/main/main.go",
-		// },
-		// "when the file has an extends": {
-		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",
-		// 	wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_extends_after_processing.yml",
-		// 	inputContext:           context.Background(),
-		// 	inputGitHubClient: aladino.MockDefaultGithubClient(
-		// 		[]mock.MockBackendOption{
-		// 			mock.WithRequestMatchHandler(
-		// 				mock.GetReposContentsByOwnerByRepoByPath,
-		// 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 					utils.MustWriteBytes(w, mock.MustMarshal(
-		// 						[]github.RepositoryContent{
-		// 							{
-		// 								Name:        github.String("reviewpad_with_no_extends_a.yml"),
-		// 								DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_no_extends_a.yml"),
-		// 							},
-		// 							{
-		// 								Name:        github.String("reviewpad_with_no_extends_b.yml"),
-		// 								DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_no_extends_b.yml"),
-		// 							},
-		// 						},
-		// 					))
-		// 				}),
-		// 			),
-		// 			mock.WithRequestMatch(
-		// 				mock.EndpointPattern{
-		// 					Pattern: "/reviewpad_with_no_extends_a.yml",
-		// 					Method:  "GET",
-		// 				},
-		// 				httpmock.File("testdata/loader/reviewpad_with_no_extends_a.yml").Bytes(),
-		// 			),
-		// 			mock.WithRequestMatch(
-		// 				mock.EndpointPattern{
-		// 					Pattern: "/reviewpad_with_no_extends_b.yml",
-		// 					Method:  "GET",
-		// 				},
-		// 				httpmock.File("testdata/loader/reviewpad_with_no_extends_b.yml").Bytes(),
-		// 			),
-		// 		},
-		// 		nil,
-		// 	),
-		// },
-		// "when the file has cyclic extends": {
-		// 	inputReviewpadFilePath: "testdata/loader/reviewpad_with_cyclic_extends_dependency_a.yml",
-		// 	inputContext:           context.Background(),
-		// 	inputGitHubClient: aladino.MockDefaultGithubClient(
-		// 		[]mock.MockBackendOption{
-		// 			mock.WithRequestMatchHandler(
-		// 				mock.GetReposContentsByOwnerByRepoByPath,
-		// 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 					utils.MustWriteBytes(w, mock.MustMarshal(
-		// 						[]github.RepositoryContent{
-		// 							{
-		// 								Name:        github.String("reviewpad_with_cyclic_extends_dependency_a.yml"),
-		// 								DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_cyclic_extends_dependency_a.yml"),
-		// 							},
-		// 							{
-		// 								Name:        github.String("reviewpad_with_cyclic_extends_dependency_b.yml"),
-		// 								DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_cyclic_extends_dependency_b.yml"),
-		// 							},
-		// 						},
-		// 					))
-		// 				}),
-		// 			),
-		// 			mock.WithRequestMatch(
-		// 				mock.EndpointPattern{
-		// 					Pattern: "/reviewpad_with_cyclic_extends_dependency_a.yml",
-		// 					Method:  "GET",
-		// 				},
-		// 				httpmock.File("testdata/loader/reviewpad_with_cyclic_extends_dependency_a.yml").Bytes(),
-		// 			),
-		// 			mock.WithRequestMatch(
-		// 				mock.EndpointPattern{
-		// 					Pattern: "/reviewpad_with_cyclic_extends_dependency_b.yml",
-		// 					Method:  "GET",
-		// 				},
-		// 				httpmock.File("testdata/loader/reviewpad_with_cyclic_extends_dependency_b.yml").Bytes(),
-		// 			),
-		// 		},
-		// 		nil,
-		// 	),
-		// 	wantErr: "loader: cyclic extends dependency",
-		// },
+		"when the file has invalid extends": {
+			inputReviewpadFilePath: "testdata/loader/reviewpad_with_invalid_extends.yml",
+			inputContext:           context.Background(),
+			wantErr:                "fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/action/blob/main/main.go",
+		},
+		"when the file has an extends": {
+			inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",
+			wantReviewpadFilePath:  "testdata/loader/process/reviewpad_with_extends_after_processing.yml",
+			inputContext:           context.Background(),
+			inputGitHubClient: aladino.MockDefaultGithubClient(
+				[]mock.MockBackendOption{
+					mock.WithRequestMatchHandler(
+						mock.GetReposContentsByOwnerByRepoByPath,
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							utils.MustWriteBytes(w, mock.MustMarshal(
+								[]github.RepositoryContent{
+									{
+										Name:        github.String("reviewpad_with_no_extends_a.yml"),
+										DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_no_extends_a.yml"),
+									},
+									{
+										Name:        github.String("reviewpad_with_no_extends_b.yml"),
+										DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_no_extends_b.yml"),
+									},
+								},
+							))
+						}),
+					),
+					mock.WithRequestMatch(
+						mock.EndpointPattern{
+							Pattern: "/reviewpad_with_no_extends_a.yml",
+							Method:  "GET",
+						},
+						httpmock.File("testdata/loader/reviewpad_with_no_extends_a.yml").Bytes(),
+					),
+					mock.WithRequestMatch(
+						mock.EndpointPattern{
+							Pattern: "/reviewpad_with_no_extends_b.yml",
+							Method:  "GET",
+						},
+						httpmock.File("testdata/loader/reviewpad_with_no_extends_b.yml").Bytes(),
+					),
+				},
+				nil,
+			),
+		},
+		"when the file has cyclic extends": {
+			inputReviewpadFilePath: "testdata/loader/reviewpad_with_cyclic_extends_dependency_a.yml",
+			inputContext:           context.Background(),
+			inputGitHubClient: aladino.MockDefaultGithubClient(
+				[]mock.MockBackendOption{
+					mock.WithRequestMatchHandler(
+						mock.GetReposContentsByOwnerByRepoByPath,
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							utils.MustWriteBytes(w, mock.MustMarshal(
+								[]github.RepositoryContent{
+									{
+										Name:        github.String("reviewpad_with_cyclic_extends_dependency_a.yml"),
+										DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_cyclic_extends_dependency_a.yml"),
+									},
+									{
+										Name:        github.String("reviewpad_with_cyclic_extends_dependency_b.yml"),
+										DownloadURL: github.String("https://raw.githubusercontent.com/reviewpad_with_cyclic_extends_dependency_b.yml"),
+									},
+								},
+							))
+						}),
+					),
+					mock.WithRequestMatch(
+						mock.EndpointPattern{
+							Pattern: "/reviewpad_with_cyclic_extends_dependency_a.yml",
+							Method:  "GET",
+						},
+						httpmock.File("testdata/loader/reviewpad_with_cyclic_extends_dependency_a.yml").Bytes(),
+					),
+					mock.WithRequestMatch(
+						mock.EndpointPattern{
+							Pattern: "/reviewpad_with_cyclic_extends_dependency_b.yml",
+							Method:  "GET",
+						},
+						httpmock.File("testdata/loader/reviewpad_with_cyclic_extends_dependency_b.yml").Bytes(),
+					),
+				},
+				nil,
+			),
+			wantErr: "loader: cyclic extends dependency",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request implements a feature to detect when a "404 Not Found" error is due to reviewpad not having access to the `reviewpad.yml` files that come from the `extends` property. The code checks the error message from the GitHub API after trying to download a file from a repository. If the error message is "Not Found" or "Repository access blocked", the error is likely due to reviewpad not being installed on a private repository. If it's not due to this reason, the error may be due to other factors.

It's worth noting that "404 Not Found" is a general HTTP error indicating that the requested resource could not be found on the server. On the other hand, "Repository access blocked" is a specific error message generated by GitHub indicating the user doesn't have sufficient permissions to access the requested repository.

GitHub uses "404 Not Found" instead of "Repository access blocked" when a user tries to download a file from a private repository they don't have access to because it fits the general case of a resource not being found on the server, regardless of the reason why it's unavailable. This allows for consistency in error messaging and avoids the need for different error messages for every possible reason a resource may be unavailable.

## Related issue

<!-- Closes # (issue) -->
Closes #659 

## Type of change

<!-- Uncomment the suitable types of change from the options below: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality not to work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Manual tests (described in https://www.notion.so/reviewpad/Extend-configuration-from-an-unauthorized-repository-85fbe0b78ace4ebe8062b283e9ef7d76) and ran the `task check` cmd.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have run `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post-merge --> 
- [x] Ask: this pull request requires a code review before the merge
