### PR TITLE
chore: remove ReviewpadIgnoreCommentAnnotation and its references

### DIFF
--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -223,7 +223,7 @@ func (i *Interpreter) ReportMetrics() error {
 			return err
 		}
 
-		r := fmt.Sprintf("%s%s\n## 📈 Pull Request Metrics\n%s", ReviewpadMetricReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation, report.String())
+		r := fmt.Sprintf("%s\n## 📈 Pull Request Metrics\n%s", ReviewpadMetricReportCommentAnnotation, report.String())
 
 		if comment == nil {
 			err = AddReportComment(i.Env, r)

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -565,7 +565,7 @@ func TestReport_OnSilentMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 				[]*github.IssueComment{
 					{
 						ID:   github.Int64(1234),
-						Body: github.String(fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)),
+						Body: github.String(fmt.Sprintf("%s\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated", ReviewpadReportCommentAnnotation)),
 					},
 				},
 			),
@@ -626,7 +626,7 @@ func TestReport_OnSilentMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 
 func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 	var addedComment string
-	commentToBeAdded := fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\nNo actions executed\n```\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
+	commentToBeAdded := fmt.Sprintf("%s\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\nNo actions executed\n```\n", ReviewpadReportCommentAnnotation)
 	mockedEnv := MockDefaultEnv(
 		t,
 		[]mock.MockBackendOption{
@@ -663,7 +663,7 @@ func TestReport_OnVerboseMode_WhenNoReviewpadCommentIsFound(t *testing.T) {
 
 func TestReport_OnVerboseMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) {
 	var updatedComment string
-	commentUpdated := fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\nNo actions executed\n```\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
+	commentUpdated := fmt.Sprintf("%s\n**Reviewpad Report**\n\n:scroll: **Executed actions**\n```yaml\nNo actions executed\n```\n", ReviewpadReportCommentAnnotation)
 	mockedEnv := MockDefaultEnv(
 		t,
 		[]mock.MockBackendOption{
@@ -672,7 +672,7 @@ func TestReport_OnVerboseMode_WhenThereIsAlreadyAReviewpadComment(t *testing.T) 
 				[]*github.IssueComment{
 					{
 						ID:   github.Int64(1234),
-						Body: github.String(fmt.Sprintf("%s%s\n**Reviewpad Report**\n**:information_source: Messages**\n* Changes the README.md", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)),
+						Body: github.String(fmt.Sprintf("%s\n**Reviewpad Report**\n**:information_source: Messages**\n* Changes the README.md", ReviewpadReportCommentAnnotation)),
 					},
 				},
 			),

--- a/lang/aladino/report.go
+++ b/lang/aladino/report.go
@@ -17,7 +17,6 @@ type Report struct {
 	Actions []string
 }
 
-const ReviewpadIgnoreCommentAnnotation = "<!--@annotation-reviewpad-ignore-->"
 const ReviewpadReportCommentAnnotation = "<!--@annotation-reviewpad-report-->"
 const ReviewpadMetricReportCommentAnnotation = "<!--@annotation-reviewpad-metric-report-->"
 
@@ -29,7 +28,7 @@ func builtReportHeader(safeMode bool) string {
 	var sb strings.Builder
 
 	// Annotations
-	sb.WriteString(fmt.Sprintf("%s%s\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation))
+	sb.WriteString(fmt.Sprintf("%s\n", ReviewpadReportCommentAnnotation))
 	// Header
 	if safeMode {
 		sb.WriteString("**Reviewpad Report** (Reviewpad ran in dry-run mode because configuration has changed)\n\n")
@@ -109,7 +108,6 @@ func BuildDryRunExecutionReport(program *engine.Program) string {
 
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("%s\n", ReviewpadIgnoreCommentAnnotation))
 	sb.WriteString("**Reviewpad Dry-Run Report**\n\n")
 	sb.WriteString(":scroll: **Actions to be executed**\n")
 	sb.WriteString("```yaml\n")

--- a/lang/aladino/report_internal_test.go
+++ b/lang/aladino/report_internal_test.go
@@ -49,7 +49,7 @@ func TestAddToReport(t *testing.T) {
 }
 
 func TestReportHeader(t *testing.T) {
-	wantReportHeader := fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
+	wantReportHeader := fmt.Sprintf("%s\n**Reviewpad Report**\n\n", ReviewpadReportCommentAnnotation)
 
 	gotReportHeader := builtReportHeader(false)
 
@@ -57,7 +57,7 @@ func TestReportHeader(t *testing.T) {
 }
 
 func TestReportHeader_WhenSafeMode(t *testing.T) {
-	wantReportHeader := fmt.Sprintf("%s%s\n**Reviewpad Report** (Reviewpad ran in dry-run mode because configuration has changed)\n\n", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)
+	wantReportHeader := fmt.Sprintf("%s\n**Reviewpad Report** (Reviewpad ran in dry-run mode because configuration has changed)\n\n", ReviewpadReportCommentAnnotation)
 
 	gotReportHeader := builtReportHeader(true)
 
@@ -69,11 +69,11 @@ func TestBuildReport(t *testing.T) {
 		Actions: []string{"$addLabel(\"test\")"},
 	}
 
-	wantReport := fmt.Sprintf(`%s%s
+	wantReport := fmt.Sprintf(`%s
 **Reviewpad Report**
 
 :scroll: **Executed actions**
-`, ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation) + "```yaml\n$addLabel(\"test\")\n```\n"
+`, ReviewpadReportCommentAnnotation) + "```yaml\n$addLabel(\"test\")\n```\n"
 
 	gotReport := buildReport(engine.VERBOSE_MODE, false, make(map[Severity][]string), &report)
 
@@ -317,7 +317,7 @@ func TestFindReportComment_WhenPullRequestCommentsListingFails(t *testing.T) {
 
 func TestFindReportComment_WhenThereIsReviewpadComment(t *testing.T) {
 	wantComment := &github.IssueComment{
-		Body: github.String(fmt.Sprintf("%s%s\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated", ReviewpadReportCommentAnnotation, ReviewpadIgnoreCommentAnnotation)),
+		Body: github.String(fmt.Sprintf("%s\n**Reviewpad Report**\n\n:scroll: **Explanation**\nNo workflows activated", ReviewpadReportCommentAnnotation)),
 	}
 	mockedEnv := MockDefaultEnv(
 		t,

--- a/plugins/aladino/actions/comment.go
+++ b/plugins/aladino/actions/comment.go
@@ -5,8 +5,6 @@
 package plugins_aladino_actions
 
 import (
-	"fmt"
-
 	"github.com/reviewpad/reviewpad/v3/handler"
 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
 )
@@ -22,7 +20,6 @@ func Comment() *aladino.BuiltInAction {
 func commentCode(e aladino.Env, args []aladino.Value) error {
 	t := e.GetTarget()
 	commentBody := args[0].(*aladino.StringValue).Val
-	commentBodyWithReviewpadAnnotation := fmt.Sprintf("%s\n%s", aladino.ReviewpadIgnoreCommentAnnotation, commentBody)
 
-	return t.Comment(commentBodyWithReviewpadAnnotation)
+	return t.Comment(commentBody)
 }

--- a/plugins/aladino/actions/commentOnce.go
+++ b/plugins/aladino/actions/commentOnce.go
@@ -26,7 +26,7 @@ func commentOnceCode(e aladino.Env, args []aladino.Value) error {
 	t := e.GetTarget()
 
 	commentBody := args[0].(*aladino.StringValue).Val
-	commentBodyWithReviewpadAnnotation := fmt.Sprintf("%s%s\n%s", ReviewpadCommentAnnotation, aladino.ReviewpadIgnoreCommentAnnotation, commentBody)
+	commentBodyWithReviewpadAnnotation := fmt.Sprintf("%s\n%s", ReviewpadCommentAnnotation, commentBody)
 	commentBodyWithReviewpadAnnotationHash := sha256.Sum256([]byte(commentBodyWithReviewpadAnnotation))
 
 	comments, err := t.GetComments()

--- a/plugins/aladino/actions/commentOnce_test.go
+++ b/plugins/aladino/actions/commentOnce_test.go
@@ -61,7 +61,7 @@ func TestCommentOnce_WhenCommentAlreadyExists(t *testing.T) {
 				mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 				[]*github.IssueComment{
 					{
-						Body: github.String(fmt.Sprintf("%s%s\n%s", ReviewpadCommentAnnotation, aladino.ReviewpadIgnoreCommentAnnotation, existingComment)),
+						Body: github.String(fmt.Sprintf("%s\n%s", ReviewpadCommentAnnotation, existingComment)),
 					},
 				},
 			),
@@ -117,5 +117,5 @@ func TestCommentOnce_WhenFirstTime(t *testing.T) {
 	err := commentOnce(mockedEnv, args)
 
 	assert.Nil(t, err)
-	assert.Equal(t, fmt.Sprintf("%s%s\n%s", ReviewpadCommentAnnotation, aladino.ReviewpadIgnoreCommentAnnotation, commentToAdd), addedComment)
+	assert.Equal(t, fmt.Sprintf("%s\n%s", ReviewpadCommentAnnotation, commentToAdd), addedComment)
 }

--- a/plugins/aladino/actions/comment_test.go
+++ b/plugins/aladino/actions/comment_test.go
@@ -5,7 +5,6 @@
 package plugins_aladino_actions_test
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -22,7 +21,6 @@ var comment = plugins_aladino.PluginBuiltIns().Actions["comment"].Code
 
 func TestComment(t *testing.T) {
 	rawComment := "Lorem Ipsum"
-	wantComment := fmt.Sprintf("%s\n%s", aladino.ReviewpadIgnoreCommentAnnotation, rawComment)
 	gotComment := ""
 
 	mockedEnv := aladino.MockDefaultEnv(
@@ -53,5 +51,5 @@ func TestComment(t *testing.T) {
 	err := comment(mockedEnv, args)
 
 	assert.Nil(t, err)
-	assert.Equal(t, wantComment, gotComment)
+	assert.Equal(t, rawComment, gotComment)
 }

--- a/runner.go
+++ b/runner.go
@@ -56,7 +56,6 @@ func createCommentWithReviewpadCommandEvaluationError(env *engine.Env, err error
 	command := env.EventDetails.Payload.(*github.IssueCommentEvent).GetComment().GetBody()
 
 	commentBody := new(strings.Builder)
-	commentBody.WriteString(fmt.Sprintf("%s\n", aladino.ReviewpadIgnoreCommentAnnotation))
 	commentBody.WriteString(fmt.Sprintf("> %s\n\n", command))
 	commentBody.WriteString(fmt.Sprintf("\n*Errors:*\n- %s\n", err.Error()))
 
@@ -72,7 +71,6 @@ func createCommentWithReviewpadCommandExecutionError(env *engine.Env, err error)
 	sender := env.EventDetails.Payload.(*github.IssueCommentEvent).GetSender().GetLogin()
 
 	commentBody := new(strings.Builder)
-	commentBody.WriteString(fmt.Sprintf("%s\n", aladino.ReviewpadIgnoreCommentAnnotation))
 	commentBody.WriteString(fmt.Sprintf("> %s\n\n", command))
 	commentBody.WriteString(fmt.Sprintf("@%s an error occurred running your command\n", sender))
 	commentBody.WriteString("\n*Errors:*\n")
@@ -101,7 +99,6 @@ func createCommentWithReviewpadCommandExecutionSuccess(env *engine.Env, executio
 	command := env.EventDetails.Payload.(*github.IssueCommentEvent).GetComment().GetBody()
 
 	commentBody := new(strings.Builder)
-	commentBody.WriteString(fmt.Sprintf("%s\n", aladino.ReviewpadIgnoreCommentAnnotation))
 	commentBody.WriteString(fmt.Sprintf("> %s\n\n", command))
 	commentBody.WriteString(fmt.Sprintf("\n*Execution details:*\n\n%s", executionDetails))
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request removes the `ReviewpadIgnoreCommentAnnotation` and all the code associated with it.

## Related issue

<!-- Closes # (issue) -->
Closes #700 

## Type of change

<!-- Uncomment the right types of change from the options below: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Unit tests.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have run `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post-merge --> 
- [x] Ask: this pull request requires a code review before the merge
