### PR TITLE
refactor: remove edition property from reviewpad file

### DIFF
--- a/engine/exec.go
+++ b/engine/exec.go
@@ -51,7 +51,6 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 		"reviewpad_file": file,
 		"reviewpad_details": map[string]interface{}{
 			"project":        fmt.Sprintf(env.TargetEntity.Owner + "/" + env.TargetEntity.Repo),
-			"edition":        file.Edition,
 			"mode":           file.Mode,
 			"ignoreErrors":   file.IgnoreErrors,
 			"metricsOnMerge": file.MetricsOnMerge,

--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -18,7 +18,6 @@ func inlineRulesNormalizer() *NormalizeRule {
 
 func inlineRulesModificator(file *ReviewpadFile) (*ReviewpadFile, error) {
 	reviewpadFile := &ReviewpadFile{
-		Edition:        file.Edition,
 		Mode:           file.Mode,
 		IgnoreErrors:   file.IgnoreErrors,
 		MetricsOnMerge: file.MetricsOnMerge,

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -197,7 +197,6 @@ func (p PadGroup) equals(o PadGroup) bool {
 }
 
 type ReviewpadFile struct {
-	Edition        string              `yaml:"edition"`
 	Mode           string              `yaml:"mode"`
 	IgnoreErrors   *bool               `yaml:"ignore-errors"`
 	MetricsOnMerge *bool               `yaml:"metrics-on-merge"`
@@ -262,10 +261,6 @@ func (p PadStage) equals(o PadStage) bool {
 }
 
 func (r *ReviewpadFile) equals(o *ReviewpadFile) bool {
-	if r.Edition != o.Edition {
-		return false
-	}
-
 	if r.Mode != o.Mode {
 		return false
 	}
@@ -411,10 +406,6 @@ func (r *ReviewpadFile) appendRecipes(o *ReviewpadFile) {
 }
 
 func (r *ReviewpadFile) extend(o *ReviewpadFile) {
-	if o.Edition != "" {
-		r.Edition = o.Edition
-	}
-
 	if o.Mode != "" {
 		r.Mode = o.Mode
 	}

--- a/engine/lang_internal_test.go
+++ b/engine/lang_internal_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 var mockedReviewpadFile = &ReviewpadFile{
-	Edition:      "professional",
 	Mode:         "silent",
 	IgnoreErrors: nil,
 	Imports: []PadImport{
@@ -728,17 +727,6 @@ func TestEquals_WhenReviewpadFilesAreEqual(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.True(t, mockedReviewpadFile.equals(otherReviewpadFile))
-}
-
-func TestEquals_WhenReviewpadFilesHaveDiffEdition(t *testing.T) {
-	otherReviewpadFile := &ReviewpadFile{}
-	err := copier.Copy(otherReviewpadFile, mockedReviewpadFile)
-
-	assert.Nil(t, err)
-
-	otherReviewpadFile.Edition = ""
-
-	assert.False(t, mockedReviewpadFile.equals(otherReviewpadFile))
 }
 
 func TestEquals_WhenReviewpadFilesHaveDiffMode(t *testing.T) {

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -262,7 +262,6 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 	}
 
 	return &ReviewpadFile{
-		Edition:        file.Edition,
 		Mode:           file.Mode,
 		IgnoreErrors:   file.IgnoreErrors,
 		MetricsOnMerge: file.MetricsOnMerge,

--- a/engine/loader_internal_test.go
+++ b/engine/loader_internal_test.go
@@ -33,7 +33,6 @@ pipelines:
 
 	metricsOnMerge := true
 	wantFile := &ReviewpadFile{
-		Edition:        "professional",
 		Mode:           "silent",
 		MetricsOnMerge: &metricsOnMerge,
 		Pipelines: []PadPipeline{

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -82,7 +82,6 @@ func TestLoadWithAST(t *testing.T) {
 	noIgnoreErrors := true
 	noMetricsOnMerge := true
 	wantReviewpadFile := &engine.ReviewpadFile{
-		Edition:        "enterprise",
 		Mode:           "verbose",
 		Recipes:        map[string]*bool{},
 		IgnoreErrors:   &noIgnoreErrors,

--- a/engine/normalize.go
+++ b/engine/normalize.go
@@ -21,20 +21,6 @@ type NormalizeRule struct {
 	Modificators []modificator
 }
 
-func defaultEditionNormalizer() *NormalizeRule {
-	normalizedRule := NewNormalizeRule()
-	normalizedRule.WithModificators(func(file *ReviewpadFile) (*ReviewpadFile, error) {
-		if file.Edition == "" {
-			file.Edition = defaultEdition
-			return file, nil
-		}
-
-		file.Edition = strings.ToLower(strings.TrimSpace(file.Edition))
-		return file, nil
-	})
-	return normalizedRule
-}
-
 func defaultModeNormalizer() *NormalizeRule {
 	defaultModeNormalizer := NewNormalizeRule()
 	defaultModeNormalizer.WithModificators(func(file *ReviewpadFile) (*ReviewpadFile, error) {
@@ -53,7 +39,6 @@ func normalize(f *ReviewpadFile, customRules ...*NormalizeRule) (*ReviewpadFile,
 	var err error
 	var errStrings []string
 	rules := []*NormalizeRule{
-		defaultEditionNormalizer(),
 		defaultModeNormalizer(),
 	}
 	rules = append(rules, customRules...)

--- a/engine/normalize_test.go
+++ b/engine/normalize_test.go
@@ -14,9 +14,6 @@ func TestNormalize(t *testing.T) {
 		reviewpadFile, err := normalize(&ReviewpadFile{})
 		assert.Nil(t, err)
 
-		if reviewpadFile.Edition != defaultEdition {
-			t.Fatalf("expected edition: %s, got edition: %s", defaultEdition, reviewpadFile.Edition)
-		}
 		if reviewpadFile.Mode != defaultMode {
 			t.Fatalf("expected mode: %s, got mode: %s", defaultMode, reviewpadFile.Mode)
 		}

--- a/runner.go
+++ b/runner.go
@@ -228,7 +228,6 @@ func runReviewpadFile(
 
 	err = collector.Collect("Trigger Analysis", map[string]interface{}{
 		"project":        fmt.Sprintf("%s/%s", targetEntity.Owner, targetEntity.Repo),
-		"edition":        reviewpadFile.Edition,
 		"mode":           reviewpadFile.Mode,
 		"ignoreErrors":   reviewpadFile.IgnoreErrors,
 		"metricsOnMerge": reviewpadFile.MetricsOnMerge,


### PR DESCRIPTION
## Description
Removes the `edition` property from reviewpad configuration.
<!-- Please include a clear and concise description of the changes. -->

## Related issue

Closes #746 

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

<!-- **Bug fix** (non-breaking change which fixes an issue) -->
<!-- **New feature** (non-breaking change which adds functionality) -->
**Improvements** (non-breaking change without functionality)
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Manually
<!-- Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable) and have tested properly
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge
