### PR TITLE
chore: load reviewpad file from gh method

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -52,6 +52,17 @@ func Load(ctx context.Context, log *logrus.Entry, githubClient *gh.GithubClient,
 	return file, nil
 }
 
+func LoadReviewpadFileFromGitHub(ctx context.Context, logger *logrus.Entry, githubClient *gh.GithubClient, filePath string, branch *github.PullRequestBranch) (*engine.ReviewpadFile, error) {
+	reviewpadFileContent, err := githubClient.DownloadContents(ctx, filePath, branch)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(reviewpadFileContent)
+
+	return Load(ctx, logger, githubClient, buf)
+}
+
 func createCommentWithReviewpadCommandEvaluationError(env *engine.Env, err error) error {
 	command := env.EventDetails.Payload.(*github.IssueCommentEvent).GetComment().GetBody()
 

--- a/runner.go
+++ b/runner.go
@@ -52,17 +52,6 @@ func Load(ctx context.Context, log *logrus.Entry, githubClient *gh.GithubClient,
 	return file, nil
 }
 
-func LoadReviewpadFileFromGitHub(ctx context.Context, logger *logrus.Entry, githubClient *gh.GithubClient, filePath string, branch *github.PullRequestBranch) (*engine.ReviewpadFile, error) {
-	reviewpadFileContent, err := githubClient.DownloadContents(ctx, filePath, branch)
-	if err != nil {
-		return nil, err
-	}
-
-	buf := bytes.NewBuffer(reviewpadFileContent)
-
-	return Load(ctx, logger, githubClient, buf)
-}
-
 func createCommentWithReviewpadCommandEvaluationError(env *engine.Env, err error) error {
 	command := env.EventDetails.Payload.(*github.IssueCommentEvent).GetComment().GetBody()
 

--- a/utils/file.go
+++ b/utils/file.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-github/v49/github"
 	gh "github.com/reviewpad/reviewpad/v3/codehost/github"
+	"github.com/sirupsen/logrus"
 )
 
 const pullRequestFileLimit = 50
@@ -70,4 +71,13 @@ func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, fi
 	}
 
 	return false, nil
+}
+
+func DownloadReviewpadFileFromGitHub(ctx context.Context, logger *logrus.Entry, githubClient *gh.GithubClient, filePath string, branch *github.PullRequestBranch) (*bytes.Buffer, error) {
+	reviewpadFileContent, err := githubClient.DownloadContents(ctx, filePath, branch)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes.NewBuffer(reviewpadFileContent), nil
 }

--- a/utils/file.go
+++ b/utils/file.go
@@ -4,7 +4,16 @@
 
 package utils
 
-import "strings"
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/google/go-github/v49/github"
+	gh "github.com/reviewpad/reviewpad/v3/codehost/github"
+)
+
+const pullRequestFileLimit = 50
 
 func FileExt(fp string) string {
 	strs := strings.Split(fp, ".")
@@ -15,4 +24,50 @@ func FileExt(fp string) string {
 	}
 
 	return str
+}
+
+// reviewpad-an: experimental
+// ReviewpadFileChanges checks if a file path was changed in a pull request.
+// The way this is done depends on the number of files changed in the pull request.
+// If the number of files changed is greater than pullRequestFileLimit,
+// then we download both files using the filePath and check their contents.
+// This strategy assumes that the file path exists in the head branch.
+// Otherwise, we download the pull request files and check the filePath exists in them.
+func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, filePath string, pullRequest *github.PullRequest) (bool, error) {
+	if *pullRequest.ChangedFiles > pullRequestFileLimit {
+		rawHeadFile, err := githubClient.DownloadContents(ctx, filePath, pullRequest.Head)
+		if err != nil {
+			if strings.HasPrefix(err.Error(), "no file named") {
+				return true, nil
+			}
+			return false, err
+		}
+
+		rawBaseFile, err := githubClient.DownloadContents(ctx, filePath, pullRequest.Base)
+		if err != nil {
+			if strings.HasPrefix(err.Error(), "no file named") {
+				return true, nil
+			}
+			return false, err
+		}
+
+		// FIXME: use the hashes of the files
+		return !bytes.Equal(rawBaseFile, rawHeadFile), nil
+	}
+
+	branchRepoOwner := *pullRequest.Base.Repo.Owner.Login
+	branchRepoName := *pullRequest.Base.Repo.Name
+
+	files, err := githubClient.GetPullRequestFiles(ctx, branchRepoOwner, branchRepoName, *pullRequest.Number)
+	if err != nil {
+		return false, err
+	}
+
+	for _, file := range files {
+		if filePath == *file.Filename {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
## Description

<!-- Please include a clear and concise description of the changes. -->
This pull request transfers the methods that load the reviewpad file contents from GitHub and check if the pull request changes the reviewpad file which lived in the GitHub Action.

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

<!-- **Bug fix** (non-breaking change which fixes an issue) -->
<!-- **New feature** (non-breaking change which adds functionality) -->
**Improvements** (non-breaking change without functionality)
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
Manual tests in the dev app where 2 pull requests were opened to test when:
- the changes contain the reviewpad file;
- the changes do not contain the reviewpad file.

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have run `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before the merge
