### PR TITLE
feat: add parameter to ignore certain conclusions in have all checks run completed

### DIFF
--- a/engine/transform.go
+++ b/engine/transform.go
@@ -65,7 +65,7 @@ func addDefaultCloseReason(str string) string {
 }
 
 func addDefaultHaveAllChecksRunCompleted(str string) string {
-	allArgsRegex := regexp.MustCompile(`\$haveAllChecksRunCompleted\(((?:\[.*\])|(?:[^,]+)),\s*((?:\[.*\])|(?:[^,]+)),\s*((?:\[.*\])|(?:[^,]+))\)`)
+	allArgsRegex := regexp.MustCompile(`\$haveAllChecksRunCompleted\(((?:\[[^\(\)]*\])|(?:\$.+\(.*\))),\s*((?:\"[^\"]*\")|(?:\$.+\(.*\))),\s((?:\[[^\(\)]*\])|(?:\$.+\(.*\)))\)`)
 	if allArgsRegex.MatchString(str) {
 		return str
 	}
@@ -91,7 +91,7 @@ func addEmptyApproveComment(str string) string {
 }
 
 func addDefaultAssignCodeAuthorReviewer(str string) string {
-	allArgsRegex := regexp.MustCompile(`\$assignCodeAuthorReviewers\((\d+),\s*((?:\[.*\])|(?:[^,]+)),\s*\d+\)`)
+	allArgsRegex := regexp.MustCompile(`^\$assignCodeAuthorReviewers\((\d+),\s*((?:\[.*\])|(?:[^,]+)),\s*\d+\)$`)
 	if allArgsRegex.MatchString(str) {
 		return str
 	}

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -65,12 +65,18 @@ func addDefaultCloseReason(str string) string {
 }
 
 func addDefaultHaveAllChecksRunCompleted(str string) string {
-	r := regexp.MustCompile(`\$haveAllChecksRunCompleted\(((?:\[(?:".*")?(?:,".*")?\])|(?:[^,\s\[\]]+))?(?:,\s*("[^\(\)]*"))?\)`)
-	str = r.ReplaceAllString(str, `$$haveAllChecksRunCompleted($1, $2)`)
-	r = regexp.MustCompile(`\$haveAllChecksRunCompleted\(((?:\[(?:".*")?(?:,".*")?\])|(?:[^,\s]+))?(\,\s?)?\)`)
+	allArgsRegex := regexp.MustCompile(`\$haveAllChecksRunCompleted\(((?:\[.*\])|(?:[^,]+)),\s*((?:\[.*\])|(?:[^,]+)),\s*((?:\[.*\])|(?:[^,]+))\)`)
+	if allArgsRegex.MatchString(str) {
+		return str
+	}
+
+	str = strings.ReplaceAll(str, "$haveAllChecksRunCompleted()", "$haveAllChecksRunCompleted([])")
+
+	r := regexp.MustCompile(`\$haveAllChecksRunCompleted\((\[[^\(\)]+\]|(?:\$.+\(.*\))|(?:[^,\(\)]+))\)`)
 	str = r.ReplaceAllString(str, `$$haveAllChecksRunCompleted($1, "")`)
-	r = regexp.MustCompile(`\$haveAllChecksRunCompleted\(,\s?""\)`)
-	return r.ReplaceAllString(str, `$$haveAllChecksRunCompleted([], "")`)
+
+	r = regexp.MustCompile(`\$haveAllChecksRunCompleted\((\[[^\(\)]+\]|(?:\$.+\(.*\))|(?:[^,\(\)]+)),\s*(\[[^\(\)]+\]|(?:\$.+\(.*\))|(?:[^,\(\)]+))\)`)
+	return r.ReplaceAllString(str, `$$haveAllChecksRunCompleted($1, $2, [])`)
 }
 
 func addDefaultJoinSeparator(str string) string {

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -91,7 +91,7 @@ func addEmptyApproveComment(str string) string {
 }
 
 func addDefaultAssignCodeAuthorReviewer(str string) string {
-	allArgsRegex := regexp.MustCompile(`^\$assignCodeAuthorReviewers\((\d+),\s*((?:\[.*\])|(?:[^,]+)),\s*\d+\)$`)
+	allArgsRegex := regexp.MustCompile(`\$assignCodeAuthorReviewers\((\d+),\s*((?:\[.*\])|(?:[^,]+)),\s*\d+\)`)
 	if allArgsRegex.MatchString(str) {
 		return str
 	}

--- a/engine/transform_internal_test.go
+++ b/engine/transform_internal_test.go
@@ -111,9 +111,9 @@ func TestTransformAladinoExpression(t *testing.T) {
 			arg:     `$haveAllChecksRunCompleted(["build", "test"], "success", ["skipped"])`,
 			wantVal: `$haveAllChecksRunCompleted(["build", "test"], "success", ["skipped"])`,
 		},
-		"multiple $haveAllChecksRunCompleted": {
-			arg:     `$haveAllChecksRunCompleted() && true && $haveAllChecksRunCompleted(["build"]) && $haveAllChecksRunCompleted(["build", "run"], "completed") && $haveAllChecksRunCompleted([]) && $haveAllChecksRunCompleted([], "")`,
-			wantVal: `$haveAllChecksRunCompleted([], "", []) && true && $haveAllChecksRunCompleted(["build"], "", []) && $haveAllChecksRunCompleted(["build", "run"], "completed", []) && $haveAllChecksRunCompleted([], "", []) && $haveAllChecksRunCompleted([], "", [])`,
+		"one $haveAllChecksRunCompleted with two args provided": {
+			arg:     `$haveAllChecksRunCompleted(["build"], "completed")`,
+			wantVal: `$haveAllChecksRunCompleted(["build"], "completed", [])`,
 		},
 		"join empty array with empty separator": {
 			arg:     `$join([])`,

--- a/engine/transform_internal_test.go
+++ b/engine/transform_internal_test.go
@@ -97,23 +97,23 @@ func TestTransformAladinoExpression(t *testing.T) {
 		},
 		"multiple $haveAllChecksRunCompleted with one empty": {
 			arg:     `$haveAllChecksRunCompleted() && true && $haveAllChecksRunCompleted(["build"])`,
-			wantVal: `$haveAllChecksRunCompleted([], "") && true && $haveAllChecksRunCompleted(["build"], "")`,
+			wantVal: `$haveAllChecksRunCompleted([], "", []) && true && $haveAllChecksRunCompleted(["build"], "", [])`,
 		},
 		"one $haveAllChecksRunCompleted with arg provided": {
-			arg:     `$haveAllChecksRunCompleted(["build", "test"], "")`,
-			wantVal: `$haveAllChecksRunCompleted(["build", "test"], "")`,
+			arg:     `$haveAllChecksRunCompleted(["build", "test"], "", [])`,
+			wantVal: `$haveAllChecksRunCompleted(["build", "test"], "", [])`,
 		},
 		"one $haveAllChecksRunCompleted with no arg provided": {
 			arg:     `$haveAllChecksRunCompleted()`,
-			wantVal: `$haveAllChecksRunCompleted([], "")`,
+			wantVal: `$haveAllChecksRunCompleted([], "", [])`,
 		},
 		"one $haveAllChecksRunCompleted with no empty arg provided": {
-			arg:     `$haveAllChecksRunCompleted([], "success")`,
-			wantVal: `$haveAllChecksRunCompleted([], "success")`,
+			arg:     `$haveAllChecksRunCompleted([], "success", [])`,
+			wantVal: `$haveAllChecksRunCompleted([], "success", [])`,
 		},
 		"multiple $haveAllChecksRunCompleted": {
 			arg:     `$haveAllChecksRunCompleted() && true && $haveAllChecksRunCompleted(["build"]) && $haveAllChecksRunCompleted(["build", "run"], "completed") && $haveAllChecksRunCompleted([]) && $haveAllChecksRunCompleted([], "")`,
-			wantVal: `$haveAllChecksRunCompleted([], "") && true && $haveAllChecksRunCompleted(["build"], "") && $haveAllChecksRunCompleted(["build", "run"], "completed") && $haveAllChecksRunCompleted([], "") && $haveAllChecksRunCompleted([], "")`,
+			wantVal: `$haveAllChecksRunCompleted([], "", []) && true && $haveAllChecksRunCompleted(["build"], "", []) && $haveAllChecksRunCompleted(["build", "run"], "completed", []) && $haveAllChecksRunCompleted([], "", []) && $haveAllChecksRunCompleted([], "", [])`,
 		},
 		"join empty array with empty separator": {
 			arg:     `$join([])`,

--- a/engine/transform_internal_test.go
+++ b/engine/transform_internal_test.go
@@ -108,8 +108,8 @@ func TestTransformAladinoExpression(t *testing.T) {
 			wantVal: `$haveAllChecksRunCompleted([], "", [])`,
 		},
 		"one $haveAllChecksRunCompleted with no empty arg provided": {
-			arg:     `$haveAllChecksRunCompleted([], "success", [])`,
-			wantVal: `$haveAllChecksRunCompleted([], "success", [])`,
+			arg:     `$haveAllChecksRunCompleted(["build", "test"], "success", ["skipped"])`,
+			wantVal: `$haveAllChecksRunCompleted(["build", "test"], "success", ["skipped"])`,
 		},
 		"multiple $haveAllChecksRunCompleted": {
 			arg:     `$haveAllChecksRunCompleted() && true && $haveAllChecksRunCompleted(["build"]) && $haveAllChecksRunCompleted(["build", "run"], "completed") && $haveAllChecksRunCompleted([]) && $haveAllChecksRunCompleted([], "")`,

--- a/plugins/aladino/functions/haveAllChecksRunCompleted.go
+++ b/plugins/aladino/functions/haveAllChecksRunCompleted.go
@@ -13,7 +13,11 @@ import (
 
 func HaveAllChecksRunCompleted() *aladino.BuiltInFunction {
 	return &aladino.BuiltInFunction{
-		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildArrayOfType(aladino.BuildStringType()), aladino.BuildStringType()}, aladino.BuildBoolType()),
+		Type: aladino.BuildFunctionType([]aladino.Type{
+			aladino.BuildArrayOfType(aladino.BuildStringType()),
+			aladino.BuildStringType(),
+			aladino.BuildArrayOfType(aladino.BuildStringType()),
+		}, aladino.BuildBoolType()),
 		Code:           haveAllChecksRunCompleted,
 		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest},
 	}

--- a/plugins/aladino/functions/haveAllChecksRunCompleted_test.go
+++ b/plugins/aladino/functions/haveAllChecksRunCompleted_test.go
@@ -17,12 +17,13 @@ var haveAllChecksRunCompleted = plugins_aladino.PluginBuiltIns().Functions["have
 
 func TestHaveAllChecksRunCompleted(t *testing.T) {
 	tests := map[string]struct {
-		checkRunsToIgnore  *aladino.ArrayValue
-		conclusion         *aladino.StringValue
-		mockBackendOptions []mock.MockBackendOption
-		graphQLHandler     http.HandlerFunc
-		wantResult         aladino.Value
-		wantErr            error
+		checkRunsToIgnore   *aladino.ArrayValue
+		conclusion          *aladino.StringValue
+		conclusionsToIgnore *aladino.ArrayValue
+		mockBackendOptions  []mock.MockBackendOption
+		graphQLHandler      http.HandlerFunc
+		wantResult          aladino.Value
+		wantErr             error
 	}{
 		"when last commit sha failed": {
 			mockBackendOptions: []mock.MockBackendOption{},
@@ -49,8 +50,9 @@ func TestHaveAllChecksRunCompleted(t *testing.T) {
 			wantResult: aladino.BuildBoolValue(false),
 		},
 		"when listing check runs fails": {
-			checkRunsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
-			conclusion:        aladino.BuildStringValue(""),
+			checkRunsToIgnore:   aladino.BuildArrayValue([]aladino.Value{}),
+			conclusion:          aladino.BuildStringValue(""),
+			conclusionsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
 			mockBackendOptions: []mock.MockBackendOption{
 				mock.WithRequestMatchHandler(
 					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -84,8 +86,9 @@ func TestHaveAllChecksRunCompleted(t *testing.T) {
 			},
 		},
 		"when there are no check runs": {
-			checkRunsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
-			conclusion:        aladino.BuildStringValue(""),
+			checkRunsToIgnore:   aladino.BuildArrayValue([]aladino.Value{}),
+			conclusion:          aladino.BuildStringValue(""),
+			conclusionsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
 			mockBackendOptions: []mock.MockBackendOption{
 				mock.WithRequestMatch(
 					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -117,8 +120,9 @@ func TestHaveAllChecksRunCompleted(t *testing.T) {
 			wantResult: aladino.BuildBoolValue(true),
 		},
 		"when all check runs are completed": {
-			checkRunsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
-			conclusion:        aladino.BuildStringValue(""),
+			checkRunsToIgnore:   aladino.BuildArrayValue([]aladino.Value{}),
+			conclusion:          aladino.BuildStringValue(""),
+			conclusionsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
 			mockBackendOptions: []mock.MockBackendOption{
 				mock.WithRequestMatch(
 					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -161,8 +165,9 @@ func TestHaveAllChecksRunCompleted(t *testing.T) {
 			wantResult: aladino.BuildBoolValue(true),
 		},
 		"when all check runs are not completed with success conclusion": {
-			checkRunsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
-			conclusion:        aladino.BuildStringValue("success"),
+			checkRunsToIgnore:   aladino.BuildArrayValue([]aladino.Value{}),
+			conclusion:          aladino.BuildStringValue("success"),
+			conclusionsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
 			mockBackendOptions: []mock.MockBackendOption{
 				mock.WithRequestMatch(
 					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -205,8 +210,9 @@ func TestHaveAllChecksRunCompleted(t *testing.T) {
 			wantResult: aladino.BuildBoolValue(false),
 		},
 		"when all check runs are completed with success conclusion": {
-			checkRunsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
-			conclusion:        aladino.BuildStringValue("success"),
+			checkRunsToIgnore:   aladino.BuildArrayValue([]aladino.Value{}),
+			conclusion:          aladino.BuildStringValue("success"),
+			conclusionsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
 			mockBackendOptions: []mock.MockBackendOption{
 				mock.WithRequestMatch(
 					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -249,8 +255,9 @@ func TestHaveAllChecksRunCompleted(t *testing.T) {
 			wantResult: aladino.BuildBoolValue(true),
 		},
 		"when all check runs are completed with ignored": {
-			checkRunsToIgnore: aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("build")}),
-			conclusion:        aladino.BuildStringValue(""),
+			checkRunsToIgnore:   aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("build")}),
+			conclusion:          aladino.BuildStringValue(""),
+			conclusionsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
 			mockBackendOptions: []mock.MockBackendOption{
 				mock.WithRequestMatch(
 					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -292,8 +299,9 @@ func TestHaveAllChecksRunCompleted(t *testing.T) {
 			wantResult: aladino.BuildBoolValue(true),
 		},
 		"when all check runs are completed with ignored and success conclusion": {
-			checkRunsToIgnore: aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("run")}),
-			conclusion:        aladino.BuildStringValue("success"),
+			checkRunsToIgnore:   aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("run")}),
+			conclusion:          aladino.BuildStringValue("success"),
+			conclusionsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
 			mockBackendOptions: []mock.MockBackendOption{
 				mock.WithRequestMatch(
 					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -341,8 +349,9 @@ func TestHaveAllChecksRunCompleted(t *testing.T) {
 			wantResult: aladino.BuildBoolValue(true),
 		},
 		"when all check runs are completed with ignored and failure conclusion": {
-			checkRunsToIgnore: aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("build")}),
-			conclusion:        aladino.BuildStringValue("failure"),
+			checkRunsToIgnore:   aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("build")}),
+			conclusion:          aladino.BuildStringValue("failure"),
+			conclusionsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
 			mockBackendOptions: []mock.MockBackendOption{
 				mock.WithRequestMatch(
 					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -390,8 +399,9 @@ func TestHaveAllChecksRunCompleted(t *testing.T) {
 			wantResult: aladino.BuildBoolValue(true),
 		},
 		"when reviewpad is one of the checks": {
-			checkRunsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
-			conclusion:        aladino.BuildStringValue(""),
+			checkRunsToIgnore:   aladino.BuildArrayValue([]aladino.Value{}),
+			conclusion:          aladino.BuildStringValue(""),
+			conclusionsToIgnore: aladino.BuildArrayValue([]aladino.Value{}),
 			mockBackendOptions: []mock.MockBackendOption{
 				mock.WithRequestMatch(
 					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
@@ -432,13 +442,63 @@ func TestHaveAllChecksRunCompleted(t *testing.T) {
 			},
 			wantResult: aladino.BuildBoolValue(true),
 		},
+		"when check runs are skipped with ignored conclusion and check run": {
+			checkRunsToIgnore:   aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("build")}),
+			conclusion:          aladino.BuildStringValue("success"),
+			conclusionsToIgnore: aladino.BuildArrayValue([]aladino.Value{aladino.BuildStringValue("skipped")}),
+			mockBackendOptions: []mock.MockBackendOption{
+				mock.WithRequestMatch(
+					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
+					github.ListCheckRunsResults{
+						Total: github.Int(2),
+						CheckRuns: []*github.CheckRun{
+							{
+								Name:       github.String("build"),
+								Status:     github.String("completed"),
+								Conclusion: github.String("failure"),
+							},
+							{
+								Name:       github.String("run"),
+								Status:     github.String("in_progress"),
+								Conclusion: github.String("skipped"),
+							},
+							{
+								Name:       github.String("test"),
+								Status:     github.String("completed"),
+								Conclusion: github.String("skipped"),
+							},
+						},
+					},
+				),
+			},
+			graphQLHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"commits": {
+									"nodes": [
+										{
+											"commit": {
+												"oid": "b0b55a8a10139a324f3ccb1a6481862a4b5b5bcc"
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantResult: aladino.BuildBoolValue(true),
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			env := aladino.MockDefaultEnv(t, test.mockBackendOptions, test.graphQLHandler, nil, nil)
 
-			res, err := haveAllChecksRunCompleted(env, []aladino.Value{test.checkRunsToIgnore, test.conclusion})
+			res, err := haveAllChecksRunCompleted(env, []aladino.Value{test.checkRunsToIgnore, test.conclusion, test.conclusionsToIgnore})
 
 			githubError := &github.ErrorResponse{}
 			if errors.As(err, &githubError) {


### PR DESCRIPTION
## Description
Adds a third parameter to the `$haveAllChecksRunCompleted` built-in function that allows the user to ignore certain conclusions
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #705 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
