### PR TITLE
fix: make cloning log debug level

### DIFF
--- a/codehost/github/repo.go
+++ b/codehost/github/repo.go
@@ -52,7 +52,7 @@ func CloneRepository(log *logrus.Entry, url string, token string, path string, o
 		},
 	}
 
-	log.Infof("cloning %s to %s", url, dir)
+	log.Debugf("cloning %s to %s", url, dir)
 
 	repo, err := git.Clone(url, dir, options)
 


### PR DESCRIPTION
## Description
The repo cloning function currently logs the URL used for cloning exposing the access token as well in the logs, this PR converts the log level into Debug so the access token won't be exposed to users.
<!-- Please include a clear and concise description of the changes. -->

## Related issue

Closes #736 

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

<!-- **Bug fix** (non-breaking change which fixes an issue) -->
<!-- **New feature** (non-breaking change which adds functionality) -->
**Improvements** (non-breaking change without functionality) 
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Manual test
<!-- Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge
