### PR TITLE
feat: consider run field when deciding if workflow will be executed

### DIFF
--- a/engine/exec.go
+++ b/engine/exec.go
@@ -142,7 +142,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 		log.Infof("evaluating workflow '%v'", workflow.Name)
 		workflowLog := log.WithField("workflow", workflow.Name)
 
-		if !workflow.AlwaysRun && triggeredExclusiveWorkflow {
+		if (!workflow.AlwaysRun && !workflow.RunUsed) && triggeredExclusiveWorkflow {
 			workflowLog.Infof("skipping workflow because it is not always run and another workflow has been triggered")
 			continue
 		}

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -142,7 +142,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 		log.Infof("evaluating workflow '%v'", workflow.Name)
 		workflowLog := log.WithField("workflow", workflow.Name)
 
-		if (!workflow.AlwaysRun && !workflow.RunUsed) && triggeredExclusiveWorkflow {
+		if !workflow.AlwaysRun && triggeredExclusiveWorkflow {
 			workflowLog.Infof("skipping workflow because it is not always run and another workflow has been triggered")
 			continue
 		}
@@ -167,7 +167,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 			}
 
 			if len(runActions) > 0 {
-				if !workflow.AlwaysRun && !workflow.RunUsed {
+				if !workflow.AlwaysRun {
 					triggeredExclusiveWorkflow = true
 				}
 

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -167,7 +167,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 			}
 
 			if len(runActions) > 0 {
-				if !workflow.AlwaysRun {
+				if !workflow.AlwaysRun && !workflow.RunUsed {
 					triggeredExclusiveWorkflow = true
 				}
 

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -400,6 +400,15 @@ func TestEvalConfigurationFile(t *testing.T) {
 			),
 			targetEntity: engine.DefaultMockTargetEntity,
 		},
+		"when workflow is skipped": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_skipped_workflow.yml",
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(`$addLabel("activated-workflow")`),
+				},
+			),
+			targetEntity: engine.DefaultMockTargetEntity,
+		},
 		"when run is a single action": {
 			inputReviewpadFilePath: "testdata/exec/reviewpad_with_string_run.yml",
 			wantProgram: engine.BuildProgram(

--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -72,6 +72,11 @@ func processWorkflow(workflow PadWorkflow, currentRules []PadRule) (*PadWorkflow
 		return nil, nil, err
 	}
 
+	// the run property was used
+	if len(runs) > 0 {
+		wf.RunUsed = true
+	}
+
 	// process only if the workflow has an if ... then ... else block
 	// since there might be cases where the workflow only has a run block
 	if workflow.NonNormalizedRules != nil {

--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -61,6 +61,7 @@ func processWorkflow(workflow PadWorkflow, currentRules []PadRule) (*PadWorkflow
 	wf := &PadWorkflow{
 		Name:        workflow.Name,
 		Description: workflow.Description,
+		AlwaysRun:   workflow.AlwaysRun,
 		Rules:       workflow.Rules,
 		Actions:     workflow.Actions,
 		On:          workflow.On,

--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -72,9 +72,10 @@ func processWorkflow(workflow PadWorkflow, currentRules []PadRule) (*PadWorkflow
 		return nil, nil, err
 	}
 
-	// the run property was used
+	// To provide backward compatibility we assume that
+	// having the run property is the same as always-run.
 	if len(runs) > 0 {
-		wf.RunUsed = true
+		wf.AlwaysRun = true
 	}
 
 	// process only if the workflow has an if ... then ... else block

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -111,6 +111,7 @@ type PadWorkflow struct {
 	NonNormalizedActions any                        `yaml:"then"`
 	NonNormalizedElse    any                        `yaml:"else"`
 	NonNormalizedRun     any                        `yaml:"run"`
+	RunUsed              bool                       `yaml:"-"`
 }
 
 type PadWorkflowRunBlock struct {

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -111,7 +111,6 @@ type PadWorkflow struct {
 	NonNormalizedActions any                        `yaml:"then"`
 	NonNormalizedElse    any                        `yaml:"else"`
 	NonNormalizedRun     any                        `yaml:"run"`
-	RunUsed              bool                       `yaml:"-"`
 }
 
 type PadWorkflowRunBlock struct {

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -103,6 +103,7 @@ type PadWorkflow struct {
 	Name                 string                     `yaml:"name"`
 	On                   []handler.TargetEntityKind `yaml:"on"`
 	Description          string                     `yaml:"description"`
+	AlwaysRun            bool                       `yaml:"always-run"`
 	Rules                []PadWorkflowRule          `yaml:"-"`
 	Actions              []string                   `yaml:"-"`
 	Runs                 []PadWorkflowRunBlock      `yaml:"-"`
@@ -151,6 +152,10 @@ func (p PadWorkflow) equals(o PadWorkflow) bool {
 	}
 
 	if len(p.Actions) != len(o.Actions) {
+		return false
+	}
+
+	if p.AlwaysRun != o.AlwaysRun {
 		return false
 	}
 

--- a/engine/lang_internal_test.go
+++ b/engine/lang_internal_test.go
@@ -45,6 +45,7 @@ var mockedReviewpadFile = &ReviewpadFile{
 		{
 			Name:        "test",
 			Description: "Test process",
+			AlwaysRun:   true,
 			Rules: []PadWorkflowRule{
 				{
 					Rule:         "tautology",
@@ -308,6 +309,7 @@ func TestEquals_WhenPadWorkflowAreEqual(t *testing.T) {
 	padWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -322,6 +324,7 @@ func TestEquals_WhenPadWorkflowAreEqual(t *testing.T) {
 	otherPadWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -340,6 +343,7 @@ func TestEquals_WhenPadWorkflowHaveDiffName(t *testing.T) {
 	padWorkflow := PadWorkflow{
 		Name:        "test#1",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -354,6 +358,7 @@ func TestEquals_WhenPadWorkflowHaveDiffName(t *testing.T) {
 	otherPadWorkflow := PadWorkflow{
 		Name:        "test#2",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -372,6 +377,7 @@ func TestEquals_WhenPadWorkflowsHaveDiffDescription(t *testing.T) {
 	padWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process #1",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -386,6 +392,7 @@ func TestEquals_WhenPadWorkflowsHaveDiffDescription(t *testing.T) {
 	otherPadWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process #2",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -404,6 +411,7 @@ func TestEquals_WhenPadWorkflowsHaveDiffRulesLength(t *testing.T) {
 	padWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -418,6 +426,7 @@ func TestEquals_WhenPadWorkflowsHaveDiffRulesLength(t *testing.T) {
 	otherPadWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -440,6 +449,7 @@ func TestEquals_WhenPadWorkflowsHaveDiffRules(t *testing.T) {
 	padWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology#1",
@@ -454,6 +464,7 @@ func TestEquals_WhenPadWorkflowsHaveDiffRules(t *testing.T) {
 	otherPadWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology#2",
@@ -472,6 +483,7 @@ func TestEquals_WhenPadWorkflowsHaveDiffActionsLength(t *testing.T) {
 	padWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -486,6 +498,7 @@ func TestEquals_WhenPadWorkflowsHaveDiffActionsLength(t *testing.T) {
 	otherPadWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -505,6 +518,7 @@ func TestEquals_WhenPadWorkflowsHaveDiffActions(t *testing.T) {
 	padWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -519,6 +533,7 @@ func TestEquals_WhenPadWorkflowsHaveDiffActions(t *testing.T) {
 	otherPadWorkflow := PadWorkflow{
 		Name:        "test",
 		Description: "Test process",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{
 				Rule:         "tautology",
@@ -527,6 +542,40 @@ func TestEquals_WhenPadWorkflowsHaveDiffActions(t *testing.T) {
 		},
 		Actions: []string{
 			"$action2()",
+		},
+	}
+
+	assert.False(t, padWorkflow.equals(otherPadWorkflow))
+}
+
+func TestEquals_WhenPadWorkflowsHaveDiffAlwaysRun(t *testing.T) {
+	padWorkflow := PadWorkflow{
+		Name:        "test",
+		Description: "Test process",
+		AlwaysRun:   true,
+		Rules: []PadWorkflowRule{
+			{
+				Rule:         "tautology",
+				ExtraActions: []string{},
+			},
+		},
+		Actions: []string{
+			"$action()",
+		},
+	}
+
+	otherPadWorkflow := PadWorkflow{
+		Name:        "test",
+		Description: "Test process",
+		AlwaysRun:   false,
+		Rules: []PadWorkflowRule{
+			{
+				Rule:         "tautology",
+				ExtraActions: []string{},
+			},
+		},
+		Actions: []string{
+			"$action()",
 		},
 	}
 
@@ -821,6 +870,7 @@ func TestEquals_WhenReviewpadFilesHaveDiffNumberOfWorkflows(t *testing.T) {
 		{
 			Name:        "test",
 			Description: "Test process",
+			AlwaysRun:   true,
 			Rules: []PadWorkflowRule{
 				{
 					Rule:         "tautology",
@@ -834,6 +884,7 @@ func TestEquals_WhenReviewpadFilesHaveDiffNumberOfWorkflows(t *testing.T) {
 		{
 			Name:        "test#2",
 			Description: "Test process x2",
+			AlwaysRun:   true,
 			Rules: []PadWorkflowRule{
 				{
 					Rule:         "test-rule",
@@ -859,6 +910,7 @@ func TestEquals_WhenReviewpadFilesHaveDiffWorkflows(t *testing.T) {
 		{
 			Name:        "test#2",
 			Description: "Test process x2",
+			AlwaysRun:   true,
 			Rules: []PadWorkflowRule{
 				{
 					Rule:         "test-rule",
@@ -1105,6 +1157,7 @@ func TestAppendWorkflows_WhenReviewpadFileHasNoWorkflows(t *testing.T) {
 		{
 			Name:        "test",
 			Description: "Test process",
+			AlwaysRun:   true,
 			Rules: []PadWorkflowRule{
 				{
 					Rule:         "tautology",
@@ -1130,6 +1183,7 @@ func TestAppendWorkflows_WhenReviewpadFileHasWorkflows(t *testing.T) {
 		{
 			Name:        "test#2",
 			Description: "Test process",
+			AlwaysRun:   true,
 			Rules: []PadWorkflowRule{
 				{
 					Rule:         "tautology",
@@ -1148,6 +1202,7 @@ func TestAppendWorkflows_WhenReviewpadFileHasWorkflows(t *testing.T) {
 		{
 			Name:        "test#2",
 			Description: "Test process",
+			AlwaysRun:   true,
 			Rules: []PadWorkflowRule{
 				{
 					Rule:         "tautology",
@@ -1161,6 +1216,7 @@ func TestAppendWorkflows_WhenReviewpadFileHasWorkflows(t *testing.T) {
 		{
 			Name:        "test",
 			Description: "Test process",
+			AlwaysRun:   true,
 			Rules: []PadWorkflowRule{
 				{
 					Rule:         "tautology",

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -218,7 +218,6 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 			Description: workflow.Description,
 			AlwaysRun:   workflow.AlwaysRun,
 			Runs:        workflow.Runs,
-			RunUsed:     workflow.RunUsed,
 		})
 	}
 

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -216,6 +216,7 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 			Name:        workflow.Name,
 			On:          transformedOn,
 			Description: workflow.Description,
+			AlwaysRun:   workflow.AlwaysRun,
 			Runs:        workflow.Runs,
 		})
 	}

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -218,6 +218,7 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 			Description: workflow.Description,
 			AlwaysRun:   workflow.AlwaysRun,
 			Runs:        workflow.Runs,
+			RunUsed:     workflow.RunUsed,
 		})
 	}
 

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -126,7 +126,8 @@ func TestLoadWithAST(t *testing.T) {
 		},
 		Workflows: []engine.PadWorkflow{
 			{
-				Name: "add-label-with-medium-size",
+				Name:      "add-label-with-medium-size",
+				AlwaysRun: false,
 				On: []handler.TargetEntityKind{
 					"pull_request",
 				},
@@ -148,7 +149,8 @@ func TestLoadWithAST(t *testing.T) {
 				},
 			},
 			{
-				Name: "info-owners",
+				Name:      "info-owners",
+				AlwaysRun: false,
 				On: []handler.TargetEntityKind{
 					"pull_request",
 				},
@@ -170,7 +172,8 @@ func TestLoadWithAST(t *testing.T) {
 				},
 			},
 			{
-				Name: "check-title",
+				Name:      "check-title",
+				AlwaysRun: false,
 				On: []handler.TargetEntityKind{
 					"pull_request",
 				},
@@ -192,7 +195,8 @@ func TestLoadWithAST(t *testing.T) {
 				},
 			},
 			{
-				Name: "add-label-with-small-size",
+				Name:      "add-label-with-small-size",
+				AlwaysRun: false,
 				On: []handler.TargetEntityKind{
 					"pull_request",
 				},

--- a/engine/program_internal_test.go
+++ b/engine/program_internal_test.go
@@ -15,6 +15,7 @@ func TestAppend(t *testing.T) {
 	workflow := PadWorkflow{
 		Name:        "test-workflow-A",
 		Description: "Testing workflow",
+		AlwaysRun:   true,
 		Rules: []PadWorkflowRule{
 			{Rule: "test-rule-A"},
 		},

--- a/engine/testdata/exec/reviewpad_with_combination_run.yml
+++ b/engine/testdata/exec/reviewpad_with_combination_run.yml
@@ -8,6 +8,7 @@ rules:
 
 workflows:
   - name: combination-run
+    always-run: true
     run:
       - $comment("reviewpad")
       - if: false-rule
@@ -23,6 +24,7 @@ workflows:
       - $info("reviewpad supports nested conditions")
 
   - name: combination-run-2
+    always-run: true
     run:
       - if:
         - rule: 'true'

--- a/engine/testdata/exec/reviewpad_with_multiple_activated_workflows.yml
+++ b/engine/testdata/exec/reviewpad_with_multiple_activated_workflows.yml
@@ -16,6 +16,7 @@ workflows:
     then:
       - $addLabel("activated-workflow-a")
   - name: activated-workflow-b
+    always-run: true
     if:
       - rule: tautology
     then:

--- a/engine/testdata/exec/reviewpad_with_single_conditional_run.yml
+++ b/engine/testdata/exec/reviewpad_with_single_conditional_run.yml
@@ -5,11 +5,13 @@
 workflows:
   - name: old-workflow-style
     if: 'true'
+    always-run: true
     then:
        - $assignRandomReviewer()
        - $fail("failing for reason")
        - $comment("old workflow style")
   - name: single-conditional-run
+    always-run: true
     run:
       if: 'true'
       then: $comment("reviewpad")

--- a/engine/testdata/exec/reviewpad_with_skipped_workflow.yml
+++ b/engine/testdata/exec/reviewpad_with_skipped_workflow.yml
@@ -1,0 +1,25 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+# Reviewpad file with use case of a skipped workflow: since the workflow 'activated-workflow' is triggered and has `always-run: false`,
+# the next workflow 'non-activated-workflow' will be skipped because it doesn't have the flag `always-run: true`.
+
+api-version: reviewpad.com/v3.x
+
+rules:
+  - name: tautology
+    kind: patch
+    spec: true
+
+workflows:
+  - name: activated-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("activated-workflow")
+  - name: non-activated-workflow
+    if:
+      - rule: tautology
+    then:
+      - $addLabel("non-activated-workflow")

--- a/integration_test/assets/builtin-close.yml
+++ b/integration_test/assets/builtin-close.yml
@@ -2,6 +2,7 @@ api-version: reviewpad.com/v3.x
 
 workflows:
   - name: closed-for-unmet-requirements
+    always-run: true
     if:
       - 'true'
     then:

--- a/integration_test/assets/builtin-delete-head-branch.yml
+++ b/integration_test/assets/builtin-delete-head-branch.yml
@@ -2,6 +2,7 @@ api-version: reviewpad.com/v3.x
 
 workflows:
   - name: delete-head-branch
+    always-run: true
     if:
       - 'true'
     then:

--- a/integration_test/assets/builtin-fail.yml
+++ b/integration_test/assets/builtin-fail.yml
@@ -2,6 +2,7 @@ api-version: reviewpad.com/v3.x
 
 workflows:
   - name: fail-due-to-missing-unit-tests
+    always-run: true
     if:
       - $changed("utils/@1.go", "utils/@1_test.go") == false
     then:

--- a/integration_test/assets/builtin-merge.yml
+++ b/integration_test/assets/builtin-merge.yml
@@ -2,6 +2,7 @@ api-version: reviewpad.com/v3.x
 
 workflows:
   - name: merge
+    always-run: true
     if:
       - '!$isMerged()'
     then:

--- a/integration_test/assets/builtin-others.yml
+++ b/integration_test/assets/builtin-others.yml
@@ -10,6 +10,7 @@ labels:
 
 workflows:
   - name: add-label-with-size
+    always-run: true
     if:
       - rule: $size() <= 30
         extra-actions:
@@ -22,6 +23,7 @@ workflows:
           - '$addLabel("large")'
 
   - name: lint-commits
+    always-run: true
     if:
       - rule: 'true'
         extra-actions:
@@ -29,108 +31,126 @@ workflows:
           - '$titleLint()'
 
   - name: label-requires-approval
+    always-run: true
     if:
       - $approvalsCount() == 0
     then:
       - $addLabel("requires-approval")
 
   - name: assign-assignees
+    always-run: true
     if:
       - $length($assignees()) == 0
     then:
       - $assignAssignees([$author()])
 
   - name: check-base
+    always-run: true
     if:
       - $base() != "development"
     then:
       - $warn("Please open all pull requests again the development branch first")
 
   - name: check-head
+    always-run: true
     if:
       - '!$any(["feat", "fix"], ($prefix: String => $startsWith($head(), $prefix)))'
     then:
       - $error("Please user proper branch naming")
 
   - name: check-description
+    always-run: true
     if:
       - $description() == ""
     then:
       - $error("Please add description")
 
   - name: has-code-pattern
+    always-run: true
     if:
       - $hasCodePattern("necessary")
     then:
       - $addLabel("necessary")
 
   - name: has-file-extensions
+    always-run: true
     if:
       - $hasFileExtensions([".md", "", ".go"])
     then:
       - $addLabel("markdown")
 
   - name: has-file-name
+    always-run: true
     if:
       - $hasFileName("README.md")
     then:
       - $addLabel("readme")
 
   - name: has-file-pattern
+    always-run: true
     if:
       - $hasFilePattern("utils/*.go")
     then:
       - $addLabel("modifies-utilities")
 
   - name: has-linked-issues
+    always-run: true
     if:
       - '!$hasLinkedIssues()'
     then:
       - $warn("Please link issue to pull request")
 
   - name: has-required-approvals
+    always-run: true
     if:
       - '!$hasRequiredApprovals(2, $organization())'
     then:
       - $review("COMMENT", "We will do this instead")
 
   - name: is-binary
+    always-run: true
     if:
       - $isBinary("hello-world")
     then:
       - $addLabel("is-binary")
 
   - name: is-linked-to-project
+    always-run: true
     if:
       - '!$isLinkedToProject("integration test project")'
     then:
       - $addToProject("[INTEGRATION TESTS] Reviewpad", "todo")
 
   - name: is-draft
+    always-run: true
     if:
       - $isDraft()
     then:
       - $setProjectField("[INTEGRATION TESTS] Reviewpad", "status", "In Progress")
 
   - name: review
+    always-run: true
     if:
       - $length($requestedReviewers()) == 0
     then:
       - $assignTeamReviewer(["integration-test"])
 
   - name: is-waiting-for-review
+    always-run: true
     if:
       - $isWaitingForReview()
     then:
       - $addLabel("waiting-for-review")
 
   - name: all-integration-test-team-members-are-organization-members
+    always-run: true
     if:
       - '$all($team("integration-test"), ($member: String => $isElementOf($member, $organization())))'
     then:
       - $comment("All integration test team members are members of the organization")
 
   - name: remove-labels
+    always-run: true
     if:
       - $isElementOf("bug", $labels())
     then:
@@ -138,30 +158,35 @@ workflows:
       - $removeLabel("documentation")
 
   - name: pull-request-count-by
+    always-run: true
     if:
       - $pullRequestCountBy($author(), "all") > 0
     then:
       - '$commentOnce($sprintf("Thank you so much for pull request %d", [$totalCreatedPullRequests($author())]))'
 
   - name: has-git-conflicts
+    always-run: true
     if:
       - $hasGitConflicts()
     then:
       - $addLabel("has-conflicts")
 
   - name: has-linear-history-trigger-workflow
+    always-run: true
     if:
       - $hasLinearHistory()
     then:
       - $triggerWorkflow("log.yaml")
 
   - name: reviewer-status
+    always-run: true
     if:
       - '!$any($reviewers(), ($r: String => $reviewerStatus($r) == "APPROVED"))'
     then:
       - '$warn("Pull request hasnt been approved by anybody")'
 
   - name: has-binary-file
+    always-run: true
     if:
       - $hasBinaryFile()
     then:
@@ -169,6 +194,7 @@ workflows:
       - $error("Please don't add any binary file into the repository")
 
   - name: pull-request-info
+    always-run: true
     if:
       - 'true'
     then:


### PR DESCRIPTION
## Description
As part of reviewpad/raas-common#131 we had deprecated the `always-run` property and changed the way workflows were executed so that workflows will be executed independently of each other but not to break existing workflows, workflows will run if `always-run` is true or the `run` property is being used, otherwise previous rules will apply.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 65e2e52</samp>

This pull request adds support for the `always-run` property in the reviewpad language and engine, which allows users to control whether a workflow should always run or only run if no other workflow with `always-run: false` is triggered. It updates the types, functions, and tests in the `engine` package and the test data files in the `integration_test` package to handle this new feature. It also modifies some test data files to enable testing of some builtin actions.

<!-- Please include a clear and concise description of the changes. -->


## Related issue

Closes #856 

## Type of change

<!-- Please uncomment the right types of change from the options below: -->

<!-- **Bug fix** (non-breaking change which fixes an issue) -->
<!-- **New feature** (non-breaking change which adds functionality) -->
**Improvements** (non-breaking change without functionality)
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Unit and manual tests
<!-- Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) and have tested properly
- [x] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 65e2e52</samp>

*  Add the `always-run` property for workflows, which allows users to specify whether a workflow should always run or only run if no other workflow with `always-run: false` is triggered. ([link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fR137-R139), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fR145-R149), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fR170-R173), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-ea18868fc6cfa08e95023e74934900b2af69a653d53a65a962abe70616a132f6R64), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-ea18868fc6cfa08e95023e74934900b2af69a653d53a65a962abe70616a132f6R75-R79), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R106), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R114), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R159-R162), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-31e0d9a2beee99e1ca91227b4cf55fc6b934b0d3bfef25a56fdf5fbf28879c92R219), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-677703a6d80a45ce719fc21fcca468c19bbebe771231de5d3f4803d89bc59ab0R18))
*  Add the `RunUsed` property for workflows, which stores whether the `run` property was used in the reviewpad file, which is an alternative way to specify the `always-run` property. ([link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-ea18868fc6cfa08e95023e74934900b2af69a653d53a65a962abe70616a132f6R75-R79), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R114))
*  Add tests for the `always-run` property in the `TestEvalConfigurationFile` function, which tests the `EvalConfigurationFile` function. ([link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2R405-R413), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-1a6309f28f6bab289cf84e30ad69c3ad489182bb9080df31991dfa4511ca56f5R11), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-1a6309f28f6bab289cf84e30ad69c3ad489182bb9080df31991dfa4511ca56f5R27), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-10170548e2f35ef28447c5028b7b03e66d77e0b7aed60ba80c073474fe7161dbR19), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-816065c74eff0236e78cdd962398a239c9a4c48f75ce950d05fbaec23043d848R8), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-816065c74eff0236e78cdd962398a239c9a4c48f75ce950d05fbaec23043d848R14), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-08e37177ed1b5549603d65f3683e2c3ab4ef990fd101e512530f724ab00a573eR1-R25))
*  Add tests for the `always-run` property in the `lang_internal_test.go` file, which contains the internal tests for the reviewpad language types and functions. ([link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR48), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR312), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR327), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR346), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR361), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR380), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR395), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR414), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR429), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR452), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR467), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR486), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR501), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR521), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR536), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR551-R584), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR873), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR887), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR913), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR1160), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR1186), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR1205), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-efe5ec1bb01c9f94e7a57a9d8b114ac501ec53a99c078c013d3aec39e2c04ffcR1219))
*  Add tests for the `always-run` property in the `TestLoadWithAST` function, which tests the `LoadWithAST` function, which loads a reviewpad file and returns an AST and a `ReviewpadFile` struct. ([link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-34dfef4f19eb650bf2195f706d2705bf093264d5e8f1e902c97a9d378a7988e9L129-R130), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-34dfef4f19eb650bf2195f706d2705bf093264d5e8f1e902c97a9d378a7988e9L151-R153), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-34dfef4f19eb650bf2195f706d2705bf093264d5e8f1e902c97a9d378a7988e9L173-R176), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-34dfef4f19eb650bf2195f706d2705bf093264d5e8f1e902c97a9d378a7988e9L195-R199))
*  Add the `always-run` property to the workflows in the test data files for the integration test, which tests the builtin actions. ([link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-58375daaaf394d61a2916de9ff5b71f20bc6c6deb68333c96f913e99c185cd7aR5), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-94cf3f0f8726beddfce0d8a1f957af5b3d64f10e2469a33ee46d3d06c6a64f3fR5), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-8b4d5c89b251530fcbb4bb503932e5978a9ee566ae289dec4297a0b708f65363R5), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-9b2015b0b717da6cd05e8fcfdd8b85f02ecb50b43692d30425227e02729f2859R5), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-276ab3f03a6d3f2d4c85c628dc0a3461ad0a00f4c533709e068771a94d31ce4eR13), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-276ab3f03a6d3f2d4c85c628dc0a3461ad0a00f4c533709e068771a94d31ce4eR26), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-276ab3f03a6d3f2d4c85c628dc0a3461ad0a00f4c533709e068771a94d31ce4eR34), [link](https://github.com/reviewpad/reviewpad/pull/857/files?diff=unified&w=0#diff-276ab3f03a6d3f2d4c85c628dc0a3461ad0a00f4c533709e068771a94d31ce4eR41))
