### PR TITLE
fix: update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/migueleliasweb/go-github-mock v0.0.16
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/ohler55/ojg v1.18.1
-	github.com/reviewpad/api/go v0.0.0-20230331234314-9a69b2fedf82
+	github.com/reviewpad/api/go v0.0.0-20230405092855-fe855effe314
 	github.com/reviewpad/go-conventionalcommits v0.10.0
 	github.com/reviewpad/go-lib v0.0.0-20230320213934-e6b45aa7e806
 	github.com/shurcooL/githubv4 v0.0.0-20230305132112-efb623903184

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYr
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/reviewpad/api/go v0.0.0-20230331234314-9a69b2fedf82 h1:5tv6cUTEJgMDcUhnwstaPUEOTUFYdzw53RPIjCECA/c=
-github.com/reviewpad/api/go v0.0.0-20230331234314-9a69b2fedf82/go.mod h1:mmrHglzTNGJQdPDSBm1EF8heFoxxDIB3sBT2yHVHKqQ=
+github.com/reviewpad/api/go v0.0.0-20230405092855-fe855effe314 h1:Pkv/K7LWvlXcuWr+Iwe6keKHayr+ymljt9pTO3M/XqI=
+github.com/reviewpad/api/go v0.0.0-20230405092855-fe855effe314/go.mod h1:mmrHglzTNGJQdPDSBm1EF8heFoxxDIB3sBT2yHVHKqQ=
 github.com/reviewpad/go-conventionalcommits v0.10.0 h1:49Fv1q5vougqA7g5mpFZ+W5sQs9kJ5F5zH7kCEwZ+w8=
 github.com/reviewpad/go-conventionalcommits v0.10.0/go.mod h1:NWUK2G+V+KrhmHW2fBAWGEgZFW8jUXqqBkm9mYJJNi4=
 github.com/reviewpad/go-lib v0.0.0-20230320213934-e6b45aa7e806 h1:Ncbh8Q4EUX5fZ4V5Q0i1UmoVyvLSxaBfriWA4oLCTKw=

--- a/plugins/aladino/functions/size.go
+++ b/plugins/aladino/functions/size.go
@@ -7,7 +7,6 @@ package plugins_aladino_functions
 import (
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/reviewpad/reviewpad/v4/codehost/github/target"
-	_ "github.com/reviewpad/reviewpad/v4/codehost/github/target"
 	"github.com/reviewpad/reviewpad/v4/handler"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 )


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5809c24</samp>

Updated the `github.com/reviewpad/api/go` module dependency and removed an unused import from the `plugins_aladino_functions` package. These changes may improve the compatibility and quality of the code.

<!-- Please include a clear and concise description of the changes. -->

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

**Bug fix** (non-breaking change which fixes an issue)
<!-- **New feature** (non-breaking change which adds functionality) -->
<!-- **Improvements** (non-breaking change without functionality) -->
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Functional testing

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5809c24</samp>

* Update the `github.com/reviewpad/api/go` module dependency to a newer version ([link](https://github.com/reviewpad/reviewpad/pull/813/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L22-R22))
* Remove the unused import of `github.com/reviewpad/reviewpad/v4/codehost/github/target` from the `plugins_aladino_functions` package ([link](https://github.com/reviewpad/reviewpad/pull/813/files?diff=unified&w=0#diff-aa1c224dfb5d945da9d42d714292996730a1e3be1d9b90611dfd875da90ac751L10))
