### PR TITLE
feat: merge and fail should update check run status

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -158,7 +158,7 @@ func run() error {
 
 	for _, targetEntity := range targetEntities {
 		log.Infof("Processing entity %s/%s#%d", targetEntity.Owner, targetEntity.Repo, targetEntity.Number)
-		_, _, err = reviewpad.Run(ctxReq, log, gitHubClient, codeHostClient, collectorClient, targetEntity, eventDetails, file, nil, dryRun, safeModeRun)
+		_, _, _, err = reviewpad.Run(ctxReq, log, gitHubClient, codeHostClient, collectorClient, targetEntity, eventDetails, file, nil, dryRun, safeModeRun)
 		if err != nil {
 			return fmt.Errorf("error running reviewpad team edition. Details %v", err.Error())
 		}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -158,7 +158,7 @@ func run() error {
 
 	for _, targetEntity := range targetEntities {
 		log.Infof("Processing entity %s/%s#%d", targetEntity.Owner, targetEntity.Repo, targetEntity.Number)
-		_, _, err = reviewpad.Run(ctxReq, log, gitHubClient, codeHostClient, collectorClient, targetEntity, eventDetails, file, dryRun, safeModeRun)
+		_, _, err = reviewpad.Run(ctxReq, log, gitHubClient, codeHostClient, collectorClient, targetEntity, eventDetails, file, nil, dryRun, safeModeRun)
 		if err != nil {
 			return fmt.Errorf("error running reviewpad team edition. Details %v", err.Error())
 		}

--- a/engine/env.go
+++ b/engine/env.go
@@ -42,6 +42,7 @@ type Interpreter interface {
 	ExecStatement(statement *Statement) error
 	Report(mode string, safeMode bool) error
 	ReportMetrics() error
+	GetCheckRunUpdated() bool
 }
 
 type Env struct {

--- a/engine/env.go
+++ b/engine/env.go
@@ -42,7 +42,7 @@ type Interpreter interface {
 	ExecStatement(statement *Statement) error
 	Report(mode string, safeMode bool) error
 	ReportMetrics() error
-	GetCheckRunUpdated() bool
+	GetCheckRunConclusion() string
 }
 
 type Env struct {

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -516,6 +516,7 @@ func mockAladinoInterpreter(githubClient *gh.GithubClient, codehostClient *codeh
 		engine.DefaultMockTargetEntity,
 		engine.DefaultMockEventPayload,
 		aladino.MockBuiltIns(),
+		nil,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("aladino NewInterpreter returned unexpected error: %v", err)

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a license that can be
 // found in the LICENSE file.
 
+//go:build integration
+// +build integration
+
 package integration_test
 
 import (

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a license that can be
 // found in the LICENSE file.
 
-//go:build integration
-// +build integration
-
 package integration_test
 
 import (
@@ -245,7 +242,7 @@ func TestIntegration(t *testing.T) {
 			},
 			commitMessage:  "test: fail",
 			reviewpadFiles: []*engine.ReviewpadFile{buildInFailReviewpadFile, closeReviewpadFile, builtInDeleteHeadBranchReviewpadFile},
-			exitStatus:     []engine.ExitStatus{engine.ExitStatusFailure, engine.ExitStatusSuccess, engine.ExitStatusSuccess},
+			exitStatus:     []engine.ExitStatus{engine.ExitStatusSuccess, engine.ExitStatusSuccess, engine.ExitStatusSuccess},
 		},
 	}
 

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -245,7 +245,7 @@ func TestIntegration(t *testing.T) {
 			},
 			commitMessage:  "test: fail",
 			reviewpadFiles: []*engine.ReviewpadFile{buildInFailReviewpadFile, closeReviewpadFile, builtInDeleteHeadBranchReviewpadFile},
-			exitStatus:     []engine.ExitStatus{engine.ExitStatusSuccess, engine.ExitStatusSuccess, engine.ExitStatusSuccess},
+			exitStatus:     []engine.ExitStatus{engine.ExitStatusFailure, engine.ExitStatusSuccess, engine.ExitStatusSuccess},
 		},
 	}
 

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -330,7 +330,7 @@ func TestIntegration(t *testing.T) {
 			// execute the reviewpad files one by one and
 			// ensure there are no errors and exit statuses match
 			for i, file := range test.reviewpadFiles {
-				exitStatus, _, err := reviewpad.Run(ctxReq, logger, githubClient, codeHostClient, collector, targetEntity, eventDetails, file, false, false)
+				exitStatus, _, _, err := reviewpad.Run(ctxReq, logger, githubClient, codeHostClient, collector, targetEntity, eventDetails, file, nil, false, false)
 				assert.Equal(test.wantErr, err)
 				assert.Equal(test.exitStatus[i], exitStatus)
 			}

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -20,6 +20,7 @@ import (
 type Severity int
 
 const (
+	SEVERITY_FAIL    Severity = 0
 	SEVERITY_FATAL   Severity = 1
 	SEVERITY_ERROR   Severity = 2
 	SEVERITY_WARNING Severity = 3

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -46,6 +46,7 @@ type Env interface {
 	GetExecWaitGroup() *sync.WaitGroup
 	GetExecFatalErrorOccurred() error
 	SetExecFatalErrorOccurred(error)
+	GetCheckRunID() *int64
 }
 
 type BaseEnv struct {
@@ -64,6 +65,7 @@ type BaseEnv struct {
 	ExecWaitGroup            *sync.WaitGroup
 	ExecMutex                *sync.Mutex
 	ExecFatalErrorOccurred   error
+	CheckRunID               *int64
 }
 
 func (e *BaseEnv) GetBuiltIns() *BuiltIns {
@@ -130,6 +132,10 @@ func (e *BaseEnv) SetExecFatalErrorOccurred(err error) {
 	e.ExecFatalErrorOccurred = err
 }
 
+func (e *BaseEnv) GetCheckRunID() *int64 {
+	return e.CheckRunID
+}
+
 func NewTypeEnv(e Env) TypeEnv {
 	builtInsType := make(map[string]Type)
 	for builtInName, builtInFunction := range e.GetBuiltIns().Functions {
@@ -153,6 +159,7 @@ func NewEvalEnv(
 	targetEntity *entities.TargetEntity,
 	eventPayload interface{},
 	builtIns *BuiltIns,
+	checkRunID *int64,
 ) (Env, error) {
 	registerMap := RegisterMap(make(map[string]Value))
 	report := &Report{Actions: make([]string, 0)}
@@ -174,6 +181,7 @@ func NewEvalEnv(
 		CodeHostClient:           codeHostClient,
 		ExecWaitGroup:            &wg,
 		ExecMutex:                &mu,
+		CheckRunID:               checkRunID,
 	}
 
 	switch targetEntity.Kind {

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -47,8 +47,8 @@ type Env interface {
 	GetExecFatalErrorOccurred() error
 	SetExecFatalErrorOccurred(error)
 	GetCheckRunID() *int64
-	SetCheckRunUpdated(bool)
-	GetCheckRunUpdated() bool
+	SetCheckRunConclusion(string)
+	GetCheckRunConclusion() string
 }
 
 type BaseEnv struct {
@@ -68,7 +68,7 @@ type BaseEnv struct {
 	ExecMutex                *sync.Mutex
 	ExecFatalErrorOccurred   error
 	CheckRunID               *int64
-	CheckRunUpdated          bool
+	CheckRunConclusion       string
 }
 
 func (e *BaseEnv) GetBuiltIns() *BuiltIns {
@@ -123,12 +123,12 @@ func (e *BaseEnv) GetExecWaitGroup() *sync.WaitGroup {
 	return e.ExecWaitGroup
 }
 
-func (e *BaseEnv) SetCheckRunUpdated(updated bool) {
-	e.CheckRunUpdated = updated
+func (e *BaseEnv) SetCheckRunConclusion(conclusion string) {
+	e.CheckRunConclusion = conclusion
 }
 
-func (e *BaseEnv) GetCheckRunUpdated() bool {
-	return e.CheckRunUpdated
+func (e *BaseEnv) GetCheckRunConclusion() string {
+	return e.CheckRunConclusion
 }
 
 func (e *BaseEnv) GetExecFatalErrorOccurred() error {

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -47,6 +47,8 @@ type Env interface {
 	GetExecFatalErrorOccurred() error
 	SetExecFatalErrorOccurred(error)
 	GetCheckRunID() *int64
+	SetCheckRunUpdated(bool)
+	GetCheckRunUpdated() bool
 }
 
 type BaseEnv struct {
@@ -66,6 +68,7 @@ type BaseEnv struct {
 	ExecMutex                *sync.Mutex
 	ExecFatalErrorOccurred   error
 	CheckRunID               *int64
+	CheckRunUpdated          bool
 }
 
 func (e *BaseEnv) GetBuiltIns() *BuiltIns {
@@ -118,6 +121,14 @@ func (e *BaseEnv) GetCodeHostClient() *codehost.CodeHostClient {
 
 func (e *BaseEnv) GetExecWaitGroup() *sync.WaitGroup {
 	return e.ExecWaitGroup
+}
+
+func (e *BaseEnv) SetCheckRunUpdated(updated bool) {
+	e.CheckRunUpdated = updated
+}
+
+func (e *BaseEnv) GetCheckRunUpdated() bool {
+	return e.CheckRunUpdated
 }
 
 func (e *BaseEnv) GetExecFatalErrorOccurred() error {

--- a/lang/aladino/env_test.go
+++ b/lang/aladino/env_test.go
@@ -55,6 +55,7 @@ func TestNewEvalEnv_WhenGetPullRequestFilesFails(t *testing.T) {
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 	)
 
 	assert.Nil(t, env)
@@ -86,6 +87,7 @@ func TestNewEvalEnv_WhenNewFileFails(t *testing.T) {
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 	)
 
 	assert.Nil(t, env)
@@ -118,6 +120,7 @@ func TestNewEvalEnv(t *testing.T) {
 		aladino.DefaultMockTargetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 	)
 
 	mockedTarget, _ := target.NewPullRequestTarget(ctx, aladino.DefaultMockTargetEntity, mockedGithubClient, mockedCodehostClient, mockedCodeReview)
@@ -181,6 +184,7 @@ func TestNewEvalEnv_WhenGetPullRequestFails(t *testing.T) {
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 	)
 
 	assert.Nil(t, env)

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -121,14 +121,6 @@ func (i *Interpreter) ExecProgram(program *engine.Program) (engine.ExitStatus, e
 			retErr = err
 			break
 		}
-
-		hasFatalError := len(i.Env.GetBuiltInsReportedMessages()[SEVERITY_FATAL]) > 0
-		if hasFatalError {
-			i.Env.GetLogger().Info("execution stopped")
-			retStatus = engine.ExitStatusFailure
-			retErr = nil
-			break
-		}
 	}
 
 	i.Env.GetExecWaitGroup().Wait()

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -252,8 +252,8 @@ func (i *Interpreter) ReportMetrics() error {
 	return nil
 }
 
-func (i *Interpreter) GetCheckRunUpdated() bool {
-	return i.Env.GetCheckRunUpdated()
+func (i *Interpreter) GetCheckRunConclusion() string {
+	return i.Env.GetCheckRunConclusion()
 }
 
 func NewInterpreter(

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -190,6 +190,9 @@ func (i *Interpreter) Report(mode string, safeMode bool) error {
 
 	reportComments := env.GetBuiltInsReportedMessages()
 
+	// Since fail messages aren't supposed to be reported, we remove them from the report
+	delete(reportComments, SEVERITY_FAIL)
+
 	if mode == engine.SILENT_MODE && len(reportComments) == 0 && !safeMode {
 		if comment != nil {
 			return DeleteReportComment(env, *comment.ID)

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -270,8 +270,9 @@ func NewInterpreter(
 	targetEntity *entities.TargetEntity,
 	eventPayload interface{},
 	builtIns *BuiltIns,
+	checkRunID *int64,
 ) (engine.Interpreter, error) {
-	evalEnv, err := NewEvalEnv(ctx, logger, dryRun, githubClient, codeHostClient, collector, targetEntity, eventPayload, builtIns)
+	evalEnv, err := NewEvalEnv(ctx, logger, dryRun, githubClient, codeHostClient, collector, targetEntity, eventPayload, builtIns, checkRunID)
 	if err != nil {
 		return nil, err
 	}

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -252,6 +252,10 @@ func (i *Interpreter) ReportMetrics() error {
 	return nil
 }
 
+func (i *Interpreter) GetCheckRunUpdated() bool {
+	return i.Env.GetCheckRunUpdated()
+}
+
 func NewInterpreter(
 	ctx context.Context,
 	logger *logrus.Entry,

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -121,6 +121,14 @@ func (i *Interpreter) ExecProgram(program *engine.Program) (engine.ExitStatus, e
 			retErr = err
 			break
 		}
+
+		hasFatalError := len(i.Env.GetBuiltInsReportedMessages()[SEVERITY_FATAL]) > 0
+		if hasFatalError {
+			i.Env.GetLogger().Info("execution stopped")
+			retStatus = engine.ExitStatusFailure
+			retErr = nil
+			break
+		}
 	}
 
 	i.Env.GetExecWaitGroup().Wait()

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -774,6 +774,7 @@ func TestNewInterpreter_WhenNewEvalEnvFails(t *testing.T) {
 		DefaultMockTargetEntity,
 		nil,
 		nil,
+		nil,
 	)
 
 	assert.Nil(t, gotInterpreter)
@@ -797,6 +798,7 @@ func TestNewInterpreter(t *testing.T) {
 		DefaultMockTargetEntity,
 		mockedEnv.GetEventPayload(),
 		mockedEnv.GetBuiltIns(),
+		nil,
 	)
 
 	assert.Nil(t, err)
@@ -1040,6 +1042,7 @@ func TestReportMetric(t *testing.T) {
 				env.GetCodeHostClient(),
 				env.GetCollector(),
 				env.GetTarget().GetTargetEntity(),
+				nil,
 				nil,
 				nil,
 			)

--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -155,6 +155,7 @@ func mockEnvWith(prOwner string, prRepoName string, prNum int, githubClient *gh.
 		targetEntity,
 		eventPayload,
 		builtIns,
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/lang/aladino/report.go
+++ b/lang/aladino/report.go
@@ -58,6 +58,10 @@ func buildCommentSection(comments map[Severity][]string) string {
 	var sb strings.Builder
 
 	for sev, list := range comments {
+		if sev == SEVERITY_FAIL {
+			continue
+		}
+
 		sb.WriteString(fmt.Sprintf("**%v**\n", severityToString(sev)))
 		for _, elem := range list {
 			sb.WriteString(fmt.Sprintf("* %v\n", elem))

--- a/lang/aladino/report.go
+++ b/lang/aladino/report.go
@@ -58,10 +58,6 @@ func buildCommentSection(comments map[Severity][]string) string {
 	var sb strings.Builder
 
 	for sev, list := range comments {
-		if sev == SEVERITY_FAIL {
-			continue
-		}
-
 		sb.WriteString(fmt.Sprintf("**%v**\n", severityToString(sev)))
 		for _, elem := range list {
 			sb.WriteString(fmt.Sprintf("* %v\n", elem))

--- a/lang/aladino/report.go
+++ b/lang/aladino/report.go
@@ -47,6 +47,8 @@ func severityToString(sev Severity) string {
 		return ":warning: Warnings"
 	case SEVERITY_INFO:
 		return ":information_source: Messages"
+	case SEVERITY_FAIL:
+		return ":x: Failures"
 	default:
 		return "Fatal"
 	}

--- a/plugins/aladino/actions/fail.go
+++ b/plugins/aladino/actions/fail.go
@@ -5,10 +5,6 @@
 package plugins_aladino_actions
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/google/go-github/v52/github"
 	"github.com/reviewpad/go-lib/entities"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 )
@@ -22,31 +18,9 @@ func Fail() *aladino.BuiltInAction {
 }
 
 func failCode(e aladino.Env, args []aladino.Value) error {
-	targetEntity := e.GetTarget().GetTargetEntity()
 	failMessage := args[0].(*aladino.StringValue).Val
 
 	e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL] = append(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL], failMessage)
-
-	if e.GetCheckRunID() != nil {
-		e.SetCheckRunConclusion("failure")
-
-		summary := strings.Builder{}
-
-		for _, msg := range e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL] {
-			summary.WriteString(fmt.Sprintf("- %s\n", msg))
-		}
-
-		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
-			Name:       "reviewpad",
-			Status:     github.String("completed"),
-			Conclusion: github.String("failure"),
-			Output: &github.CheckRunOutput{
-				Title:   github.String("Reviewpad policy failed"),
-				Summary: github.String(summary.String()),
-			},
-		})
-		return err
-	}
 
 	return nil
 }

--- a/plugins/aladino/actions/fail.go
+++ b/plugins/aladino/actions/fail.go
@@ -27,6 +27,7 @@ func failCode(e aladino.Env, args []aladino.Value) error {
 	if e.GetCheckRunID() != nil {
 		e.SetCheckRunUpdated(true)
 		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
+			Name:       "reviewpad",
 			Status:     github.String("completed"),
 			Conclusion: github.String("failure"),
 		})

--- a/plugins/aladino/actions/fail.go
+++ b/plugins/aladino/actions/fail.go
@@ -25,6 +25,7 @@ func failCode(e aladino.Env, args []aladino.Value) error {
 	e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL] = append(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL], failMessage)
 
 	if e.GetCheckRunID() != nil {
+		e.SetCheckRunUpdated(true)
 		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
 			Status:     github.String("completed"),
 			Conclusion: github.String("failure"),

--- a/plugins/aladino/actions/fail.go
+++ b/plugins/aladino/actions/fail.go
@@ -5,6 +5,7 @@
 package plugins_aladino_actions
 
 import (
+	"github.com/google/go-github/v52/github"
 	"github.com/reviewpad/go-lib/entities"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 )
@@ -18,9 +19,18 @@ func Fail() *aladino.BuiltInAction {
 }
 
 func failCode(e aladino.Env, args []aladino.Value) error {
+	targetEntity := e.GetTarget().GetTargetEntity()
 	failMessage := args[0].(*aladino.StringValue).Val
 
 	e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL] = append(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL], failMessage)
+
+	if e.GetCheckRunID() != nil {
+		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
+			Status:     github.String("completed"),
+			Conclusion: github.String("failure"),
+		})
+		return err
+	}
 
 	return nil
 }

--- a/plugins/aladino/actions/fail.go
+++ b/plugins/aladino/actions/fail.go
@@ -25,7 +25,7 @@ func failCode(e aladino.Env, args []aladino.Value) error {
 	e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL] = append(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL], failMessage)
 
 	if e.GetCheckRunID() != nil {
-		e.SetCheckRunUpdated(true)
+		e.SetCheckRunConclusion("failure")
 		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
 			Name:       "reviewpad",
 			Status:     github.String("completed"),

--- a/plugins/aladino/actions/failCheckStatus.go
+++ b/plugins/aladino/actions/failCheckStatus.go
@@ -32,6 +32,7 @@ func failCheckStatusCode(e aladino.Env, args []aladino.Value) error {
 		e.SetCheckRunConclusion("failure")
 
 		summary := strings.Builder{}
+		summary.WriteString("## Here are the reasons for Reviewpad's failure:\n\n")
 
 		for _, msg := range e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL] {
 			summary.WriteString(fmt.Sprintf("- %s\n", msg))

--- a/plugins/aladino/actions/failCheckStatus.go
+++ b/plugins/aladino/actions/failCheckStatus.go
@@ -1,0 +1,52 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_actions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v52/github"
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+)
+
+func FailCheckStatus() *aladino.BuiltInAction {
+	return &aladino.BuiltInAction{
+		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType()}, nil),
+		Code:           failCheckStatusCode,
+		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest, entities.Issue},
+	}
+}
+
+func failCheckStatusCode(e aladino.Env, args []aladino.Value) error {
+	targetEntity := e.GetTarget().GetTargetEntity()
+	failMessage := args[0].(*aladino.StringValue).Val
+
+	e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL] = append(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL], failMessage)
+
+	if e.GetCheckRunID() != nil {
+		e.SetCheckRunConclusion("failure")
+
+		summary := strings.Builder{}
+
+		for _, msg := range e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL] {
+			summary.WriteString(fmt.Sprintf("- %s\n", msg))
+		}
+
+		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
+			Name:       "reviewpad",
+			Status:     github.String("completed"),
+			Conclusion: github.String("failure"),
+			Output: &github.CheckRunOutput{
+				Title:   github.String("Reviewpad policy failed"),
+				Summary: github.String(summary.String()),
+			},
+		})
+		return err
+	}
+
+	return nil
+}

--- a/plugins/aladino/actions/failCheckStatus.go
+++ b/plugins/aladino/actions/failCheckStatus.go
@@ -32,7 +32,7 @@ func failCheckStatusCode(e aladino.Env, args []aladino.Value) error {
 
 		summary := strings.Builder{}
 
-		for _, msg := range e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL] {
+		for _, msg := range e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL] {
 			summary.WriteString(fmt.Sprintf("- %s\n", msg))
 		}
 

--- a/plugins/aladino/actions/failCheckStatus.go
+++ b/plugins/aladino/actions/failCheckStatus.go
@@ -32,7 +32,7 @@ func failCheckStatusCode(e aladino.Env, args []aladino.Value) error {
 		e.SetCheckRunConclusion("failure")
 
 		summary := strings.Builder{}
-		summary.WriteString("## Here are the reasons for Reviewpad's failure:\n\n")
+		summary.WriteString("#### Here are the reasons for Reviewpad's failure:\n\n")
 
 		for _, msg := range e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL] {
 			summary.WriteString(fmt.Sprintf("- %s\n", msg))

--- a/plugins/aladino/actions/failCheckStatus.go
+++ b/plugins/aladino/actions/failCheckStatus.go
@@ -13,6 +13,7 @@ import (
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 )
 
+// FailCheckStatus is a built-in action that fails the check run with a message without failing reviewpad.
 func FailCheckStatus() *aladino.BuiltInAction {
 	return &aladino.BuiltInAction{
 		Type:           aladino.BuildFunctionType([]aladino.Type{aladino.BuildStringType()}, nil),

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -37,7 +37,7 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
-	if e.GetCheckRunID() != nil && len(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL]) > 0 {
+	if e.GetCheckRunID() != nil && len(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL]) == 0 {
 		e.SetCheckRunConclusion("success")
 		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
 			Name:       "reviewpad",

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -47,7 +47,12 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
-	return t.Merge(mergeMethod)
+	err = t.Merge(mergeMethod)
+	if err != nil {
+		e.GetLogger().WithError(err).Warnln("failed to merge pull request")
+	}
+
+	return nil
 }
 
 func parseMergeMethod(args []aladino.Value) (string, error) {

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -47,9 +47,9 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
-	err = t.Merge(mergeMethod)
-	if err != nil {
-		e.GetLogger().WithError(err).Warnln("failed to merge pull request")
+	mergeErr := t.Merge(mergeMethod)
+	if mergeErr != nil {
+		e.GetLogger().WithError(mergeErr).Warnln("failed to merge pull request")
 	}
 
 	return nil

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -40,6 +40,7 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 	if e.GetCheckRunID() != nil {
 		e.SetCheckRunUpdated(true)
 		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
+			Name:       "reviewpad",
 			Status:     github.String("completed"),
 			Conclusion: github.String("success"),
 		})

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -37,7 +37,7 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
-	if e.GetCheckRunID() != nil && len(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL]) == 0 {
+	if e.GetCheckRunID() != nil {
 		e.SetCheckRunConclusion("success")
 		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
 			Name:       "reviewpad",
@@ -51,6 +51,10 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if len(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL]) > 0 {
+		return nil
 	}
 
 	mergeErr := t.Merge(mergeMethod)

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -43,6 +43,10 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 			Name:       "reviewpad",
 			Status:     github.String("completed"),
 			Conclusion: github.String("success"),
+			Output: &github.CheckRunOutput{
+				Title:   github.String("Reviewpad about to merge"),
+				Summary: github.String("Reviewpad is about to merge this pull request."),
+			},
 		})
 		return err
 	}

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -48,7 +48,9 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 				Summary: github.String("Reviewpad is about to merge this pull request."),
 			},
 		})
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	mergeErr := t.Merge(mergeMethod)

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -38,7 +38,7 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 	}
 
 	if e.GetCheckRunID() != nil {
-		e.SetCheckRunUpdated(true)
+		e.SetCheckRunConclusion("success")
 		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
 			Name:       "reviewpad",
 			Status:     github.String("completed"),

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -37,6 +37,10 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
+	if len(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL]) > 0 {
+		return nil
+	}
+
 	if e.GetCheckRunID() != nil {
 		e.SetCheckRunConclusion("success")
 		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
@@ -51,10 +55,6 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if len(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL]) > 0 {
-		return nil
 	}
 
 	mergeErr := t.Merge(mergeMethod)

--- a/plugins/aladino/actions/merge.go
+++ b/plugins/aladino/actions/merge.go
@@ -37,7 +37,7 @@ func mergeCode(e aladino.Env, args []aladino.Value) error {
 		return err
 	}
 
-	if e.GetCheckRunID() != nil {
+	if e.GetCheckRunID() != nil && len(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL]) > 0 {
 		e.SetCheckRunConclusion("success")
 		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
 			Name:       "reviewpad",

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -156,6 +156,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"disableActions":            actions.DisableActions(),
 			"error":                     actions.ErrorMsg(),
 			"fail":                      actions.Fail(),
+			"failCheckStatus":           actions.FailCheckStatus(),
 			"info":                      actions.Info(),
 			"merge":                     actions.Merge(),
 			"rebase":                    actions.Rebase(),

--- a/runner.go
+++ b/runner.go
@@ -281,6 +281,7 @@ func Run(
 	targetEntity *entities.TargetEntity,
 	eventDetails *entities.EventDetails,
 	reviewpadFile *engine.ReviewpadFile,
+	checkRunId *int64,
 	dryRun bool,
 	safeMode bool,
 ) (engine.ExitStatus, *engine.Program, error) {
@@ -291,7 +292,7 @@ func Run(
 
 	defer config.CleanupPluginConfig()
 
-	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, codeHostClient, collector, targetEntity, eventDetails.Payload, plugins_aladino.PluginBuiltInsWithConfig(config))
+	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, codeHostClient, collector, targetEntity, eventDetails.Payload, plugins_aladino.PluginBuiltInsWithConfig(config), checkRunId)
 	if err != nil {
 		return engine.ExitStatusFailure, nil, err
 	}

--- a/runner.go
+++ b/runner.go
@@ -117,7 +117,7 @@ func runReviewpadCommandDryRun(
 	targetEntity *entities.TargetEntity,
 	reviewpadFile *engine.ReviewpadFile,
 	env *engine.Env,
-) (engine.ExitStatus, *engine.Program, error) {
+) (engine.ExitStatus, *engine.Program, bool, error) {
 	err := collector.Collect("Trigger Command", map[string]interface{}{
 		"project": fmt.Sprintf("%s/%s", targetEntity.Owner, targetEntity.Repo),
 		"command": "dry-run",
@@ -135,23 +135,23 @@ func runReviewpadCommandDryRun(
 			logger.WithError(err).Errorf("error creating comment to report error on command execution")
 		}
 
-		return engine.ExitStatusFailure, nil, err
+		return engine.ExitStatusFailure, nil, false, err
 	}
 
 	program, err := engine.EvalConfigurationFile(reviewpadFile, env)
 	if err != nil {
 		logErrorAndCollect(logger, collector, "error evaluating configuration file", err)
-		return engine.ExitStatusFailure, nil, err
+		return engine.ExitStatusFailure, nil, false, err
 	}
 
 	report := aladino.BuildDryRunExecutionReport(program)
 
 	err = createCommentWithReviewpadCommandExecutionSuccess(env, report)
 	if err != nil {
-		return engine.ExitStatusFailure, program, fmt.Errorf("error on creating report comment %v", err.(*github.ErrorResponse).Message)
+		return engine.ExitStatusFailure, program, false, fmt.Errorf("error on creating report comment %v", err.(*github.ErrorResponse).Message)
 	}
 
-	return engine.ExitStatusSuccess, program, nil
+	return engine.ExitStatusSuccess, program, false, nil
 }
 
 func runReviewpadCommand(
@@ -163,7 +163,7 @@ func runReviewpadCommand(
 	env *engine.Env,
 	aladinoInterpreter engine.Interpreter,
 	command string,
-) (engine.ExitStatus, *engine.Program, error) {
+) (engine.ExitStatus, *engine.Program, bool, error) {
 	err := collector.Collect("Trigger Command", map[string]interface{}{
 		"project": fmt.Sprintf("%s/%s", targetEntity.Owner, targetEntity.Repo),
 		"command": command,
@@ -179,10 +179,10 @@ func runReviewpadCommand(
 		err = createCommentWithReviewpadCommandEvaluationError(env, err)
 		if err != nil {
 			logger.WithError(err).Errorf("error creating comment to report error on command execution")
-			return engine.ExitStatusFailure, nil, err
+			return engine.ExitStatusFailure, nil, false, err
 		}
 
-		return engine.ExitStatusFailure, nil, err
+		return engine.ExitStatusFailure, nil, false, err
 	}
 
 	exitStatus, err := aladinoInterpreter.ExecProgram(program)
@@ -194,7 +194,7 @@ func runReviewpadCommand(
 			logger.WithError(err).Errorf("error creating comment to report error on command execution")
 		}
 
-		return engine.ExitStatusFailure, nil, err
+		return engine.ExitStatusFailure, nil, false, err
 	}
 
 	err = collector.Collect("Completed Command Execution", map[string]interface{}{})
@@ -202,7 +202,7 @@ func runReviewpadCommand(
 		logger.WithError(err).Errorf("error collecting completed command execution")
 	}
 
-	return exitStatus, program, nil
+	return exitStatus, program, false, nil
 }
 
 func runReviewpadFile(
@@ -269,7 +269,7 @@ func runReviewpadFile(
 		env.Logger.WithError(err).Errorf("error collecting completed analysis")
 	}
 
-	return exitStatus, program, nil
+	return exitStatus, program, aladinoInterpreter.GetCheckRunUpdated(), nil
 }
 
 func Run(
@@ -284,22 +284,22 @@ func Run(
 	checkRunId *int64,
 	dryRun bool,
 	safeMode bool,
-) (engine.ExitStatus, *engine.Program, error) {
+) (engine.ExitStatus, *engine.Program, bool, error) {
 	config, err := plugins_aladino.DefaultPluginConfig()
 	if err != nil {
-		return engine.ExitStatusFailure, nil, err
+		return engine.ExitStatusFailure, nil, false, err
 	}
 
 	defer config.CleanupPluginConfig()
 
 	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, codeHostClient, collector, targetEntity, eventDetails.Payload, plugins_aladino.PluginBuiltInsWithConfig(config), checkRunId)
 	if err != nil {
-		return engine.ExitStatusFailure, nil, err
+		return engine.ExitStatusFailure, nil, false, err
 	}
 
 	env, err := engine.NewEvalEnv(ctx, log, dryRun, gitHubClient, collector, targetEntity, aladinoInterpreter, eventDetails)
 	if err != nil {
-		return engine.ExitStatusFailure, nil, err
+		return engine.ExitStatusFailure, nil, false, err
 	}
 
 	if utils.IsReviewpadCommand(env.EventDetails) {

--- a/runner.go
+++ b/runner.go
@@ -117,7 +117,7 @@ func runReviewpadCommandDryRun(
 	targetEntity *entities.TargetEntity,
 	reviewpadFile *engine.ReviewpadFile,
 	env *engine.Env,
-) (engine.ExitStatus, *engine.Program, bool, error) {
+) (engine.ExitStatus, *engine.Program, string, error) {
 	err := collector.Collect("Trigger Command", map[string]interface{}{
 		"project": fmt.Sprintf("%s/%s", targetEntity.Owner, targetEntity.Repo),
 		"command": "dry-run",
@@ -135,23 +135,23 @@ func runReviewpadCommandDryRun(
 			logger.WithError(err).Errorf("error creating comment to report error on command execution")
 		}
 
-		return engine.ExitStatusFailure, nil, false, err
+		return engine.ExitStatusFailure, nil, "", err
 	}
 
 	program, err := engine.EvalConfigurationFile(reviewpadFile, env)
 	if err != nil {
 		logErrorAndCollect(logger, collector, "error evaluating configuration file", err)
-		return engine.ExitStatusFailure, nil, false, err
+		return engine.ExitStatusFailure, nil, "", err
 	}
 
 	report := aladino.BuildDryRunExecutionReport(program)
 
 	err = createCommentWithReviewpadCommandExecutionSuccess(env, report)
 	if err != nil {
-		return engine.ExitStatusFailure, program, false, fmt.Errorf("error on creating report comment %v", err.(*github.ErrorResponse).Message)
+		return engine.ExitStatusFailure, program, "", fmt.Errorf("error on creating report comment %v", err.(*github.ErrorResponse).Message)
 	}
 
-	return engine.ExitStatusSuccess, program, false, nil
+	return engine.ExitStatusSuccess, program, "", nil
 }
 
 func runReviewpadCommand(
@@ -163,7 +163,7 @@ func runReviewpadCommand(
 	env *engine.Env,
 	aladinoInterpreter engine.Interpreter,
 	command string,
-) (engine.ExitStatus, *engine.Program, bool, error) {
+) (engine.ExitStatus, *engine.Program, string, error) {
 	err := collector.Collect("Trigger Command", map[string]interface{}{
 		"project": fmt.Sprintf("%s/%s", targetEntity.Owner, targetEntity.Repo),
 		"command": command,
@@ -179,10 +179,10 @@ func runReviewpadCommand(
 		err = createCommentWithReviewpadCommandEvaluationError(env, err)
 		if err != nil {
 			logger.WithError(err).Errorf("error creating comment to report error on command execution")
-			return engine.ExitStatusFailure, nil, false, err
+			return engine.ExitStatusFailure, nil, "", err
 		}
 
-		return engine.ExitStatusFailure, nil, false, err
+		return engine.ExitStatusFailure, nil, "", err
 	}
 
 	exitStatus, err := aladinoInterpreter.ExecProgram(program)
@@ -194,7 +194,7 @@ func runReviewpadCommand(
 			logger.WithError(err).Errorf("error creating comment to report error on command execution")
 		}
 
-		return engine.ExitStatusFailure, nil, false, err
+		return engine.ExitStatusFailure, nil, "", err
 	}
 
 	err = collector.Collect("Completed Command Execution", map[string]interface{}{})
@@ -202,7 +202,7 @@ func runReviewpadCommand(
 		logger.WithError(err).Errorf("error collecting completed command execution")
 	}
 
-	return exitStatus, program, false, nil
+	return exitStatus, program, "", nil
 }
 
 func runReviewpadFile(
@@ -269,7 +269,7 @@ func runReviewpadFile(
 		env.Logger.WithError(err).Errorf("error collecting completed analysis")
 	}
 
-	return exitStatus, program, aladinoInterpreter.GetCheckRunUpdated(), nil
+	return exitStatus, program, aladinoInterpreter.GetCheckRunConclusion(), nil
 }
 
 func Run(
@@ -284,22 +284,22 @@ func Run(
 	checkRunId *int64,
 	dryRun bool,
 	safeMode bool,
-) (engine.ExitStatus, *engine.Program, bool, error) {
+) (engine.ExitStatus, *engine.Program, string, error) {
 	config, err := plugins_aladino.DefaultPluginConfig()
 	if err != nil {
-		return engine.ExitStatusFailure, nil, false, err
+		return engine.ExitStatusFailure, nil, "", err
 	}
 
 	defer config.CleanupPluginConfig()
 
 	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, codeHostClient, collector, targetEntity, eventDetails.Payload, plugins_aladino.PluginBuiltInsWithConfig(config), checkRunId)
 	if err != nil {
-		return engine.ExitStatusFailure, nil, false, err
+		return engine.ExitStatusFailure, nil, "", err
 	}
 
 	env, err := engine.NewEvalEnv(ctx, log, dryRun, gitHubClient, collector, targetEntity, aladinoInterpreter, eventDetails)
 	if err != nil {
-		return engine.ExitStatusFailure, nil, false, err
+		return engine.ExitStatusFailure, nil, "", err
 	}
 
 	if utils.IsReviewpadCommand(env.EventDetails) {


### PR DESCRIPTION
## Description
In order to support merge policies the `$merge` and `$fail` built-ins need to be able to set the status of the check run, this pull request updates reviewpad so that it receives a check run id that the built-ins can use to control the status of the check.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5f2400</samp>

This pull request adds support for GitHub check runs for reviewpad policies. It modifies the `lang/aladino` package and its plugins to handle check run IDs, conclusions, and outputs in the interpreter and the built-in functions. It also updates the `runner.go` file and the `engine` package to pass and return the check run information. It adjusts the test files and the `cli` package to reflect the changes in the function signatures.

Closes #874 

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b5f2400</samp>

*  Add support for GitHub check runs for reviewpad policies ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-90ee5300adc85797bd4537cc53f7b93a501cad3d1bd40d87d77a8520258e718bL161-R161), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-bd383b1ff56f0a02ff20cb2df318417891c9954441067394d8ad3ec8a30638c2R45), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2R519), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R49-R51), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R70-R71), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R126-R133), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R146-R149), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R173), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R195), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR58), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR90), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR123), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR187), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL124-L131), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becR255-R258), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL273-R271), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R777), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R801), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R1047), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-60b59276b5de7d54b1037102856a01cf3f454fd5793a4d9f57f2b01878ae927bR158), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-58d38d6f1311e488197b318ccf3ed98a9109b0a7a7b3066637c9456558e6e22cR8-R11), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-58d38d6f1311e488197b318ccf3ed98a9109b0a7a7b3066637c9456558e6e22cL21-R50), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-26a95b4cf217b7be91710ac65c7d91ec151c36b235096cb01800e162299b35abR10), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-26a95b4cf217b7be91710ac65c7d91ec151c36b235096cb01800e162299b35abR27), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-26a95b4cf217b7be91710ac65c7d91ec151c36b235096cb01800e162299b35abL38-R55), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L121-R121), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L139-R139), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L145-R145), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L152-R155), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L167-R167), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L183-R186), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L198-R198), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L206-R206), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L216-R223), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L228-R229), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L253-R254), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L263-R264), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L276-R277), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L285-R286), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L294-R295), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L304-R305), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L316-R335), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L343-R350))
  * Add a new parameter `checkRunId` to the `Run` function signature in the `runner.go` file and pass it to the `runReviewpadFile` and `runReviewpadCommand` functions ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L316-R335), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L343-R350))
  * Add a new parameter `checkRunId` to the `runReviewpadFile` function signature in the `runner.go` file and pass it to the `NewInterpreter` function in the `lang/aladino` package ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L216-R223))
  * Add a new parameter `checkRunId` to the `runReviewpadCommand` function signature in the `runner.go` file and pass it to the `runReviewpadCommandDryRun` function ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L167-R167))
  * Add a new parameter `checkRunId` to the `runReviewpadCommandDryRun` function signature in the `runner.go` file and pass it to the `reviewpad.Run` function in the `cli` package ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L121-R121))
  * Add a new parameter `checkRunId` to the `reviewpad.Run` function signature in the `cli` package and pass it to the `NewInterpreter` function in the `engine` package ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-90ee5300adc85797bd4537cc53f7b93a501cad3d1bd40d87d77a8520258e718bL161-R161))
  * Add a new parameter `checkRunId` to the `NewInterpreter` function signature in the `engine` package and pass it to the `NewEvalEnv` function in the `lang/aladino` package ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL273-R271))
  * Add a new parameter `checkRunId` to the `NewEvalEnv` function signature in the `lang/aladino` package and assign it to the `CheckRunID` field of the `BaseEnv` struct ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R173), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R195))
  * Add two new fields `CheckRunID` and `CheckRunConclusion` to the `BaseEnv` struct in the `lang/aladino` package to store the check run ID and conclusion that correspond to the aladino interpreter's execution ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R70-R71))
  * Add three new methods `GetCheckRunID`, `SetCheckRunConclusion`, and `GetCheckRunConclusion` to the `Env` interface in the `lang/aladino` package to access and modify the check run ID and conclusion ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R49-R51))
  * Implement the `GetCheckRunID`, `SetCheckRunConclusion`, and `GetCheckRunConclusion` methods for the `BaseEnv` struct in the `lang/aladino` package ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R126-R133), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R146-R149))
  * Implement the `GetCheckRunConclusion` method for the `Interpreter` struct in the `lang/aladino` package to return the check run conclusion from the aladino environment ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becR255-R258))
  * Add a new method `GetCheckRunConclusion` to the `Interpreter` interface in the `engine` package to return the conclusion of the check run that corresponds to the interpreter's execution ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-bd383b1ff56f0a02ff20cb2df318417891c9954441067394d8ad3ec8a30638c2R45))
  * Modify the `runReviewpadFile` function in the `runner.go` file to return the check run conclusion from the aladino interpreter as the third value ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L228-R229), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L253-R254), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L263-R264), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L276-R277), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L285-R286), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L294-R295), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L304-R305))
  * Modify the `runReviewpadCommandDryRun` function in the `runner.go` file to return an empty string as the third value, which corresponds to the check run conclusion ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L139-R139), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L145-R145), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L152-R155))
  * Modify the `runReviewpadCommand` function in the `runner.go` file to return an empty string as the third value, which corresponds to the check run conclusion ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L183-R186), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L198-R198), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L206-R206))
  * Remove the code that checks for fatal errors in the aladino environment and stops the execution in the `Run` method of the `Interpreter` struct in the `lang/aladino` package, as the fatal errors are handled by the `fail` built-in function ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL124-L131))
  * Modify the `failCode` function in the `plugins/aladino/actions/fail.go` file to set the check run conclusion to "failure" and update the check run status and output with the fatal messages from the aladino environment, if the check run ID is not nil ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-58d38d6f1311e488197b318ccf3ed98a9109b0a7a7b3066637c9456558e6e22cL21-R50))
  * Modify the `mergeCode` function in the `plugins/aladino/actions/merge.go` file to set the check run conclusion to "success" and update the check run status and output with a success message, if the check run ID is not nil and there are no fatal messages from the aladino environment ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-26a95b4cf217b7be91710ac65c7d91ec151c36b235096cb01800e162299b35abL38-R55))
  * Add new imports to the `plugins/aladino/actions/fail.go` and `plugins/aladino/actions/merge.go` files for the new logic that updates the check run status and output ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-58d38d6f1311e488197b318ccf3ed98a9109b0a7a7b3066637c9456558e6e22cR8-R11), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-26a95b4cf217b7be91710ac65c7d91ec151c36b235096cb01800e162299b35abR10))
  * Add a new variable `targetEntity` to the `mergeCode` function in the `plugins/aladino/actions/merge.go` file to hold the target entity information for the check run output ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-26a95b4cf217b7be91710ac65c7d91ec151c36b235096cb01800e162299b35abR27))
  * Add a new argument `nil` to the `NewInterpreter` function calls in the test functions in the `lang/aladino` package, which corresponds to the `checkRunID` parameter that was added to the `NewInterpreter` function signature ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R777), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R801), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R1047))
  * Add a new argument `nil` to the `NewEvalEnv` function calls in the test functions in the `lang/aladino` package, which corresponds to the `checkRunID` parameter that was added to the `NewEvalEnv` function signature ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR58), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR90), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR123), [link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR187))
  * Add a new argument `nil` to the `NewInterpreter` function call in the `mockEnvWith` function in the `lang/aladino` package, which corresponds to the `checkRunID` parameter that was added to the `NewInterpreter` function signature ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-60b59276b5de7d54b1037102856a01cf3f454fd5793a4d9f57f2b01878ae927bR158))
  * Add a new argument `nil` to the `mockAladinoInterpreter` function call in the `engine` package, which corresponds to the `checkRunId` parameter that was added to the `NewInterpreter` function signature ([link](https://github.com/reviewpad/reviewpad/pull/876/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2R519))
