### PR TITLE
fix: add dismissed review event to map of review state to event

### DIFF
--- a/plugins/aladino/actions/review.go
+++ b/plugins/aladino/actions/review.go
@@ -107,6 +107,8 @@ func mapReviewStateToEvent(reviewState string) (string, error) {
 		return "REQUEST_CHANGES", nil
 	case "APPROVED":
 		return "APPROVE", nil
+	case "DISMISSED":
+		return "DISMISSED", nil
 	default:
 		return "", fmt.Errorf("review: unsupported review state %v", reviewState)
 	}


### PR DESCRIPTION
## Description
Fixes a bug on the `$review` built-in action where an error occurs if the previous review was dismissed by the user.
copilot:summary

<!-- Please include a clear and concise description of the changes. -->


## Related issue

Closes #788 

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

**Bug fix** (non-breaking change which fixes an issue)
<!-- **New feature** (non-breaking change which adds functionality) -->
<!-- **Improvements** (non-breaking change without functionality) -->
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Manual tests
<!-- Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) and have tested properly
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge

### HOW
copilot:walkthrough
