### PR TITLE
fix: transform expressions for pipeline until

### DIFF
--- a/engine/loader.go
+++ b/engine/loader.go
@@ -249,7 +249,7 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 
 			transformedStages = append(transformedStages, PadStage{
 				Actions: transformedActions,
-				Until:   stage.Until,
+				Until:   transformAladinoExpression(stage.Until),
 			})
 		}
 


### PR DESCRIPTION
## Description
Passes the `until` part of the pipelines through the aladino expression transformer
<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->

## Related issue

Closes #722 

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Manual tests
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post merge --> 
- [x] Ask: this pull request requires a code review before merge
