### PR TITLE
chore: hasAnyCheckRunCompleted to ignore reviewpad check default

### DIFF
--- a/plugins/aladino/functions/hasAnyCheckRunCompleted.go
+++ b/plugins/aladino/functions/hasAnyCheckRunCompleted.go
@@ -47,7 +47,10 @@ func hasAnyCheckRunCompleted(e aladino.Env, args []aladino.Value) (aladino.Value
 		return nil, fmt.Errorf("failed to get check runs: %s", err.Error())
 	}
 
-	checkRunIgnored := map[string]bool{}
+	checkRunIgnored := map[string]bool{
+		// By default, ignore Reviewpad's own check runs
+		"reviewpad": true,
+	}
 	for _, item := range checkRunsToIgnore.Vals {
 		checkRunIgnored[item.(*aladino.StringValue).Val] = true
 	}


### PR DESCRIPTION
## Description

This pull request introduces the update to the built-in `hasAnyCheckRunCompleted` to ignore reviewpad check by default.

## Related issue

Closes #785 

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

<!-- **Bug fix** (non-breaking change which fixes an issue) -->
<!-- **New feature** (non-breaking change which adds functionality) -->
**Improvements** (non-breaking change without functionality)
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Manual tests.
<!-- Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) and have tested properly
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge 
