### PR TITLE
fix: only consider opinionated reviews in has required approvals

### DIFF
--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -526,7 +526,7 @@ func (target *PullRequestTarget) GetLatestApprovedReviews() ([]string, error) {
 						}
 						State githubv4.String
 					}
-				} `graphql:"latestReviews(last: 100)"`
+				} `graphql:"latestReviews: latestOpinionatedReviews(last: 100)"`
 			} `graphql:"pullRequest(number: $pullRequestNumber)"`
 		} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
 	}

--- a/codehost/github/target/pull_request_target_test.go
+++ b/codehost/github/target/pull_request_target_test.go
@@ -155,7 +155,7 @@ func TestGetLatestApprovedReviews(t *testing.T) {
 		"query":"query($pullRequestNumber:Int!$repositoryName:String!$repositoryOwner:String!){
 			repository(owner:$repositoryOwner,name:$repositoryName){
 				pullRequest(number:$pullRequestNumber){
-					latestReviews(last:100){
+					latestReviews: latestOpinionatedReviews(last:100){
 						nodes{
 							author{login},
 							state

--- a/plugins/aladino/functions/hasRequiredApprovals_test.go
+++ b/plugins/aladino/functions/hasRequiredApprovals_test.go
@@ -26,7 +26,7 @@ func TestHasRequiredApprovals_WhenErrorOccurs(t *testing.T) {
 		"query":"query($pullRequestNumber:Int!$repositoryName:String!$repositoryOwner:String!){
 			repository(owner:$repositoryOwner,name:$repositoryName){
 				pullRequest(number:$pullRequestNumber){
-					latestReviews(last:100){
+					latestReviews: latestOpinionatedReviews(last:100){
 						nodes{
 							author{login},
 							state
@@ -88,7 +88,7 @@ func TestHasRequiredApprovals(t *testing.T) {
 		"query":"query($pullRequestNumber:Int!$repositoryName:String!$repositoryOwner:String!){
 			repository(owner:$repositoryOwner,name:$repositoryName){
 				pullRequest(number:$pullRequestNumber){
-					latestReviews(last:100){
+					latestReviews: latestOpinionatedReviews(last:100){
 						nodes{
 							author{login},
 							state


### PR DESCRIPTION
## Description
Right now if the user approves a pull request and then leave a comment review the `$hasRequiredApprovals` built-in doesn't consider it as approved, this PR fixes that behaviour so that only opinionated reviews are considered.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c43da4</samp>

Improve the aladino plugin and the GitHub codehost integration to check the required approvals for a pull request. Use the `latestOpinionatedReviews` field in the GraphQL query to filter out non-opinionated reviews. Update the test cases to mock and verify the API responses.

<!-- Please include a clear and concise description of the changes. -->


## Related issue

Closes #787 

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

**Bug fix** (non-breaking change which fixes an issue)
<!-- **New feature** (non-breaking change which adds functionality) -->
<!-- **Improvements** (non-breaking change without functionality) -->
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit and manual tests
<!-- Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) and have tested properly
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c43da4</samp>

*  Use `latestOpinionatedReviews` field to query GitHub API for approved reviews ([link](https://github.com/reviewpad/reviewpad/pull/825/files?diff=unified&w=0#diff-941cc2c2b19ac7ec6160457e465d3089df7aa23e19248596ec71396396dc7c54L529-R529), [link](https://github.com/reviewpad/reviewpad/pull/825/files?diff=unified&w=0#diff-907e9ada6a5056ebe893dcfb28b7d4b3daa7691c82962a53764d733ae02483a8L29-R29), [link](https://github.com/reviewpad/reviewpad/pull/825/files?diff=unified&w=0#diff-907e9ada6a5056ebe893dcfb28b7d4b3daa7691c82962a53764d733ae02483a8L91-R91))
  * Update `GetLatestApprovedReviews` function in `pull_request_target.go` to use the new field ([link](https://github.com/reviewpad/reviewpad/pull/825/files?diff=unified&w=0#diff-941cc2c2b19ac7ec6160457e465d3089df7aa23e19248596ec71396396dc7c54L529-R529))
  * Update `HasRequiredApprovals` function in `hasRequiredApprovals_test.go` to match the new query ([link](https://github.com/reviewpad/reviewpad/pull/825/files?diff=unified&w=0#diff-907e9ada6a5056ebe893dcfb28b7d4b3daa7691c82962a53764d733ae02483a8L29-R29), [link](https://github.com/reviewpad/reviewpad/pull/825/files?diff=unified&w=0#diff-907e9ada6a5056ebe893dcfb28b7d4b3daa7691c82962a53764d733ae02483a8L91-R91))
  * Update test cases for both functions to mock the expected responses and errors from the API ([link](https://github.com/reviewpad/reviewpad/pull/825/files?diff=unified&w=0#diff-ff2d8e305420f35c24c797591af182acfa91192630ca5f1a251b472cfad598c7L158-R158), [link](https://github.com/reviewpad/reviewpad/pull/825/files?diff=unified&w=0#diff-907e9ada6a5056ebe893dcfb28b7d4b3daa7691c82962a53764d733ae02483a8L29-R29), [link](https://github.com/reviewpad/reviewpad/pull/825/files?diff=unified&w=0#diff-907e9ada6a5056ebe893dcfb28b7d4b3daa7691c82962a53764d733ae02483a8L91-R91))
