### PR TITLE
fix: $assignCodeAuthorReviewers shouldn't assign reviewers when there is already feedback provided

### DIFF
--- a/plugins/aladino/actions/assignCodeAuthorReviewers.go
+++ b/plugins/aladino/actions/assignCodeAuthorReviewers.go
@@ -50,6 +50,18 @@ func assignCodeAuthorReviewersCode(env aladino.Env, args []aladino.Value) error 
 		return nil
 	}
 
+	// since github removes users from the requested reviewers list
+	// after they've submitted a review, we need to check here that
+	// there are no there are no reviews submitted as well
+	reviews, err := pr.GetReviews()
+	if err != nil {
+		return fmt.Errorf("error getting reviews: %s", err)
+	}
+
+	if len(reviews) > 0 {
+		return nil
+	}
+
 	// Fetch all available assignees to which the pull request may be assigned to
 	// in order to avoid assigning a reviewer that is not available.
 	availableAssignees, err := pr.GetAvailableAssignees()

--- a/plugins/aladino/actions/assignCodeAuthorReviewers_test.go
+++ b/plugins/aladino/actions/assignCodeAuthorReviewers_test.go
@@ -82,6 +82,31 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 			},
 			mockedFileList: aladino.GetDefaultPullRequestFileList(),
 		},
+		"when the pull request already has reviews": {
+			totalReviewers:    1,
+			maxReviews:        3,
+			excludedReviewers: aladino.BuildArrayValue([]aladino.Value{}),
+			mockBackendOptions: []mock.MockBackendOption{
+				mock.WithRequestMatch(
+					mock.GetReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
+					&github.Reviewers{},
+				),
+				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{
+						{
+							ID:    github.Int64(1),
+							Body:  github.String("body"),
+							State: github.String("APPROVED"),
+							User: &github.User{
+								Login: github.String("test"),
+							},
+						},
+					},
+				),
+			},
+			mockedFileList: aladino.GetDefaultPullRequestFileList(),
+		},
 		"when error getting git blame information": {
 			totalReviewers:    1,
 			maxReviews:        3,
@@ -98,6 +123,10 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 							Login: github.String("test"),
 						},
 					},
+				),
+				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{},
 				),
 			},
 			mockedFileList: []*pbc.File{{
@@ -135,6 +164,10 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 							Login: github.String("test"),
 						},
 					},
+				),
+				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{},
 				),
 			},
 			mockedFileList: aladino.GetDefaultPullRequestFileList(),
@@ -218,6 +251,10 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 						},
 					},
 				),
+				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{},
+				),
 			},
 			mockedFileList: aladino.GetDefaultPullRequestFileList(),
 			wantErr:        fmt.Errorf("error getting open pull requests as reviewer: non-200 OK status code: 400 Bad Request body: \"\""),
@@ -300,6 +337,10 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 					mock.GetReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
 					&github.Reviewers{},
 					&github.Reviewers{},
+				),
+				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{},
 				),
 				mock.WithRequestMatch(
 					mock.GetReposAssigneesByOwnerByRepo,
@@ -405,6 +446,10 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 					mock.GetReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
 					&github.Reviewers{},
 					&github.Reviewers{},
+				),
+				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{},
 				),
 				mock.WithRequestMatch(
 					mock.GetReposAssigneesByOwnerByRepo,
@@ -584,6 +629,10 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 					&github.Reviewers{},
 				),
 				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{},
+				),
+				mock.WithRequestMatch(
 					mock.GetReposAssigneesByOwnerByRepo,
 					[]*github.User{
 						{
@@ -749,6 +798,10 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 					&github.Reviewers{},
 				),
 				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{},
+				),
+				mock.WithRequestMatch(
 					mock.GetReposAssigneesByOwnerByRepo,
 					[]*github.User{
 						{
@@ -896,6 +949,10 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 				mock.WithRequestMatch(
 					mock.GetReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
 					&github.Reviewers{},
+				),
+				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{},
 				),
 				mock.WithRequestMatch(
 					mock.GetReposAssigneesByOwnerByRepo,
@@ -1073,6 +1130,10 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 					&github.Reviewers{},
 				),
 				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{},
+				),
+				mock.WithRequestMatch(
 					mock.GetReposAssigneesByOwnerByRepo,
 					[]*github.User{
 						{
@@ -1220,6 +1281,10 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 					mock.GetReposPullsRequestedReviewersByOwnerByRepoByPullNumber,
 					&github.Reviewers{},
 					&github.Reviewers{},
+				),
+				mock.WithRequestMatch(
+					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+					[]*github.PullRequestReview{},
 				),
 				mock.WithRequestMatch(
 					mock.GetReposAssigneesByOwnerByRepo,


### PR DESCRIPTION
## Description
Currently because github removes users from the list of requested reviewers after they've given feedback(https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#list-requested-reviewers-for-a-pull-request) the `$assignCodeAuthorReviewers` built-in would assign a new reviewer to a pull request after the previous one has given feedback, this pull request fixes that behaviour so that reviewpad checks both the requested reviewers and the reviews list before assigning reviewers.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 396303e</samp>

This pull request adds tests and a logic improvement to the `assignCodeAuthorReviewers` plugin. It ensures that the plugin does not request reviewers that have already submitted reviews for a pull request, and it covers different scenarios of file patterns and pull request states in the tests.

Closes #863 

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 396303e</samp>

*  Add a check to skip requesting reviewers if the pull request already has reviews ([link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-acd9551bb4313dcc36ef244051ab652050f97e37e9a907c5bfbccc9f171a90d0R53-R64))
*  Add test cases to verify the behavior of requesting reviewers based on the number of existing reviews and requested reviewers, and the file patterns of the pull request ([link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR85-R109), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR127-R130), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR168-R171), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR254-R257), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR342-R345), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR451-R454), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR632-R635), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR801-R804), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR954-R957), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR1133-R1136), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR1286-R1289))
*  Add mock request matches to return empty slices of reviews for the pull request in the test cases ([link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR127-R130), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR168-R171), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR254-R257), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR342-R345), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR451-R454), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR632-R635), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR801-R804), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR954-R957), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR1133-R1136), [link](https://github.com/reviewpad/reviewpad/pull/868/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR1286-R1289))
