### PR TITLE
feat: add repository target to push event

### DIFF
--- a/handler/processors.go
+++ b/handler/processors.go
@@ -25,7 +25,13 @@ const (
 type TargetEntityKind string
 
 func (entityType TargetEntityKind) String() string {
-	return string(entityType)
+	switch entityType {
+	case Issue:
+		return "issues"
+	case Repository:
+		return "repository"
+	}
+	return "pull"
 }
 
 type TargetEntity struct {

--- a/handler/processors_test.go
+++ b/handler/processors_test.go
@@ -752,7 +752,12 @@ func TestProcessEvent(t *testing.T) {
 				Token:     github.String("test-token"),
 				EventPayload: buildPayload([]byte(`{
 					"repository": {
-						"full_name": "reviewpad/reviewpad"
+						"full_name": "reviewpad/reviewpad",
+						"owner": {
+							"login": "reviewpad",
+							"type": "Organization"
+						},
+						"name": "reviewpad"
 					},
 					"ref": "refs/heads/main"
 				}`)),
@@ -766,12 +771,24 @@ func TestProcessEvent(t *testing.T) {
 					AccountType: "Organization",
 					Visibility:  "public",
 				},
+				{
+					Kind:        handler.Repository,
+					Owner:       owner,
+					Repo:        repo,
+					AccountType: "Organization",
+					Visibility:  "public",
+				},
 			},
 			wantEventDetails: &handler.EventDetails{
 				EventName: "push",
 				Payload: &github.PushEvent{
 					Repo: &github.PushEventRepository{
 						FullName: github.String("reviewpad/reviewpad"),
+						Name:     github.String("reviewpad"),
+						Owner: &github.User{
+							Login: github.String("reviewpad"),
+							Type:  github.String("Organization"),
+						},
 					},
 					Ref: github.String("refs/heads/main"),
 				},
@@ -783,17 +800,37 @@ func TestProcessEvent(t *testing.T) {
 				Token:     github.String("test-token"),
 				EventPayload: buildPayload([]byte(`{
 					"repository": {
-						"full_name": "reviewpad/reviewpad"
+						"full_name": "reviewpad/reviewpad",
+						"private": true,
+						"owner": {
+							"login": "reviewpad",
+							"type": "Organization"
+						},
+						"name": "reviewpad"
 					},
 					"ref": "refs/heads/master"
 				}`)),
 			},
-			wantTargets: []*handler.TargetEntity{},
+			wantTargets: []*handler.TargetEntity{
+				{
+					Kind:        handler.Repository,
+					Owner:       owner,
+					Repo:        repo,
+					AccountType: "Organization",
+					Visibility:  "private",
+				},
+			},
 			wantEventDetails: &handler.EventDetails{
 				EventName: "push",
 				Payload: &github.PushEvent{
 					Repo: &github.PushEventRepository{
 						FullName: github.String("reviewpad/reviewpad"),
+						Name:     github.String("reviewpad"),
+						Private:  github.Bool(true),
+						Owner: &github.User{
+							Login: github.String("reviewpad"),
+							Type:  github.String("Organization"),
+						},
 					},
 					Ref: github.String("refs/heads/master"),
 				},


### PR DESCRIPTION
## Description
Adds a repository target to push event processor.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d22d332</samp>

Add support for push events on repositories. Simplify `TargetEntityKind` type and update `handler/processors.go` to handle repository events.

<!-- Please include a clear and concise description of the changes. -->


## Related issue

Closes #852 

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

<!-- **Bug fix** (non-breaking change which fixes an issue) -->
**New feature** (non-breaking change which adds functionality)
<!-- **Improvements** (non-breaking change without functionality) -->
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit tests
<!-- Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) and have tested properly
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d22d332</samp>

*  Add `Repository` constant to `TargetEntityKind` type ([link](https://github.com/reviewpad/reviewpad/pull/853/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3R22))
* Simplify `String` method of `TargetEntityKind` type by returning underlying value ([link](https://github.com/reviewpad/reviewpad/pull/853/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L27-R28))
* Handle push events that are not related to a pull request in `processPushEvent` function ([link](https://github.com/reviewpad/reviewpad/pull/853/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3R352-R367))
