### PR TITLE
feat: built-in hasOnlyCodeChanges with semantic diff 

### DIFF
--- a/codehost/diff.go
+++ b/codehost/diff.go
@@ -22,7 +22,7 @@ type diffSpan struct {
 }
 
 type diffBlock struct {
-	isContext bool
+	IsContext bool
 	Old       *diffSpan
 	New       *diffSpan
 	oldLine   string
@@ -140,7 +140,7 @@ func appendUnmodifiedLine(diff *diff, lines *chunkLinesInfo, lineText string) {
 	var block *diffBlock
 	if len(diff.blocks) > 0 {
 		lastBlock := diff.blocks[len(diff.blocks)-1]
-		if lastBlock.isContext && lastBlock.Old.End == lines.oldLine-1 {
+		if lastBlock.IsContext && lastBlock.Old.End == lines.oldLine-1 {
 			block = lastBlock
 			block.newLine = block.newLine + "\n" + lineText
 			block.oldLine = block.oldLine + "\n" + lineText
@@ -157,7 +157,7 @@ func appendUnmodifiedLine(diff *diff, lines *chunkLinesInfo, lineText string) {
 				Start: lines.newLine,
 				End:   0,
 			},
-			isContext: true,
+			IsContext: true,
 			oldLine:   lineText,
 			newLine:   lineText,
 		}
@@ -171,7 +171,7 @@ func appendUnmodifiedLine(diff *diff, lines *chunkLinesInfo, lineText string) {
 
 func appendAddedLine(diff *diff, lines *chunkLinesInfo, lineText string) {
 	var block *diffBlock
-	if len(diff.blocks) > 0 && !diff.blocks[len(diff.blocks)-1].isContext {
+	if len(diff.blocks) > 0 && !diff.blocks[len(diff.blocks)-1].IsContext {
 		block = diff.blocks[len(diff.blocks)-1]
 		if block.New == nil {
 			block.New = &diffSpan{
@@ -188,7 +188,7 @@ func appendAddedLine(diff *diff, lines *chunkLinesInfo, lineText string) {
 				Start: lines.newLine,
 				End:   0,
 			},
-			isContext: false,
+			IsContext: false,
 			newLine:   lineText,
 		}
 		diff.blocks = append(diff.blocks, block)
@@ -199,7 +199,7 @@ func appendAddedLine(diff *diff, lines *chunkLinesInfo, lineText string) {
 
 func appendRemovedLine(diff *diff, lines *chunkLinesInfo, lineText string) {
 	var block *diffBlock
-	if len(diff.blocks) > 0 && !diff.blocks[len(diff.blocks)-1].isContext && diff.blocks[len(diff.blocks)-1].New == nil {
+	if len(diff.blocks) > 0 && !diff.blocks[len(diff.blocks)-1].IsContext && diff.blocks[len(diff.blocks)-1].New == nil {
 		block = diff.blocks[len(diff.blocks)-1]
 		block.oldLine = block.oldLine + "\n" + lineText
 	} else {
@@ -208,7 +208,7 @@ func appendRemovedLine(diff *diff, lines *chunkLinesInfo, lineText string) {
 				Start: lines.oldLine,
 				End:   0,
 			},
-			isContext: false,
+			IsContext: false,
 			oldLine:   lineText,
 		}
 		diff.blocks = append(diff.blocks, block)

--- a/codehost/file.go
+++ b/codehost/file.go
@@ -22,7 +22,7 @@ func (f *File) AppendToDiff(
 	oldLine, newLine string,
 ) {
 	f.Diff = append(f.Diff, &diffBlock{
-		isContext: isContext,
+		IsContext: isContext,
 		Old: &diffSpan{
 			int32(oldStart),
 			int32(oldEnd),
@@ -55,7 +55,7 @@ func (f *File) Query(expr string) (bool, error) {
 	}
 
 	for _, block := range f.Diff {
-		if !block.isContext {
+		if !block.IsContext {
 			if r.Match([]byte(block.newLine)) {
 				return true, nil
 			}

--- a/codehost/file_internal_test.go
+++ b/codehost/file_internal_test.go
@@ -53,7 +53,7 @@ func TestAppendToDiff(t *testing.T) {
 
 	wantDiff := []*diffBlock{
 		{
-			isContext: isContext,
+			IsContext: isContext,
 			Old: &diffSpan{
 				int32(oldStart),
 				int32(oldEnd),

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -61,8 +61,8 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 	return &aladino.BuiltIns{
 		Functions: map[string]*aladino.BuiltInFunction{
 			// Pull Request
-			"assignees":                 functions.Assignees(),
 			"approvalsCount":            functions.ApprovalsCount(),
+			"assignees":                 functions.Assignees(),
 			"author":                    functions.Author(),
 			"base":                      functions.Base(),
 			"changed":                   functions.Changed(),
@@ -86,15 +86,16 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"hasGitConflicts":           functions.HasGitConflicts(),
 			"hasLinearHistory":          functions.HasLinearHistory(),
 			"hasLinkedIssues":           functions.HasLinkedIssues(),
+			"hasOnlyCodeChanges":        functions.HasOnlyCodeChanges(),
 			"hasRequiredApprovals":      functions.HasRequiredApprovals(),
 			"hasUnaddressedThreads":     functions.HasUnaddressedThreads(),
 			"haveAllChecksRunCompleted": functions.HaveAllChecksRunCompleted(),
 			"head":                      functions.Head(),
 			"isBinary":                  functions.IsBinary(),
 			"isDraft":                   functions.IsDraft(),
-			"isUpdatedWithBaseBranch":   functions.IsUpdatedWithBaseBranch(),
 			"isLinkedToProject":         functions.IsLinkedToProject(),
 			"isMerged":                  functions.IsMerged(),
+			"isUpdatedWithBaseBranch":   functions.IsUpdatedWithBaseBranch(),
 			"isWaitingForReview":        functions.IsWaitingForReview(),
 			"labels":                    functions.Labels(),
 			"lastEventAt":               functions.LastEventAt(),

--- a/plugins/aladino/functions/hasOnlyCodeChanges.go
+++ b/plugins/aladino/functions/hasOnlyCodeChanges.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2023 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/reviewpad/api/go/entities"
+	api "github.com/reviewpad/api/go/services"
+	"github.com/reviewpad/reviewpad/v3/codehost/github/target"
+	"github.com/reviewpad/reviewpad/v3/handler"
+	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+	semantic "github.com/reviewpad/reviewpad/v3/plugins/aladino/semantic"
+	plugins_aladino_services "github.com/reviewpad/reviewpad/v3/plugins/aladino/services"
+	"github.com/reviewpad/reviewpad/v3/utils"
+)
+
+func HasOnlyCodeChanges() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type: aladino.BuildFunctionType(
+			[]aladino.Type{
+				aladino.BuildArrayOfType(aladino.BuildStringType()),
+				aladino.BuildArrayOfType(aladino.BuildStringType()),
+			}, aladino.BuildBoolType()),
+		Code:           hasOnlyCodeChanges,
+		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest},
+	}
+}
+
+func hasOnlyCodeChanges(e aladino.Env, args []aladino.Value) (aladino.Value, error) {
+	pullRequest := e.GetTarget().(*target.PullRequestTarget)
+	head := pullRequest.PullRequest.GetHead()
+	url := head.GetRepo().GetURL()
+
+	baseSymbols, baseFiles, err := semantic.GetSymbolsFromBase(e)
+	if err != nil {
+		return nil, err
+	}
+
+	headSymbols, headFiles, err := semantic.GetSymbolsFromHead(e)
+	if err != nil {
+		return nil, err
+	}
+
+	gitDiff, err := getRawDiff(e, baseFiles, headFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	service, ok := e.GetBuiltIns().Services[plugins_aladino_services.DIFF_SERVICE_KEY]
+	if !ok {
+		return nil, fmt.Errorf("diff service not found")
+	}
+
+	diffClient := service.(api.DiffClient)
+
+	req := &api.EnhancedDiffRequest{
+		Old:     baseSymbols,
+		New:     headSymbols,
+		RawDiff: gitDiff,
+		RepoUri: url,
+	}
+
+	reply, err := diffClient.EnhancedDiff(e.GetCtx(), req)
+	if err != nil {
+		return nil, err
+	}
+
+	// if any symbol is modified, then return false
+	for _, symbol := range reply.Diff.Symbols {
+		if symbol.ChangeType != entities.ChangeType_UNMODIFIED {
+			return aladino.BuildFalseValue(), nil
+		}
+	}
+
+	return aladino.BuildTrueValue(), nil
+}
+
+func getRawDiff(e aladino.Env, baseFiles map[string]string, headFiles map[string]string) (*entities.GitDiff, error) {
+	pullRequest := e.GetTarget().(*target.PullRequestTarget)
+	head := pullRequest.PullRequest.GetHead()
+	headCommit := head.GetSHA()
+
+	base := pullRequest.PullRequest.GetBase()
+	baseCommit := base.GetSHA()
+
+	files := make(map[string]*entities.FileInfoDiff)
+	diffs := make(map[string]*entities.GitFileDiffs)
+
+	for fp, commitFile := range pullRequest.Patch {
+		gitFileDiffs := make([]*entities.GitDiffBlock, len(commitFile.Diff))
+
+		for i, diffBlock := range commitFile.Diff {
+			gitFileDiffs[i] = &entities.GitDiffBlock{
+				Old: &entities.GitDiffSpan{
+					Start: diffBlock.Old.Start,
+					End:   diffBlock.Old.End,
+				},
+				New: &entities.GitDiffSpan{
+					Start: diffBlock.New.Start,
+					End:   diffBlock.New.End,
+				},
+				IsContext: diffBlock.IsContext,
+			}
+		}
+
+		diffs[fp] = &entities.GitFileDiffs{
+			Blocks: gitFileDiffs,
+		}
+
+		files[fp] = &entities.FileInfoDiff{
+			OldInfo: &entities.FileInfo{
+				Path:      commitFile.Repr.GetPreviousFilename(),
+				Extension: utils.FileExt(commitFile.Repr.GetPreviousFilename()),
+				BlobId:    commitFile.Repr.GetBlobURL(),
+				NumLines:  getLineCount(baseFiles[fp]),
+			},
+			NewInfo: &entities.FileInfo{
+				Path:      commitFile.Repr.GetFilename(),
+				Extension: utils.FileExt(commitFile.Repr.GetFilename()),
+				BlobId:    commitFile.Repr.GetBlobURL(),
+				NumLines:  getLineCount(headFiles[fp]),
+			},
+			NumAddedLines:   int32(commitFile.Repr.GetAdditions()),
+			NumRemovedLines: int32(commitFile.Repr.GetDeletions()),
+			// FIXME: this is not correct, we need to check if the file is binary
+			// IsBinary: false,
+		}
+	}
+
+	res := &entities.GitDiff{
+		OldCommitId: baseCommit,
+		NewCommitId: headCommit,
+		Files:       files,
+		Diffs:       diffs,
+	}
+
+	return res, nil
+}
+
+func getLineCount(contents string) int32 {
+	numLines := int32(strings.Count(contents, "\n") + 1)
+	//Ignoring end of line whitespaces
+	if len(contents) > 0 && rune(contents[len(contents)-1]) == '\n' {
+		numLines--
+	}
+
+	return numLines
+}

--- a/plugins/aladino/semantic/symbols.go
+++ b/plugins/aladino/semantic/symbols.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/go-github/v49/github"
 	"github.com/reviewpad/api/go/entities"
 	api "github.com/reviewpad/api/go/services"
 	"github.com/reviewpad/reviewpad/v3/codehost"
@@ -70,6 +71,109 @@ func GetSymbolsFromPatch(e aladino.Env) (map[string]*entities.Symbols, error) {
 	}
 
 	return res, nil
+}
+
+func GetSymbolsFromHead(e aladino.Env) (*entities.Symbols, map[string]string, error) {
+	pullRequest := e.GetTarget().(*target.PullRequestTarget)
+	head := pullRequest.PullRequest.GetHead()
+	patch := pullRequest.Patch
+
+	res := &entities.Symbols{
+		Files:   make(map[string]*entities.File),
+		Symbols: make(map[string]*entities.Symbol),
+	}
+
+	files := make(map[string]string)
+
+	for fp, commitFile := range patch {
+		if commitFile.Repr.GetStatus() == "removed" {
+			// in this case, the file is not in the head branch
+			continue
+		}
+
+		symbols, contents, err := GetSymbolsFromFileInBranch(e, commitFile, head)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		files[fp] = contents
+		joinSymbols(res, symbols)
+	}
+
+	return res, files, nil
+}
+
+func GetSymbolsFromBase(e aladino.Env) (*entities.Symbols, map[string]string, error) {
+	pullRequest := e.GetTarget().(*target.PullRequestTarget)
+	base := pullRequest.PullRequest.GetBase()
+	patch := pullRequest.Patch
+
+	res := &entities.Symbols{
+		Files:   make(map[string]*entities.File),
+		Symbols: make(map[string]*entities.Symbol),
+	}
+
+	files := make(map[string]string)
+
+	for fp, commitFile := range patch {
+		if commitFile.Repr.GetStatus() == "added" {
+			// in this case, the file is not in the base branch
+			continue
+		}
+
+		symbols, contents, err := GetSymbolsFromFileInBranch(e, commitFile, base)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		files[fp] = contents
+		joinSymbols(res, symbols)
+	}
+
+	return res, files, nil
+}
+
+func joinSymbols(current *entities.Symbols, new *entities.Symbols) {
+	for path, file := range new.Files {
+		current.Files[path] = file
+	}
+
+	for symbol, gotoSymbol := range new.Symbols {
+		current.Symbols[symbol] = gotoSymbol
+	}
+}
+
+func GetSymbolsFromFileInBranch(e aladino.Env, commitFile *codehost.File, branch *github.PullRequestBranch) (*entities.Symbols, string, error) {
+	fp := commitFile.Repr.GetFilename()
+
+	blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, branch)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Convert the bytes array to string, remove the escape and convert again to bytes
+	str, _ := strconv.Unquote(strings.Replace(strconv.Quote(string(blob)), `\\u`, `\u`, -1))
+	blob = []byte(str)
+
+	service, ok := e.GetBuiltIns().Services[plugins_aladino_services.SEMANTIC_SERVICE_KEY]
+	if !ok {
+		return nil, "", fmt.Errorf("semantic service not found")
+	}
+
+	semanticClient := service.(api.SemanticClient)
+	req := &api.GetSymbolsRequest{
+		Uri:      branch.GetRepo().GetURL(),
+		CommitId: branch.GetSHA(),
+		Filepath: fp,
+		Blob:     blob,
+		BlobId:   commitFile.Repr.GetSHA(),
+	}
+	reply, err := semanticClient.GetSymbols(e.GetCtx(), req)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return reply.GetSymbols(), str, nil
 }
 
 func getBlocks(commitFile *codehost.File) []*entities.ResolveBlockDiff {


### PR DESCRIPTION
## Description

This pull request introduces the main functionality to be able to compute semantic diffs. The hasOnlyCodeChanges built-in uses the semantic diff to check the type of changes made by the developers.

## Related issue

WIP #386 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works <!-- Delete this if not applicable -->
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [ ] Ask: this pull request requires a code review before merge
