### PR TITLE
feat: process if then else block as a run

### DIFF
--- a/engine/exec.go
+++ b/engine/exec.go
@@ -242,7 +242,7 @@ func getActionsFromRunBlock(interpreter Interpreter, run *PadWorkflowRunBlock, r
 				return getActionsFromRunBlocks(interpreter, run.Then, rules, rule.ExtraActions)
 			}
 
-			return run.Actions, nil
+			return append(run.Actions, rule.ExtraActions...), nil
 		}
 
 		if run.Else != nil {

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -267,21 +267,21 @@ func getActionsFromRunBlock(interpreter Interpreter, run *PadWorkflowRunBlock, r
 
 		if activated {
 			if len(run.Then) > 0 {
-				return getActionsFromRunBlocks(interpreter, run.Then, rules)
+				return getActionsFromRunBlocks(interpreter, run.Then, rules, rule.ExtraActions)
 			}
 
 			return run.Actions, nil
 		}
 
 		if run.Else != nil {
-			return getActionsFromRunBlocks(interpreter, run.Else, rules)
+			return getActionsFromRunBlocks(interpreter, run.Else, rules, nil)
 		}
 	}
 
 	return nil, nil
 }
 
-func getActionsFromRunBlocks(interpreter Interpreter, runs []PadWorkflowRunBlock, rules map[string]PadRule) ([]string, error) {
+func getActionsFromRunBlocks(interpreter Interpreter, runs []PadWorkflowRunBlock, rules map[string]PadRule, extraActions []string) ([]string, error) {
 	actions := []string{}
 	for _, run := range runs {
 		runActions, err := getActionsFromRunBlock(interpreter, &run, rules)
@@ -289,7 +289,7 @@ func getActionsFromRunBlocks(interpreter Interpreter, runs []PadWorkflowRunBlock
 			return nil, err
 		}
 
-		actions = append(actions, runActions...)
+		actions = append(actions, append(extraActions, runActions...)...)
 	}
 
 	return actions, nil

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -109,6 +109,7 @@ type PadWorkflow struct {
 	Runs                 []PadWorkflowRunBlock      `yaml:"-"`
 	NonNormalizedRules   any                        `yaml:"if"`
 	NonNormalizedActions any                        `yaml:"then"`
+	NonNormalizedElse    any                        `yaml:"else"`
 	NonNormalizedRun     any                        `yaml:"run"`
 }
 

--- a/engine/linter.go
+++ b/engine/linter.go
@@ -165,6 +165,8 @@ func lintWorkflows(log *logrus.Entry, rules []PadRule, padWorkflows []PadWorkflo
 }
 
 func validateWorkflowRun(run *PadWorkflowRunBlock, workflow *PadWorkflow) error {
+	var hasActions = run.Actions != nil && len(run.Actions) > 0
+	var hasThenActions = run.Then != nil && len(run.Then) > 0
 	var hasExtraActions bool
 	for _, rule := range run.If {
 		hasExtraActions = len(rule.ExtraActions) > 0
@@ -173,7 +175,10 @@ func validateWorkflowRun(run *PadWorkflowRunBlock, workflow *PadWorkflow) error 
 		}
 	}
 
-	if (run.Then == nil || len(run.Then) == 0) && (len(run.Actions) == 0 || run.Actions == nil) && !hasExtraActions {
+	// Old style workflow if/then/else are converted to new run block format.
+	// The old style workflow allows if blocks to have extra actions.
+	// Because of this, a run block can have extra actions.
+	if !hasThenActions && !hasActions && !hasExtraActions {
 		return fmt.Errorf("workflow '%v' has a run block without a 'then' block, no actions and no extra actions", workflow.Name)
 	}
 

--- a/engine/linter.go
+++ b/engine/linter.go
@@ -165,8 +165,16 @@ func lintWorkflows(log *logrus.Entry, rules []PadRule, padWorkflows []PadWorkflo
 }
 
 func validateWorkflowRun(run *PadWorkflowRunBlock, workflow *PadWorkflow) error {
-	if (run.Then == nil || len(run.Then) == 0) && (len(run.Actions) == 0 || run.Actions == nil) {
-		return fmt.Errorf("workflow '%v' has a run block without a 'then' block and no actions", workflow.Name)
+	var hasExtraActions bool
+	for _, rule := range run.If {
+		hasExtraActions = len(rule.ExtraActions) > 0
+		if hasExtraActions {
+			break
+		}
+	}
+
+	if (run.Then == nil || len(run.Then) == 0) && (len(run.Actions) == 0 || run.Actions == nil) && !hasExtraActions {
+		return fmt.Errorf("workflow '%v' has a run block without a 'then' block, no actions and no extra actions", workflow.Name)
 	}
 
 	for _, thenRun := range run.Then {

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -207,24 +207,6 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 			transformRunBlock(run, transformAladinoExpression)
 		}
 
-		var transformedRules []PadWorkflowRule
-		for _, rule := range workflow.Rules {
-			var transformedExtraActions []string
-			for _, extraAction := range rule.ExtraActions {
-				transformedExtraActions = append(transformedExtraActions, transformAladinoExpression(extraAction))
-			}
-
-			transformedRules = append(transformedRules, PadWorkflowRule{
-				Rule:         rule.Rule,
-				ExtraActions: transformedExtraActions,
-			})
-		}
-
-		var transformedActions []string
-		for _, action := range workflow.Actions {
-			transformedActions = append(transformedActions, transformAladinoExpression(action))
-		}
-
 		transformedOn := []handler.TargetEntityKind{handler.PullRequest}
 		if len(workflow.On) > 0 {
 			transformedOn = workflow.On
@@ -234,8 +216,6 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 			Name:        workflow.Name,
 			On:          transformedOn,
 			Description: workflow.Description,
-			Rules:       transformedRules,
-			Actions:     transformedActions,
 			AlwaysRun:   workflow.AlwaysRun,
 			Runs:        workflow.Runs,
 		})

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -131,13 +131,21 @@ func TestLoadWithAST(t *testing.T) {
 				On: []handler.TargetEntityKind{
 					"pull_request",
 				},
-				Rules: []engine.PadWorkflowRule{
+				Runs: []engine.PadWorkflowRunBlock{
 					{
-						Rule: "is-medium",
+						If: []engine.PadWorkflowRule{
+							{
+								Rule: "is-medium",
+							},
+						},
+						Then: []engine.PadWorkflowRunBlock{
+							{
+								Actions: []string{
+									"$addLabel(\"medium\")",
+								},
+							},
+						},
 					},
-				},
-				Actions: []string{
-					"$addLabel(\"medium\")",
 				},
 			},
 			{
@@ -146,13 +154,21 @@ func TestLoadWithAST(t *testing.T) {
 				On: []handler.TargetEntityKind{
 					"pull_request",
 				},
-				Rules: []engine.PadWorkflowRule{
+				Runs: []engine.PadWorkflowRunBlock{
 					{
-						Rule: "$isElementOf($author(), $group(\"owners\"))",
+						If: []engine.PadWorkflowRule{
+							{
+								Rule: "$isElementOf($author(), $group(\"owners\"))",
+							},
+						},
+						Then: []engine.PadWorkflowRunBlock{
+							{
+								Actions: []string{
+									"$info(\"bob has authored a PR\")",
+								},
+							},
+						},
 					},
-				},
-				Actions: []string{
-					"$info(\"bob has authored a PR\")",
 				},
 			},
 			{
@@ -161,13 +177,21 @@ func TestLoadWithAST(t *testing.T) {
 				On: []handler.TargetEntityKind{
 					"pull_request",
 				},
-				Rules: []engine.PadWorkflowRule{
+				Runs: []engine.PadWorkflowRunBlock{
 					{
-						Rule: "true",
+						If: []engine.PadWorkflowRule{
+							{
+								Rule: "true",
+							},
+						},
+						Then: []engine.PadWorkflowRunBlock{
+							{
+								Actions: []string{
+									"$titleLint()",
+								},
+							},
+						},
 					},
-				},
-				Actions: []string{
-					"$titleLint()",
 				},
 			},
 			{
@@ -176,13 +200,21 @@ func TestLoadWithAST(t *testing.T) {
 				On: []handler.TargetEntityKind{
 					"pull_request",
 				},
-				Rules: []engine.PadWorkflowRule{
+				Runs: []engine.PadWorkflowRunBlock{
 					{
-						Rule: "is-small",
+						If: []engine.PadWorkflowRule{
+							{
+								Rule: "is-small",
+							},
+						},
+						Then: []engine.PadWorkflowRunBlock{
+							{
+								Actions: []string{
+									"$addLabel(\"small\")",
+								},
+							},
+						},
 					},
-				},
-				Actions: []string{
-					"$addLabel(\"small\")",
 				},
 			},
 		},

--- a/engine/testdata/exec/reviewpad_with_combination_run.yml
+++ b/engine/testdata/exec/reviewpad_with_combination_run.yml
@@ -8,6 +8,7 @@ rules:
 
 workflows:
   - name: combination-run
+    always-run: true
     run:
       - $comment("reviewpad")
       - if: false-rule
@@ -23,6 +24,7 @@ workflows:
       - $info("reviewpad supports nested conditions")
 
   - name: combination-run-2
+    always-run: true
     run:
       - if:
         - rule: 'true'

--- a/plugins/aladino/actions/assignCodeAuthorReviewers_test.go
+++ b/plugins/aladino/actions/assignCodeAuthorReviewers_test.go
@@ -107,7 +107,7 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 			graphQLHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusForbidden)
 			},
-			wantErr: fmt.Errorf("error getting authors from git blame: error executing blame query: Message: 403 Forbidden; body: \"\", Locations: [], Extensions: map[code:request_error internal:map[request:map[body:{\"query\":\"query($owner: String!, $name: String!, $objectExpression: String!) {\\n\\t\\trepository(owner: $owner, name: $name) {\\n\\t\\t\\tobject(expression: $objectExpression) {\\n\\t\\t\\t\\t... on Commit {\\n\\t\\t\\t\\t\\tblame0: blame(path: \\\"default-mock-repo/file1.ts\\\") {\\n\\t\\t\\tranges {\\n\\t\\t\\t\\tstartingLine\\n\\t\\t\\t\\tendingLine\\n\\t\\t\\t\\tage\\n\\t\\t\\t\\tcommit {\\n\\t\\t\\t\\t\\tauthor {\\n\\t\\t\\t\\t\\t\\tuser {\\n\\t\\t\\t\\t\\t\\t\\tlogin\\n\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t}\\n\\t\\t\\t}\\n\\t\\t}\\n\\t\\tblame1: blame(path: \\\"default-mock-repo/file2.ts\\\") {\\n\\t\\t\\tranges {\\n\\t\\t\\t\\tstartingLine\\n\\t\\t\\t\\tendingLine\\n\\t\\t\\t\\tage\\n\\t\\t\\t\\tcommit {\\n\\t\\t\\t\\t\\tauthor {\\n\\t\\t\\t\\t\\t\\tuser {\\n\\t\\t\\t\\t\\t\\t\\tlogin\\n\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t}\\n\\t\\t\\t}\\n\\t\\t}\\n\\t\\tblame2: blame(path: \\\"default-mock-repo/file3.ts\\\") {\\n\\t\\t\\tranges {\\n\\t\\t\\t\\tstartingLine\\n\\t\\t\\t\\tendingLine\\n\\t\\t\\t\\tage\\n\\t\\t\\t\\tcommit {\\n\\t\\t\\t\\t\\tauthor {\\n\\t\\t\\t\\t\\t\\tuser {\\n\\t\\t\\t\\t\\t\\t\\tlogin\\n\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t}\\n\\t\\t\\t}\\n\\t\\t}\\n\\t\\t\\n\\t\\t\\t\\t}\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\",\"variables\":{\"name\":\"default-mock-repo\",\"objectExpression\":\"\",\"owner\":\"foobar\"}}\n headers:map[Content-Type:[application/json]]]]]"),
+			wantErr: fmt.Errorf("error getting authors from git blame: error executing blame query: Message: 403 Forbidden; body: \"\", Locations: [], Extensions: map[code:request_error internal:map[request:map[body:{\"query\":\"query($owner: String!, $name: String!, $objectExpression: String!) {\\n\\t\\trepository(owner: $owner, name: $name) {\\n\\t\\t\\tobject(expression: $objectExpression) {\\n\\t\\t\\t\\t... on Commit {\\n\\t\\t\\t\\t\\tblame0: blame(path: \\\"default-mock-repo/file1.ts\\\") {\\n\\t\\t\\tranges {\\n\\t\\t\\t\\tstartingLine\\n\\t\\t\\t\\tendingLine\\n\\t\\t\\t\\tage\\n\\t\\t\\t\\tcommit {\\n\\t\\t\\t\\t\\tauthor {\\n\\t\\t\\t\\t\\t\\tuser {\\n\\t\\t\\t\\t\\t\\t\\tlogin\\n\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t}\\n\\t\\t\\t}\\n\\t\\t}\\n\\t\\t\\n\\t\\t\\t\\t}\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\",\"variables\":{\"name\":\"default-mock-repo\",\"objectExpression\":\"\",\"owner\":\"foobar\"}}\n headers:map[Content-Type:[application/json]]]]]"),
 		},
 		"when no blame information is found": {
 			totalReviewers:    1,
@@ -1263,7 +1263,7 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 				test.mockBackendOptions,
 				test.graphQLHandler,
 				aladino.GetDefaultPullRequestDetails(),
-				aladino.GetDefaultPullRequestFileList(),
+				test.mockedFileList,
 				nil,
 				nil,
 			)


### PR DESCRIPTION
## Description
introduces an `else` block in reviewpad workflows, this pull request will enable arbitrarily nested conditionals in reviewpad `if ... then ... else` blocks in addition to introducing `else`.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 474de44</samp>

Added support for extra actions in rules and a new syntax for the top level `if ... then ... else` block in workflows. Modified the `PadWorkflow` type, the `processWorkflow` function, and the `getActionsFromRunBlocks` function to handle the new features.

<!-- Please include a clear and concise description of the changes. -->


## Related issue

Closes reviewpad/raas-common#102

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

<!-- **Bug fix** (non-breaking change which fixes an issue) -->
**New feature** (non-breaking change which adds functionality)
<!-- **Improvements** (non-breaking change without functionality) -->
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Manual and Unit tests
<!-- Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [ ] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) and have tested properly
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 474de44</samp>

*  Add `extraActions` parameter to `getActionsFromRunBlocks` function to execute additional actions before run actions ([link](https://github.com/reviewpad/reviewpad/pull/834/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL270-R270), [link](https://github.com/reviewpad/reviewpad/pull/834/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL277-R277), [link](https://github.com/reviewpad/reviewpad/pull/834/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL284-R284), [link](https://github.com/reviewpad/reviewpad/pull/834/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL292-R292))
*  Handle new syntax of workflow definition that allows top level `if ... then ... else` block as a run block ([link](https://github.com/reviewpad/reviewpad/pull/834/files?diff=unified&w=0#diff-ea18868fc6cfa08e95023e74934900b2af69a653d53a65a962abe70616a132f6L70-R88), [link](https://github.com/reviewpad/reviewpad/pull/834/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R112))
