### PR TITLE
feat: run robin summarize asynchronously

### DIFF
--- a/lang/aladino/builtins.go
+++ b/lang/aladino/builtins.go
@@ -19,10 +19,11 @@ type BuiltInFunction struct {
 }
 
 type BuiltInAction struct {
-	Type           Type
-	Code           func(e Env, args []Value) error
-	Disabled       bool
-	SupportedKinds []handler.TargetEntityKind
+	Type              Type
+	Code              func(e Env, args []Value) error
+	Disabled          bool
+	SupportedKinds    []handler.TargetEntityKind
+	RunAsynchronously bool
 }
 
 func MergeAladinoBuiltIns(builtInsList ...*BuiltIns) *BuiltIns {

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -44,7 +44,6 @@ type Env interface {
 	GetTarget() codehost.Target
 	GetLogger() *logrus.Entry
 	GetExecWaitGroup() *sync.WaitGroup
-	GetExecMutex() *sync.Mutex
 	GetExecFatalErrorOccurred() error
 	SetExecFatalErrorOccurred(error)
 }
@@ -119,15 +118,15 @@ func (e *BaseEnv) GetExecWaitGroup() *sync.WaitGroup {
 	return e.ExecWaitGroup
 }
 
-func (e *BaseEnv) GetExecMutex() *sync.Mutex {
-	return e.ExecMutex
-}
-
 func (e *BaseEnv) GetExecFatalErrorOccurred() error {
+	e.ExecMutex.Lock()
+	defer e.ExecMutex.Unlock()
 	return e.ExecFatalErrorOccurred
 }
 
 func (e *BaseEnv) SetExecFatalErrorOccurred(err error) {
+	e.ExecMutex.Lock()
+	defer e.ExecMutex.Unlock()
 	e.ExecFatalErrorOccurred = err
 }
 

--- a/lang/aladino/exec.go
+++ b/lang/aladino/exec.go
@@ -67,9 +67,7 @@ func (fc *FunctionCall) exec(env Env) error {
 
 					err := action.Code(env, args)
 					if err != nil {
-						env.GetExecMutex().Lock()
 						env.SetExecFatalErrorOccurred(err)
-						env.GetExecMutex().Unlock()
 					}
 				}()
 				return nil

--- a/plugins/aladino/actions/robinSummarize.go
+++ b/plugins/aladino/actions/robinSummarize.go
@@ -17,9 +17,10 @@ import (
 
 func RobinSummarize() *aladino.BuiltInAction {
 	return &aladino.BuiltInAction{
-		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType(), aladino.BuildStringType()}, nil),
-		Code:           robinSummarizeCode,
-		SupportedKinds: []handler.TargetEntityKind{handler.PullRequest, handler.Issue},
+		Type:              aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType(), aladino.BuildStringType()}, nil),
+		Code:              robinSummarizeCode,
+		SupportedKinds:    []handler.TargetEntityKind{handler.PullRequest, handler.Issue},
+		RunAsynchronously: true,
 	}
 }
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36f4683</samp>

Added support for asynchronous actions in the Aladino language and the `robinSummarize` plugin. Refactored the `Env` interface, the `BaseEnv` type, and the `ExecProgram` function to handle concurrency and synchronization of the actions. Modified the `BuiltInAction` type and the `exec` function to execute actions in separate goroutines based on a new field. Added a test case for a program with an asynchronous action that returns an error.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36f4683</samp>

*  Add a new field `RunAsynchronously` to the `BuiltInAction` type to indicate whether the action should be executed in a separate goroutine or not ([link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-71666134c1ac7f644c4e35ad7c2307908f68b14a1f09e303e88da480b8549c61L22-R26))
*  Import the `sync` package and extend the `Env` interface with four new methods for managing concurrency and synchronization of the asynchronous actions ([link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R10), [link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R46-R49))
*  Implement the new fields and methods of the `Env` interface in the `BaseEnv` type and initialize them in the `NewEvalEnv` function ([link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R65-R67), [link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R118-R133), [link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R161-R163), [link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R176-R177))
*  Modify the `exec` function to check the `RunAsynchronously` field of the action and execute it in a separate goroutine if true, using the `ExecWaitGroup`, `ExecMutex`, and `ExecFatalErrorOccurred` fields of the environment to coordinate the execution and error handling of the asynchronous actions ([link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-ccd0f6eb139760590a619908dbdcaca639bc998003a2e26079152a8bdc0c2fddR63-R76))
*  Modify the `ExecProgram` function to use local variables to store the exit status and error of the program execution, and to wait for the asynchronous actions to finish before returning the final status and error, using the `GetExecWaitGroup` and `GetExecFatalErrorOccurred` methods of the environment ([link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL114-R122), [link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL123-R146))
*  Add a new test function `TestExecAsyncProgram` to the `interpreter_internal_test.go` file to test the execution of a program that contains an asynchronous action that returns an error, using a mocked environment and a custom action `robin` ([link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R402-R462))
*  Modify the `RobinSummarize` function in the `plugins/aladino/actions/robinSummarize.go` file to set the `RunAsynchronously` field of the `BuiltInAction` struct to true, so that the `robinSummarizeCode` function can run asynchronously and summarize the pull request or issue without blocking the execution of other actions ([link](https://github.com/reviewpad/reviewpad/pull/862/files?diff=unified&w=0#diff-f364aa940beaeb00af74460f687b3c549a713a6c6f10cb0b5e1d4f0dea615452L20-R23))
