### PR TITLE
feat: separate check for fail built in

### DIFF
--- a/codehost/github/commits.go
+++ b/codehost/github/commits.go
@@ -1,0 +1,38 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+type CreateCommitStatusOptions struct {
+	State       string `json:"state"`
+	Context     string `json:"context"`
+	Description string `json:"description"`
+}
+
+type CommitStatus struct {
+	ID  uint64 `json:"id"`
+	URL string `json:"url"`
+}
+
+func (c *GithubClient) CreateCommitStatus(ctx context.Context, owner string, repo string, headSHA string, opt *CreateCommitStatusOptions) (*CommitStatus, error) {
+	url := fmt.Sprintf("repos/%s/%s/statuses/%s", owner, repo, headSHA)
+	req, err := c.clientREST.NewRequest("POST", url, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	commitStatus := &CommitStatus{}
+
+	_, err = c.clientREST.Do(ctx, req, commitStatus)
+	if err != nil {
+		return nil, err
+	}
+
+	return commitStatus, nil
+}

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -239,7 +239,7 @@ func TestIntegration(t *testing.T) {
 			},
 			commitMessage:  "test: fail",
 			reviewpadFiles: []*engine.ReviewpadFile{buildInFailReviewpadFile, closeReviewpadFile, builtInDeleteHeadBranchReviewpadFile},
-			exitStatus:     []engine.ExitStatus{engine.ExitStatusFailure, engine.ExitStatusSuccess, engine.ExitStatusSuccess},
+			exitStatus:     []engine.ExitStatus{engine.ExitStatusSuccess, engine.ExitStatusSuccess, engine.ExitStatusSuccess},
 		},
 	}
 

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -257,7 +257,7 @@ func (i *Interpreter) createReviewpadFailCommitStatus(state string) error {
 		log.Println(pr.GetHead().GetSHA())
 
 		_, err := i.Env.GetGithubClient().CreateCommitStatus(ctx, targetEntity.Owner, targetEntity.Repo, pr.GetHead().GetSHA(), &gh.CreateCommitStatusOptions{
-			Context:     "Reviewpad Failed",
+			Context:     "Reviewpad Fail",
 			State:       state,
 			Description: "Reviewpad $fail built-in status.",
 		})

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -365,6 +365,12 @@ func TestExecProgram(t *testing.T) {
 					{Name: github.String("test")},
 				},
 			),
+			mock.WithRequestMatchHandler(mock.EndpointPattern{
+				Pattern: "/repos/foobar/default-mock-repo/statuses/",
+				Method:  "POST",
+			}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{}`)
+			})),
 		},
 		nil,
 		builtIns,


### PR DESCRIPTION
## Description
Currently, the `$fail` built-in fails reviewpad, this PR modifies reviewpad so that `$fail` built-in instead of failing reviewpad creates a new commit status with a `failure` state.
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #652 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Manual tests performed on the action and on the github app.
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
