### PR TITLE
fix: empty reviewpad report

### DIFF
--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -620,7 +620,7 @@ func TestReport_OnSilentMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 
 func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 	var addedComment string
-	commentToBeAdded := fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\n```\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
+	commentToBeAdded := fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\nNo actions executed\n```\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
 	mockedEnv := MockDefaultEnv(
 		t,
 		[]mock.MockBackendOption{
@@ -657,7 +657,7 @@ func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 
 func TestReport_OnVerboseMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 	var updatedComment string
-	commentUpdated := fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\n```\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
+	commentUpdated := fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\nNo actions executed\n```\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
 	mockedEnv := MockDefaultEnv(
 		t,
 		[]mock.MockBackendOption{

--- a/lang/aladino/report.go
+++ b/lang/aladino/report.go
@@ -90,8 +90,12 @@ func BuildVerboseReport(report *Report) string {
 	sb.WriteString("```yaml\n")
 
 	// Report
-	for _, action := range report.Actions {
-		sb.WriteString(fmt.Sprintf("%v\n", action))
+	if len(report.Actions) == 0 {
+		sb.WriteString("No actions executed\n")
+	} else {
+		for _, action := range report.Actions {
+			sb.WriteString(fmt.Sprintf("%v\n", action))
+		}
 	}
 
 	sb.WriteString("```\n")

--- a/lang/aladino/report_internal_test.go
+++ b/lang/aladino/report_internal_test.go
@@ -93,7 +93,7 @@ func TestBuildVerboseReport_WhenNoReportProvided(t *testing.T) {
 func TestBuildVerboseReport_WhenIsProvidedReportWithNoWorkflowDetails(t *testing.T) {
 	reportWithNoWorkflowDetails := &Report{}
 
-	wantReport := ":scroll: **Executed actions**\n```yaml\n```\n"
+	wantReport := ":scroll: **Executed actions**\n```yaml\nNo actions executed\n```\n"
 
 	gotReport := BuildVerboseReport(reportWithNoWorkflowDetails)
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request resolves the issue where the Reviewpad generates an empty report when the `mode` property is set to `verbose`. The solution handles the scenario where there are no actions executed by generating a report indicating this, otherwise, it presents a list of the actions executed.

## Related issue

<!-- Closes # (issue) -->
Closes #654 

## Type of change

<!-- Uncomment the right types of change from the options below: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Manual tests (described here https://www.notion.so/reviewpad/Reviewpad-generates-an-empty-report-e5eb16579ae84e2ab10f4464241a2dc9) and ran the `task check -f` cmd.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have run `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post-merge --> 
- [x] Ask: this pull request requires a code review before the merge
