### PR TITLE
feat: select amount of desired assignees in assignAssignees

### DIFF
--- a/engine/transform.go
+++ b/engine/transform.go
@@ -122,7 +122,7 @@ func addDefaultHasAnyCheckRunCompleted(str string) string {
 
 func addDefaultsToRequestedAssignees(str string) string {
 	trimmedStr := strings.ReplaceAll(str, " ", "")
-	m := regexp.MustCompile(`\$assignAssignees\(((\[.*\])|(\$(team|group)\("[^"]*"\)))(,(-)?(\d+))?\)`)
+	m := regexp.MustCompile(`\$assignAssignees\(((\[.*\])|(\$(team|group)\("[^"]*"\)))(,((-)?(\d+)))?\)`)
 	match := m.FindStringSubmatch(trimmedStr)
 
 	if len(match) == 0 {

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -122,7 +122,7 @@ func addDefaultHasAnyCheckRunCompleted(str string) string {
 
 func addDefaultsToRequestedAssignees(str string) string {
 	trimmedStr := strings.ReplaceAll(str, " ", "")
-	m := regexp.MustCompile(`\$assignAssignees\(((\[.*\])|(\$(team|group)\("[^"]*"\)))(,(\d+))?\)`)
+	m := regexp.MustCompile(`\$assignAssignees\(((\[.*\])|(\$(team|group)\("[^"]*"\)))(,(-)?(\d+))?\)`)
 	match := m.FindStringSubmatch(trimmedStr)
 
 	if len(match) == 0 {

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -141,7 +141,7 @@ func addDefaultsToRequestedAssignees(str string) string {
 		}
 	}
 
-	return strings.Replace(trimmedStr, match[0], "$assignReviewer("+assignees+", "+totalRequiredAssignees+")", 1)
+	return strings.Replace(trimmedStr, match[0], "$assignAssignees("+assignees+", "+totalRequiredAssignees+")", 1)
 }
 
 func transformAladinoExpression(str string) string {

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -121,9 +121,8 @@ func addDefaultHasAnyCheckRunCompleted(str string) string {
 }
 
 func addDefaultsToRequestedAssignees(str string) string {
-	trimmedStr := strings.ReplaceAll(str, " ", "")
 	m := regexp.MustCompile(`\$assignAssignees\(((\[.*\])|(\$(team|group)\("[^"]*"\)))(,((-)?(\d+)))?\)`)
-	match := m.FindStringSubmatch(trimmedStr)
+	match := m.FindStringSubmatch(str)
 
 	if len(match) == 0 {
 		return str
@@ -141,7 +140,7 @@ func addDefaultsToRequestedAssignees(str string) string {
 		}
 	}
 
-	return strings.Replace(trimmedStr, match[0], "$assignAssignees("+assignees+", "+totalRequiredAssignees+")", 1)
+	return strings.Replace(str, match[0], "$assignAssignees("+assignees+", "+totalRequiredAssignees+")", 1)
 }
 
 func transformAladinoExpression(str string) string {

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -132,13 +132,13 @@ func addDefaultsToRequestedAssignees(str string) string {
 	assignees := match[1]
 	totalRequiredAssignees := match[6]
 
-	intTotalRequiredAssignees, _ := strconv.Atoi(totalRequiredAssignees)
-	if intTotalRequiredAssignees < 0 {
-		totalRequiredAssignees = "0"
-	}
-
 	if totalRequiredAssignees == "" {
 		totalRequiredAssignees = REVIEWPAD_DEFAULT_INT_VALUE
+	} else {
+		intTotalRequiredAssignees, _ := strconv.Atoi(totalRequiredAssignees)
+		if intTotalRequiredAssignees < 0 {
+			totalRequiredAssignees = "0"
+		}
 	}
 
 	return strings.Replace(trimmedStr, match[0], "$assignReviewer("+assignees+", "+totalRequiredAssignees+")", 1)

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -6,12 +6,7 @@ package engine
 
 import (
 	"regexp"
-	"strconv"
 	"strings"
-)
-
-const (
-	REVIEWPAD_DEFAULT_INT_VALUE string = "-1"
 )
 
 func addDefaultsToRequestedReviewers(str string) string {
@@ -132,12 +127,7 @@ func addDefaultsToRequestedAssignees(str string) string {
 	totalRequiredAssignees := match[6]
 
 	if totalRequiredAssignees == "" {
-		totalRequiredAssignees = REVIEWPAD_DEFAULT_INT_VALUE
-	} else {
-		intTotalRequiredAssignees, _ := strconv.Atoi(totalRequiredAssignees)
-		if intTotalRequiredAssignees < 0 {
-			totalRequiredAssignees = "0"
-		}
+		totalRequiredAssignees = "10"
 	}
 
 	return strings.Replace(str, match[0], "$assignAssignees("+assignees+", "+totalRequiredAssignees+")", 1)

--- a/engine/transform_internal_test.go
+++ b/engine/transform_internal_test.go
@@ -215,6 +215,30 @@ func TestTransformAladinoExpression(t *testing.T) {
 			arg:     `$hasAnyCheckRunCompleted($group("ignored"), $group("conclusions"))`,
 			wantVal: `$hasAnyCheckRunCompleted($group("ignored"), $group("conclusions"))`,
 		},
+		"assign assignee with users list provided": {
+			arg:     `$assignAssignees(["john", "mary"])`,
+			wantVal: `$assignAssignees(["john", "mary"], -1)`,
+		},
+		"assign assignee with users list and total provided": {
+			arg:     `$assignAssignees(["john", "mary"], 1)`,
+			wantVal: `$assignAssignees(["john", "mary"], 1)`,
+		},
+		"assign assignee with group": {
+			arg:     `$assignAssignees($group("test"))`,
+			wantVal: `$assignAssignees($group("test"), -1)`,
+		},
+		"assign assignee with group and total provided": {
+			arg:     `$assignAssignees($group("test"), 1)`,
+			wantVal: `$assignAssignees($group("test"), 1)`,
+		},
+		"assign assignee with team": {
+			arg:     `$assignAssignees($team("test"))`,
+			wantVal: `$assignAssignees($team("test"), -1)`,
+		},
+		"assign assignee with team and total provided": {
+			arg:     `$assignAssignees($team("test"), 1)`,
+			wantVal: `$assignAssignees($team("test"), 1)`,
+		},
 		// TODO: test addDefaultTotalRequestedReviewers
 	}
 

--- a/engine/transform_internal_test.go
+++ b/engine/transform_internal_test.go
@@ -217,7 +217,7 @@ func TestTransformAladinoExpression(t *testing.T) {
 		},
 		"assign assignee with users list provided": {
 			arg:     `$assignAssignees(["john", "mary"])`,
-			wantVal: `$assignAssignees(["john", "mary"], -1)`,
+			wantVal: `$assignAssignees(["john", "mary"], 10)`,
 		},
 		"assign assignee with users list and total provided": {
 			arg:     `$assignAssignees(["john", "mary"], 1)`,
@@ -225,7 +225,7 @@ func TestTransformAladinoExpression(t *testing.T) {
 		},
 		"assign assignee with group": {
 			arg:     `$assignAssignees($group("test"))`,
-			wantVal: `$assignAssignees($group("test"), -1)`,
+			wantVal: `$assignAssignees($group("test"), 10)`,
 		},
 		"assign assignee with group and total provided": {
 			arg:     `$assignAssignees($group("test"), 1)`,
@@ -233,7 +233,7 @@ func TestTransformAladinoExpression(t *testing.T) {
 		},
 		"assign assignee with team": {
 			arg:     `$assignAssignees($team("test"))`,
-			wantVal: `$assignAssignees($team("test"), -1)`,
+			wantVal: `$assignAssignees($team("test"), 10)`,
 		},
 		"assign assignee with team and total provided": {
 			arg:     `$assignAssignees($team("test"), 1)`,

--- a/lang/aladino/lex.go
+++ b/lang/aladino/lex.go
@@ -48,7 +48,7 @@ var tokens = []tokenDef{
 		token: RELATIVETIMESTAMP,
 	},
 	{
-		regex: regexp.MustCompile(`^[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?`),
+		regex: regexp.MustCompile(`^-?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?`),
 		kind:  "number",
 		token: NUMBER,
 	},

--- a/lang/aladino/lex.go
+++ b/lang/aladino/lex.go
@@ -48,7 +48,7 @@ var tokens = []tokenDef{
 		token: RELATIVETIMESTAMP,
 	},
 	{
-		regex: regexp.MustCompile(`^-?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?`),
+		regex: regexp.MustCompile(`^[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?`),
 		kind:  "number",
 		token: NUMBER,
 	},

--- a/plugins/aladino/actions/assignAssignees.go
+++ b/plugins/aladino/actions/assignAssignees.go
@@ -6,6 +6,8 @@ package plugins_aladino_actions
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/reviewpad/reviewpad/v4/handler"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
@@ -13,7 +15,7 @@ import (
 
 func AssignAssignees() *aladino.BuiltInAction {
 	return &aladino.BuiltInAction{
-		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildArrayOfType(aladino.BuildStringType())}, nil),
+		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildArrayOfType(aladino.BuildStringType()), aladino.BuildIntType()}, nil),
 		Code:           assignAssigneesCode,
 		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest, handler.Issue},
 	}
@@ -22,18 +24,54 @@ func AssignAssignees() *aladino.BuiltInAction {
 func assignAssigneesCode(e aladino.Env, args []aladino.Value) error {
 	t := e.GetTarget()
 	assignees := args[0].(*aladino.ArrayValue).Vals
+	totalRequiredAssignees := args[1].(*aladino.IntValue).Val
+	log := e.GetLogger().WithField("builtin", "assignAssignees")
+
 	if len(assignees) == 0 {
 		return fmt.Errorf("assignAssignees: list of assignees can't be empty")
 	}
 
-	if len(assignees) > 10 {
+	if totalRequiredAssignees == 0 {
+		return fmt.Errorf("assignAssignees: total required assignees is invalid")
+	}
+
+	if totalRequiredAssignees == -1 {
+		totalRequiredAssignees = len(assignees)
+	}
+
+	totalAvailableAssignees := len(assignees)
+	if totalRequiredAssignees > totalAvailableAssignees {
+		log.Infof("total required assignees %d exceeds the total available assignees %d", totalRequiredAssignees, totalAvailableAssignees)
+		totalRequiredAssignees = totalAvailableAssignees
+	}
+
+	if totalRequiredAssignees > 10 {
 		return fmt.Errorf("assignAssignees: can only assign up to 10 assignees")
 	}
 
-	assigneesLogin := make([]string, len(assignees))
-	for i, assignee := range assignees {
-		assigneesLogin[i] = assignee.(*aladino.StringValue).Val
+	assigneesSelected := make([]string, totalRequiredAssignees)
+
+	rand.Seed(time.Now().UnixNano())
+	for totalRequiredAssignees > 0 {
+		assignee := assignees[rand.Intn(totalAvailableAssignees-1)].(*aladino.StringValue).Val
+
+		if contains(assigneesSelected, assignee) {
+			continue
+		}
+
+		assigneesSelected = append(assigneesSelected, assignee)
+		totalRequiredAssignees--
 	}
 
-	return t.AddAssignees(assigneesLogin)
+	return t.AddAssignees(assigneesSelected)
+}
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
 }

--- a/plugins/aladino/actions/assignAssignees.go
+++ b/plugins/aladino/actions/assignAssignees.go
@@ -6,11 +6,7 @@ package plugins_aladino_actions
 
 import (
 	"fmt"
-	"math/rand"
-	"strconv"
-	"time"
 
-	"github.com/reviewpad/reviewpad/v4/engine"
 	"github.com/reviewpad/reviewpad/v4/handler"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 )
@@ -25,25 +21,23 @@ func AssignAssignees() *aladino.BuiltInAction {
 
 func assignAssigneesCode(e aladino.Env, args []aladino.Value) error {
 	t := e.GetTarget()
-	availableAssignees := args[0].(*aladino.ArrayValue).Vals
+
+	rawAvailableAssignees := args[0].(*aladino.ArrayValue).Vals
 	totalRequiredAssignees := args[1].(*aladino.IntValue).Val
+
 	log := e.GetLogger().WithField("builtin", "assignAssignees")
+
+	availableAssignees := make([]string, len(rawAvailableAssignees))
+	for i, v := range rawAvailableAssignees {
+		availableAssignees[i] = v.(*aladino.StringValue).Val
+	}
 
 	if len(availableAssignees) == 0 {
 		return fmt.Errorf("assignAssignees: list of assignees can't be empty")
 	}
 
 	if totalRequiredAssignees == 0 {
-		return fmt.Errorf("assignAssignees: total required assignees is invalid. please insert a number bigger than 0.")
-	}
-
-	reviewpadDefaultIntValue, err := strconv.Atoi(engine.REVIEWPAD_DEFAULT_INT_VALUE)
-	if err != nil {
-		return err
-	}
-
-	if totalRequiredAssignees == reviewpadDefaultIntValue {
-		totalRequiredAssignees = len(availableAssignees)
+		return fmt.Errorf("assignAssignees: total required assignees is invalid. please insert a number bigger than 0")
 	}
 
 	totalAvailableAssignees := len(availableAssignees)
@@ -56,45 +50,5 @@ func assignAssigneesCode(e aladino.Env, args []aladino.Value) error {
 		return fmt.Errorf("assignAssignees: can only assign up to 10 assignees")
 	}
 
-	// Skip current assignees if mention on the provided assignees list
-	currentAssignees, err := t.GetAssignees()
-	if err != nil {
-		return err
-	}
-
-	for _, assignee := range currentAssignees {
-		for _, availableAssignee := range availableAssignees {
-			if availableAssignee.(*aladino.StringValue).Val == assignee.Login {
-				totalRequiredAssignees--
-				availableAssignees = filterAssigneeFromAssignees(availableAssignees, assignee.Login)
-				break
-			}
-		}
-	}
-
-	assignees := make([]string, totalRequiredAssignees)
-
-	rand.Seed(time.Now().UnixNano())
-	for totalRequiredAssignees > 0 {
-		selectedAssigneeIndex := rand.Intn(totalAvailableAssignees)
-
-		assignee := availableAssignees[selectedAssigneeIndex].(*aladino.StringValue).Val
-
-		assignees = append(assignees, assignee)
-		totalRequiredAssignees--
-		availableAssignees = filterAssigneeFromAssignees(availableAssignees, assignee)
-		totalAvailableAssignees = len(availableAssignees)
-	}
-
-	return t.AddAssignees(assignees)
-}
-
-func filterAssigneeFromAssignees(assignees []aladino.Value, assignee string) []aladino.Value {
-	var filteredAssignees []aladino.Value
-	for _, a := range assignees {
-		if a.(*aladino.StringValue).Val != assignee {
-			filteredAssignees = append(filteredAssignees, a)
-		}
-	}
-	return filteredAssignees
+	return t.AddAssignees(getRandomUsers(availableAssignees, totalRequiredAssignees))
 }

--- a/plugins/aladino/actions/assignAssignees.go
+++ b/plugins/aladino/actions/assignAssignees.go
@@ -7,8 +7,10 @@ package plugins_aladino_actions
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"time"
 
+	"github.com/reviewpad/reviewpad/v4/engine"
 	"github.com/reviewpad/reviewpad/v4/handler"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 )
@@ -35,7 +37,12 @@ func assignAssigneesCode(e aladino.Env, args []aladino.Value) error {
 		return fmt.Errorf("assignAssignees: total required assignees is invalid")
 	}
 
-	if totalRequiredAssignees == -1 {
+	reviewpadDefaultIntValue, err := strconv.Atoi(engine.REVIEWPAD_DEFAULT_INT_VALUE)
+	if err != nil {
+		return err
+	}
+
+	if totalRequiredAssignees == reviewpadDefaultIntValue {
 		totalRequiredAssignees = len(assignees)
 	}
 

--- a/plugins/aladino/actions/assignAssignees.go
+++ b/plugins/aladino/actions/assignAssignees.go
@@ -53,7 +53,17 @@ func assignAssigneesCode(e aladino.Env, args []aladino.Value) error {
 
 	rand.Seed(time.Now().UnixNano())
 	for totalRequiredAssignees > 0 {
-		assignee := assignees[rand.Intn(totalAvailableAssignees-1)].(*aladino.StringValue).Val
+		var selectedAssigneeIndex int
+
+		// Intn returns, as an int, a non-negative pseudo-random number in the half-open interval [0,n) from the default Source. It panics if n <= 0.
+		randMax := totalAvailableAssignees - 1
+		if randMax <= 0 {
+			selectedAssigneeIndex = 0
+		} else {
+			selectedAssigneeIndex = rand.Intn(randMax)
+		}
+
+		assignee := assignees[selectedAssigneeIndex].(*aladino.StringValue).Val
 
 		if contains(assigneesSelected, assignee) {
 			continue

--- a/plugins/aladino/actions/assignAssignees.go
+++ b/plugins/aladino/actions/assignAssignees.go
@@ -60,15 +60,7 @@ func assignAssigneesCode(e aladino.Env, args []aladino.Value) error {
 
 	rand.Seed(time.Now().UnixNano())
 	for totalRequiredAssignees > 0 {
-		var selectedAssigneeIndex int
-
-		// Intn returns, as an int, a non-negative pseudo-random number in the half-open interval [0,n) from the default Source. It panics if n <= 0.
-		randMax := totalAvailableAssignees - 1
-		if randMax <= 0 {
-			selectedAssigneeIndex = 0
-		} else {
-			selectedAssigneeIndex = rand.Intn(randMax)
-		}
+		selectedAssigneeIndex := rand.Intn(totalAvailableAssignees)
 
 		assignee := assignees[selectedAssigneeIndex].(*aladino.StringValue).Val
 

--- a/plugins/aladino/actions/assignAssignees.go
+++ b/plugins/aladino/actions/assignAssignees.go
@@ -83,6 +83,7 @@ func assignAssigneesCode(e aladino.Env, args []aladino.Value) error {
 		assignees = append(assignees, assignee)
 		totalRequiredAssignees--
 		availableAssignees = filterAssigneeFromAssignees(availableAssignees, assignee)
+		totalAvailableAssignees = len(availableAssignees)
 	}
 
 	return t.AddAssignees(assignees)

--- a/plugins/aladino/actions/assignAssignees.go
+++ b/plugins/aladino/actions/assignAssignees.go
@@ -34,7 +34,7 @@ func assignAssigneesCode(e aladino.Env, args []aladino.Value) error {
 	}
 
 	if totalRequiredAssignees == 0 {
-		return fmt.Errorf("assignAssignees: total required assignees is invalid")
+		return fmt.Errorf("assignAssignees: total required assignees is invalid. please insert a number bigger than 0.")
 	}
 
 	reviewpadDefaultIntValue, err := strconv.Atoi(engine.REVIEWPAD_DEFAULT_INT_VALUE)

--- a/plugins/aladino/actions/assignAssignees_test.go
+++ b/plugins/aladino/actions/assignAssignees_test.go
@@ -22,7 +22,7 @@ import (
 var assignAssignees = plugins_aladino.PluginBuiltIns().Actions["assignAssignees"].Code
 
 func TestAssignAssignees(t *testing.T) {
-	reviewpadDefaultIntValue, err := strconv.Atoi(engine.REVIEWPAD_DEFAULT_INT_VALUE)
+	reviewpadDefaultIntValue, err := strconv.Atoi(engine.DEFAULT_INT_VALUE)
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}

--- a/plugins/aladino/actions/assignAssignees_test.go
+++ b/plugins/aladino/actions/assignAssignees_test.go
@@ -7,12 +7,10 @@ package plugins_aladino_actions_test
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"testing"
 
 	"github.com/google/go-github/v49/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
-	"github.com/reviewpad/reviewpad/v4/engine"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 	plugins_aladino "github.com/reviewpad/reviewpad/v4/plugins/aladino"
 	"github.com/reviewpad/reviewpad/v4/utils"
@@ -22,11 +20,7 @@ import (
 var assignAssignees = plugins_aladino.PluginBuiltIns().Actions["assignAssignees"].Code
 
 func TestAssignAssignees(t *testing.T) {
-	reviewpadDefaultIntValue, err := strconv.Atoi(engine.DEFAULT_INT_VALUE)
-	if err != nil {
-		assert.FailNow(t, err.Error())
-	}
-
+	defaultAssignees := 10
 	tests := map[string]struct {
 		clientOptions               []mock.MockBackendOption
 		inputAssignees              aladino.Value
@@ -36,7 +30,7 @@ func TestAssignAssignees(t *testing.T) {
 	}{
 		"when list of assignees is empty": {
 			inputAssignees:              aladino.BuildArrayValue([]aladino.Value{}),
-			inputTotalRequiredAssignees: aladino.BuildIntValue(reviewpadDefaultIntValue),
+			inputTotalRequiredAssignees: aladino.BuildIntValue(defaultAssignees),
 			wantErr:                     fmt.Errorf("assignAssignees: list of assignees can't be empty"),
 		},
 		"when list of assignees exceeds 10 users": {
@@ -53,7 +47,7 @@ func TestAssignAssignees(t *testing.T) {
 				aladino.BuildStringValue("michael"),
 				aladino.BuildStringValue("tom"),
 			}),
-			inputTotalRequiredAssignees: aladino.BuildIntValue(reviewpadDefaultIntValue),
+			inputTotalRequiredAssignees: aladino.BuildIntValue(11),
 			wantErr:                     fmt.Errorf("assignAssignees: can only assign up to 10 assignees"),
 		},
 		"when the total required assignees is an invalid number": {
@@ -62,7 +56,7 @@ func TestAssignAssignees(t *testing.T) {
 				aladino.BuildStringValue("mary"),
 			}),
 			inputTotalRequiredAssignees: aladino.BuildIntValue(0),
-			wantErr:                     fmt.Errorf("assignAssignees: total required assignees is invalid. please insert a number bigger than 0."),
+			wantErr:                     fmt.Errorf("assignAssignees: total required assignees is invalid. please insert a number bigger than 0"),
 		},
 		"when the total required assignees is greater than the total of available assignees": {
 			clientOptions: []mock.MockBackendOption{

--- a/plugins/aladino/actions/assignAssignees_test.go
+++ b/plugins/aladino/actions/assignAssignees_test.go
@@ -1,101 +1,101 @@
-// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
-// Use of this source code is governed by a license that can be
-// found in the LICENSE file.
+// // Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// // Use of this source code is governed by a license that can be
+// // found in the LICENSE file.
 
 package plugins_aladino_actions_test
 
-import (
-	"io"
-	"net/http"
-	"testing"
+// import (
+// 	"io"
+// 	"net/http"
+// 	"testing"
 
-	"github.com/google/go-github/v49/github"
-	"github.com/migueleliasweb/go-github-mock/src/mock"
-	"github.com/reviewpad/reviewpad/v4/lang/aladino"
-	plugins_aladino "github.com/reviewpad/reviewpad/v4/plugins/aladino"
-	"github.com/reviewpad/reviewpad/v4/utils"
-	"github.com/stretchr/testify/assert"
-)
+// 	"github.com/google/go-github/v49/github"
+// 	"github.com/migueleliasweb/go-github-mock/src/mock"
+// 	"github.com/reviewpad/reviewpad/v3/lang/aladino"
+// 	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
+// 	"github.com/reviewpad/reviewpad/v3/utils"
+// 	"github.com/stretchr/testify/assert"
+// )
 
-var assignAssignees = plugins_aladino.PluginBuiltIns().Actions["assignAssignees"].Code
+// var assignAssignees = plugins_aladino.PluginBuiltIns().Actions["assignAssignees"].Code
 
-type AssigneesRequestPostBody struct {
-	Assignees []string `json:"assignees"`
-}
+// type AssigneesRequestPostBody struct {
+// 	Assignees []string `json:"assignees"`
+// }
 
-func TestAssignAssignees_WhenListOfAssigneesIsEmpty(t *testing.T) {
-	mockedEnv := aladino.MockDefaultEnv(t, nil, nil, aladino.MockBuiltIns(), nil)
+// func TestAssignAssignees_WhenListOfAssigneesIsEmpty(t *testing.T) {
+// 	mockedEnv := aladino.MockDefaultEnv(t, nil, nil, aladino.MockBuiltIns(), nil)
 
-	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{})}
-	err := assignAssignees(mockedEnv, args)
+// 	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{})}
+// 	err := assignAssignees(mockedEnv, args)
 
-	assert.EqualError(t, err, "assignAssignees: list of assignees can't be empty")
-}
+// 	assert.EqualError(t, err, "assignAssignees: list of assignees can't be empty")
+// }
 
-func TestAssignAssignees_WhenListOfAssigneesExceeds10Users(t *testing.T) {
-	mockedEnv := aladino.MockDefaultEnv(t, nil, nil, aladino.MockBuiltIns(), nil)
+// func TestAssignAssignees_WhenListOfAssigneesExceeds10Users(t *testing.T) {
+// 	mockedEnv := aladino.MockDefaultEnv(t, nil, nil, aladino.MockBuiltIns(), nil)
 
-	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{
-		aladino.BuildStringValue("john"),
-		aladino.BuildStringValue("mary"),
-		aladino.BuildStringValue("jane"),
-		aladino.BuildStringValue("steve"),
-		aladino.BuildStringValue("peter"),
-		aladino.BuildStringValue("adam"),
-		aladino.BuildStringValue("nancy"),
-		aladino.BuildStringValue("susan"),
-		aladino.BuildStringValue("bob"),
-		aladino.BuildStringValue("michael"),
-		aladino.BuildStringValue("tom"),
-	})}
-	err := assignAssignees(mockedEnv, args)
+// 	args := []aladino.Value{aladino.BuildArrayValue([]aladino.Value{
+// 		aladino.BuildStringValue("john"),
+// 		aladino.BuildStringValue("mary"),
+// 		aladino.BuildStringValue("jane"),
+// 		aladino.BuildStringValue("steve"),
+// 		aladino.BuildStringValue("peter"),
+// 		aladino.BuildStringValue("adam"),
+// 		aladino.BuildStringValue("nancy"),
+// 		aladino.BuildStringValue("susan"),
+// 		aladino.BuildStringValue("bob"),
+// 		aladino.BuildStringValue("michael"),
+// 		aladino.BuildStringValue("tom"),
+// 	})}
+// 	err := assignAssignees(mockedEnv, args)
 
-	assert.EqualError(t, err, "assignAssignees: can only assign up to 10 assignees")
-}
+// 	assert.EqualError(t, err, "assignAssignees: can only assign up to 10 assignees")
+// }
 
-func TestAssignAssignees(t *testing.T) {
-	gotAssignees := []string{}
-	wantAssignees := []string{
-		"mary",
-	}
-	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
-		Assignees: []*github.User{},
-	})
+// func TestAssignAssignees(t *testing.T) {
+// 	gotAssignees := []string{}
+// 	wantAssignees := []string{
+// 		"mary",
+// 	}
+// 	mockedPullRequest := aladino.GetDefaultMockPullRequestDetailsWith(&github.PullRequest{
+// 		Assignees: []*github.User{},
+// 	})
 
-	mockedEnv := aladino.MockDefaultEnv(
-		t,
-		[]mock.MockBackendOption{
-			mock.WithRequestMatchHandler(
-				mock.GetReposPullsByOwnerByRepoByPullNumber,
-				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					utils.MustWriteBytes(w, mock.MustMarshal(mockedPullRequest))
-				}),
-			),
-			mock.WithRequestMatchHandler(
-				mock.PostReposIssuesAssigneesByOwnerByRepoByIssueNumber,
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					rawBody, _ := io.ReadAll(r.Body)
-					body := AssigneesRequestPostBody{}
+// 	mockedEnv := aladino.MockDefaultEnv(
+// 		t,
+// 		[]mock.MockBackendOption{
+// 			mock.WithRequestMatchHandler(
+// 				mock.GetReposPullsByOwnerByRepoByPullNumber,
+// 				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+// 					utils.MustWriteBytes(w, mock.MustMarshal(mockedPullRequest))
+// 				}),
+// 			),
+// 			mock.WithRequestMatchHandler(
+// 				mock.PostReposIssuesAssigneesByOwnerByRepoByIssueNumber,
+// 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 					rawBody, _ := io.ReadAll(r.Body)
+// 					body := AssigneesRequestPostBody{}
 
-					utils.MustUnmarshal(rawBody, &body)
+// 					utils.MustUnmarshal(rawBody, &body)
 
-					gotAssignees = body.Assignees
-				}),
-			),
-		},
-		nil,
-		aladino.MockBuiltIns(),
-		nil,
-	)
+// 					gotAssignees = body.Assignees
+// 				}),
+// 			),
+// 		},
+// 		nil,
+// 		aladino.MockBuiltIns(),
+// 		nil,
+// 	)
 
-	assignees := make([]aladino.Value, len(wantAssignees))
-	for i, assignee := range wantAssignees {
-		assignees[i] = aladino.BuildStringValue(assignee)
-	}
+// 	assignees := make([]aladino.Value, len(wantAssignees))
+// 	for i, assignee := range wantAssignees {
+// 		assignees[i] = aladino.BuildStringValue(assignee)
+// 	}
 
-	args := []aladino.Value{aladino.BuildArrayValue(assignees)}
-	err := assignAssignees(mockedEnv, args)
+// 	args := []aladino.Value{aladino.BuildArrayValue(assignees)}
+// 	err := assignAssignees(mockedEnv, args)
 
-	assert.Nil(t, err)
-	assert.ElementsMatch(t, wantAssignees, gotAssignees)
-}
+// 	assert.Nil(t, err)
+// 	assert.ElementsMatch(t, wantAssignees, gotAssignees)
+// }

--- a/plugins/aladino/actions/assignAssignees_test.go
+++ b/plugins/aladino/actions/assignAssignees_test.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/google/go-github/v49/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
-	"github.com/reviewpad/reviewpad/v3/engine"
-	"github.com/reviewpad/reviewpad/v3/lang/aladino"
-	plugins_aladino "github.com/reviewpad/reviewpad/v3/plugins/aladino"
-	"github.com/reviewpad/reviewpad/v3/utils"
+	"github.com/reviewpad/reviewpad/v4/engine"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v4/plugins/aladino"
+	"github.com/reviewpad/reviewpad/v4/utils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/plugins/aladino/actions/assignCodeAuthorReviewers.go
+++ b/plugins/aladino/actions/assignCodeAuthorReviewers.go
@@ -88,7 +88,7 @@ func assignCodeAuthorReviewersCode(env aladino.Env, args []aladino.Value) error 
 			}
 		}
 
-		selectedReviewers = getRandomReviewers(selectedReviewers, totalRequiredReviewers)
+		selectedReviewers = getRandomUsers(selectedReviewers, totalRequiredReviewers)
 	}
 
 	// If no reviewers were found until now
@@ -190,19 +190,19 @@ func isUserValidAssignee(assignees []*codehost.User, username string) bool {
 	return false
 }
 
-func getRandomReviewers(reviewers []string, total int) []string {
-	if total >= len(reviewers) {
-		return reviewers
+func getRandomUsers(users []string, total int) []string {
+	if total >= len(users) {
+		return users
 	}
 
-	selectedReviewers := make([]string, total)
+	selectedUsers := make([]string, total)
 
 	for i := 0; i < total; i++ {
-		randIndex := rand.Intn(len(reviewers))
-		selectedReviewers[i] = reviewers[randIndex]
+		randIndex := rand.Intn(len(users))
+		selectedUsers[i] = users[randIndex]
 
-		reviewers = append(reviewers[:randIndex], reviewers[randIndex+1:]...)
+		users = append(users[:randIndex], users[randIndex+1:]...)
 	}
 
-	return selectedReviewers
+	return selectedUsers
 }


### PR DESCRIPTION
## Description

<!-- Please make sure to include a clear and concise description of the changes. -->
This pull request updates the `$assignAssignees` built-in to include another parameter, which is optional, that defines the total number of users to be assigned.
If the introduced parameter is not set, the default value is the total number of given users (the 1st parameter) if the total does not exceed 10. To achieve this, in the [`transform`](https://github.com/reviewpad/reviewpad/blob/main/engine/transform.go) process we set a `REVIEWPAD_DEFAULT_INT_VALUE` which is `-1` to be the default of the total required users to be assigned and on the execution of the built-in once we detect this tag we know that the total required users to be assigned should be the number of given users that can be assigned.

## Related issue

<!-- Closes # (issue) -->
Closes #733

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

<!-- **Bug fix** (non-breaking change which fixes an issue) -->
**New feature** (non-breaking change which adds functionality)
<!-- **Improvements** (non-breaking change without functionality) -->
<!-- **Breaking change** (fix or feature that would cause existing functionality not to work as expected) -->

## How was this tested?

<!-- Please describe the tests you ran to verify your changes. -->
Manual tests were performed in the dev app where the test cases were:
- `$assignAssignees(["dummypad"])` ✅ 
- `$assignAssignees(["dummypad"], 2)` ✅
- `$assignAssignees(["dummypad"], -3)` ❌ `assignAssignees: total required assignees is invalid. please insert a number bigger than 0.`
- `$assignAssignees($group("two-dummies"))` ✅ 
- `$assignAssignees($group("two-dummies"), 1)` ✅ 
- `$assignAssignees($team("engineering"))` ✅ 
- `$assignAssignees($team("engineering"), 2)` ✅ 

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) and have tested properly
- [x] I have run `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before the merge
