### PR TITLE
fix: push event should find pull requests

### DIFF
--- a/handler/processors.go
+++ b/handler/processors.go
@@ -343,7 +343,7 @@ func processPushEvent(log *logrus.Entry, token string, e *github.PushEvent) ([]*
 
 	targets := make([]*TargetEntity, 0)
 	for _, pr := range prs {
-		if pr.Base.GetRef() == e.GetRef() {
+		if pr.GetHead().GetRef() == e.GetRef() {
 			targets = append(targets, &TargetEntity{
 				Kind:        PullRequest,
 				Number:      *pr.Number,

--- a/handler/processors.go
+++ b/handler/processors.go
@@ -343,7 +343,7 @@ func processPushEvent(log *logrus.Entry, token string, e *github.PushEvent) ([]*
 
 	targets := make([]*TargetEntity, 0)
 	for _, pr := range prs {
-		if pr.GetHead().GetRef() == e.GetRef() {
+		if fmt.Sprintf("refs/heads/%s", pr.GetHead().GetRef()) == e.GetRef() {
 			targets = append(targets, &TargetEntity{
 				Kind:        PullRequest,
 				Number:      *pr.Number,

--- a/handler/processors_test.go
+++ b/handler/processors_test.go
@@ -176,6 +176,7 @@ func TestProcessEvent(t *testing.T) {
 						},
 					},
 					Head: &github.PullRequestBranch{
+						Ref: github.String("refs/heads/feat"),
 						SHA: github.String("4bf24cc72f3a62423927a0ac8d70febad7c78e0g"),
 					},
 				},
@@ -193,6 +194,7 @@ func TestProcessEvent(t *testing.T) {
 						},
 					},
 					Head: &github.PullRequestBranch{
+						Ref: github.String("refs/heads/bug"),
 						SHA: github.String("4bf24cc72f3a62423927a0ac8d70febad7c78e0k"),
 					},
 				},
@@ -759,7 +761,7 @@ func TestProcessEvent(t *testing.T) {
 						},
 						"name": "reviewpad"
 					},
-					"ref": "refs/heads/main"
+					"ref": "refs/heads/feat"
 				}`)),
 			},
 			wantTargets: []*handler.TargetEntity{
@@ -790,7 +792,7 @@ func TestProcessEvent(t *testing.T) {
 							Type:  github.String("Organization"),
 						},
 					},
-					Ref: github.String("refs/heads/main"),
+					Ref: github.String("refs/heads/feat"),
 				},
 			},
 		},
@@ -808,7 +810,7 @@ func TestProcessEvent(t *testing.T) {
 						},
 						"name": "reviewpad"
 					},
-					"ref": "refs/heads/master"
+					"ref": "refs/heads/docs"
 				}`)),
 			},
 			wantTargets: []*handler.TargetEntity{
@@ -832,7 +834,7 @@ func TestProcessEvent(t *testing.T) {
 							Type:  github.String("Organization"),
 						},
 					},
-					Ref: github.String("refs/heads/master"),
+					Ref: github.String("refs/heads/docs"),
 				},
 			},
 		},

--- a/handler/processors_test.go
+++ b/handler/processors_test.go
@@ -176,7 +176,7 @@ func TestProcessEvent(t *testing.T) {
 						},
 					},
 					Head: &github.PullRequestBranch{
-						Ref: github.String("refs/heads/feat"),
+						Ref: github.String("feat"),
 						SHA: github.String("4bf24cc72f3a62423927a0ac8d70febad7c78e0g"),
 					},
 				},
@@ -194,7 +194,7 @@ func TestProcessEvent(t *testing.T) {
 						},
 					},
 					Head: &github.PullRequestBranch{
-						Ref: github.String("refs/heads/bug"),
+						Ref: github.String("bug"),
 						SHA: github.String("4bf24cc72f3a62423927a0ac8d70febad7c78e0k"),
 					},
 				},


### PR DESCRIPTION
## Description
Currently, when processing push events, pull requests related to the push are not found because of a wrong comparison on the references, this pull request fixes that.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1591d99</samp>

This pull request fixes a bug in the `processPushEvent` function and updates the test cases in `handler/processors_test.go` to match the new branch naming convention and logic.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1591d99</samp>

* Fix a bug in `processPushEvent` that caused the wrong pull requests to be selected as targets for a push event by comparing the head branch instead of the base branch of the pull request with the pushed branch ([link](https://github.com/reviewpad/reviewpad/pull/865/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L346-R346))
* Add new test cases to `TestProcessEvent` to cover push events to branches named `feat` and `bug` ([link](https://github.com/reviewpad/reviewpad/pull/865/files?diff=unified&w=0#diff-58db4e638fd27a2899b743ab001fd291fe7cd6d79023eddff3ad6bfc2f44af95R179), [link](https://github.com/reviewpad/reviewpad/pull/865/files?diff=unified&w=0#diff-58db4e638fd27a2899b743ab001fd291fe7cd6d79023eddff3ad6bfc2f44af95R197))
* Update existing test cases to `TestProcessEvent` to match the new logic of `processPushEvent` by using push events and pull requests with base branches of `feat` and `docs` instead of `main` and `master` ([link](https://github.com/reviewpad/reviewpad/pull/865/files?diff=unified&w=0#diff-58db4e638fd27a2899b743ab001fd291fe7cd6d79023eddff3ad6bfc2f44af95L762-R764), [link](https://github.com/reviewpad/reviewpad/pull/865/files?diff=unified&w=0#diff-58db4e638fd27a2899b743ab001fd291fe7cd6d79023eddff3ad6bfc2f44af95L793-R795), [link](https://github.com/reviewpad/reviewpad/pull/865/files?diff=unified&w=0#diff-58db4e638fd27a2899b743ab001fd291fe7cd6d79023eddff3ad6bfc2f44af95L811-R813), [link](https://github.com/reviewpad/reviewpad/pull/865/files?diff=unified&w=0#diff-58db4e638fd27a2899b743ab001fd291fe7cd6d79023eddff3ad6bfc2f44af95L835-R837))
