### PR TITLE
fix: always remove label

### DIFF
--- a/plugins/aladino/actions/removeLabel.go
+++ b/plugins/aladino/actions/removeLabel.go
@@ -32,19 +32,5 @@ func removeLabelCode(e aladino.Env, args []aladino.Value) error {
 		log.Warnf("the %v label was not found in the environment", labelID)
 	}
 
-	labels := t.GetLabels()
-
-	labelIsAppliedToPullRequest := false
-	for _, label := range labels {
-		if label.Name == labelName {
-			labelIsAppliedToPullRequest = true
-			break
-		}
-	}
-
-	if !labelIsAppliedToPullRequest {
-		return nil
-	}
-
 	return t.RemoveLabel(labelName)
 }

--- a/plugins/aladino/actions/removeLabel_test.go
+++ b/plugins/aladino/actions/removeLabel_test.go
@@ -48,7 +48,7 @@ func TestRemoveLabel_WhenLabelIsNotAppliedToPullRequest(t *testing.T) {
 	err := removeLabel(mockedEnv, args)
 
 	assert.Nil(t, err)
-	assert.False(t, isLabelRemoved, "The label should not be removed")
+	assert.True(t, isLabelRemoved, "The label should be removed")
 }
 
 func TestRemoveLabel_WhenLabelIsAppliedToPullRequestAndLabelIsInEnvironment(t *testing.T) {


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0701d2f</samp>

Fix a bug in the `TestRemoveLabel_WhenLabelIsNotAppliedToPullRequest` function and remove redundant code from the `removeLabelCode` function in the `plugins/aladino` package. These changes improve the correctness and efficiency of the label removal feature.

## Related issue

Closes #819 

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

**Bug fix** (non-breaking change which fixes an issue)
<!-- **New feature** (non-breaking change which adds functionality) -->
<!-- **Improvements** (non-breaking change without functionality) -->
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Functional test

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) and have tested properly
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0701d2f</samp>

* Fix and simplify the logic of removing a label from a pull request in `removeLabel.go` and `removeLabel_test.go`
  - Remove redundant loop over labels in `removeLabelCode` ([link](https://github.com/reviewpad/reviewpad/pull/820/files?diff=unified&w=0#diff-a016e601d927ba63f583132466f4e68cae048466d9793ab19a101573f61ff6ceL35-L48))
  - Correct the assertion in `TestRemoveLabel_WhenLabelIsNotAppliedToPullRequest` to expect true instead of false ([link](https://github.com/reviewpad/reviewpad/pull/820/files?diff=unified&w=0#diff-3896ca6b61309ad4de9591997e722da87c6964e49b6a41dc31c3bee782ae60a9L51-R51))
