### PR TITLE
fix: trigger report checks before program execution

### DIFF
--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -138,7 +138,7 @@ func NewEvalEnv(
 		ReviewpadMergeGateCheckName: {
 			Name:   ReviewpadMergeGateCheckName,
 			Status: engine.CheckStateSuccess,
-			Reason: "Reviewpad merge gate completed successfully",
+			Reason: "Completed successfully",
 		},
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -249,6 +249,15 @@ func runReviewpadFile(
 		logger.WithError(err).Errorf("error collecting trigger analysis")
 	}
 
+	if targetEntity.Kind == handler.PullRequest && !dryRun {
+		err = aladinoInterpreter.ReportChecks()
+		if err != nil {
+			logErrorAndCollect(logger, collector, "error reporting checks", err)
+			// Do not fail if there's an error creating the commit status
+			// When using Reviewpad as a GitHub Action without a GitHub token Reviewpad won't be able to create the commit status.
+		}
+	}
+
 	exitStatus, err := aladinoInterpreter.ExecProgram(program)
 	if err != nil {
 		logErrorAndCollect(logger, collector, "error executing configuration file", err)
@@ -284,14 +293,6 @@ func runReviewpadFile(
 		err = aladinoInterpreter.Report(reviewpadFile.Mode, safeMode)
 		if err != nil {
 			logErrorAndCollect(logger, collector, "error reporting results", err)
-			return engine.ExitStatusFailure, nil, err
-		}
-	}
-
-	if !dryRun && targetEntity.Kind == handler.PullRequest {
-		err = aladinoInterpreter.ReportChecks()
-		if err != nil {
-			logErrorAndCollect(logger, collector, "error reporting checks", err)
 			return engine.ExitStatusFailure, nil, err
 		}
 	}


### PR DESCRIPTION
## Description

This pull request introduces the ability to report checks before executing the program. This is to allow Reviewpad to auto-merge while allowing to block the merge button using `reviewpad merge gate`.

By reporting the checks before executing the program, Reviewpad creates the checks with their default value (i.e. green). Then, when executing the program, if the built-in `disableMerge` is executed the check will be set to `fail` and Reviewpad won't be able to `merge`. On the other hand, if the built-in `disableMerge` is not triggered, then Reviewpad will be able to `merge`.

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Improvements (non-breaking change without functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Manual tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
