### PR TITLE
feat(summarize): add request id to error message for tracking

### DIFF
--- a/plugins/aladino/actions/robinSummarize.go
+++ b/plugins/aladino/actions/robinSummarize.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/reviewpad/api/go/services"
 	converter "github.com/reviewpad/go-lib/converters"
 	"github.com/reviewpad/go-lib/entities"
+	lib_http "github.com/reviewpad/go-lib/http"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 	plugins_aladino_services "github.com/reviewpad/reviewpad/v4/plugins/aladino/services"
 )
@@ -54,7 +55,7 @@ func robinSummarizeCode(e aladino.Env, args []aladino.Value) error {
 	resp, err := robinClient.Summarize(e.GetCtx(), req)
 	if err != nil {
 		log.Infof("summarize failed with %v", err)
-		return fmt.Errorf("summarize failed - please contact us on [Discord](https://reviewpad.com/discord)")
+		return fmt.Errorf("summarize failed on request %v - please contact us on [Discord](https://reviewpad.com/discord)", lib_http.InRequestID(e.GetCtx()))
 	}
 
 	return target.Comment(fmt.Sprintf("**AI-Generated Summary**: %s", resp.Summary))


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 May 23 10:43 UTC
This pull request adds the request ID to the error message for tracking purposes in the robinSummarizeCode function in robinSummarize.go.
<!-- reviewpad:summarize:end -->

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f4db5c</samp>

* Import the `lib_http` package to use the `InRequestID` function for debugging and tracing requests ([link](https://github.com/reviewpad/reviewpad/pull/883/files?diff=unified&w=0#diff-f364aa940beaeb00af74460f687b3c549a713a6c6f10cb0b5e1d4f0dea615452R14))
* Improve the error message returned by the `robinSummarizeCode` function to include the request ID ([link](https://github.com/reviewpad/reviewpad/pull/883/files?diff=unified&w=0#diff-f364aa940beaeb00af74460f687b3c549a713a6c6f10cb0b5e1d4f0dea615452L57-R58))
