### PR TITLE
feat: eager evaluation of reviewpad files

### DIFF
--- a/engine/exec.go
+++ b/engine/exec.go
@@ -161,7 +161,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 		}
 
 		for _, run := range workflow.Runs {
-			runActions, err := getActionsFromRunBlock(interpreter, &run, rules)
+			runActions, err := getActionsFromRunBlock(interpreter, run, rules)
 			if err != nil {
 				return nil, err
 			}
@@ -453,12 +453,7 @@ func execStatementBlock(interpreter Interpreter, runs []PadWorkflowRunBlock, rul
 	return ExitStatusSuccess, actions, nil
 }
 
-func getActionsFromRunBlock(interpreter Interpreter, run *PadWorkflowRunBlock, rules map[string]PadRule) ([]string, error) {
-	// QUESTION: why is this needed?
-	if run == nil {
-		return nil, nil
-	}
-
+func getActionsFromRunBlock(interpreter Interpreter, run PadWorkflowRunBlock, rules map[string]PadRule) ([]string, error) {
 	// if the run block was just a simple string
 	// there is no rule to evaluate, so just return the actions
 	if run.If == nil {
@@ -493,7 +488,7 @@ func getActionsFromRunBlock(interpreter Interpreter, run *PadWorkflowRunBlock, r
 func getActionsFromRunBlocks(interpreter Interpreter, runs []PadWorkflowRunBlock, rules map[string]PadRule, extraActions []string) ([]string, error) {
 	actions := []string{}
 	for _, run := range runs {
-		runActions, err := getActionsFromRunBlock(interpreter, &run, rules)
+		runActions, err := getActionsFromRunBlock(interpreter, run, rules)
 		if err != nil {
 			return nil, err
 		}

--- a/runner.go
+++ b/runner.go
@@ -210,11 +210,7 @@ func runReviewpadFile(
 	aladinoInterpreter engine.Interpreter,
 	reviewpadFile *engine.ReviewpadFile,
 	safeMode bool,
-) (engine.ExitStatus, *engine.Program, string, error) {
-	if safeMode && !env.DryRun {
-		return engine.ExitStatusFailure, nil, "", fmt.Errorf("when reviewpad is running in safe mode, it must also run in dry-run")
-	}
-
+) (engine.ExitStatus, *engine.Program, error) {
 	program, err := engine.EvalConfigurationFile(reviewpadFile, env)
 	if err != nil {
 		logErrorAndCollect(env.Logger, env.Collector, "error evaluating configuration file", err)

--- a/runner.go
+++ b/runner.go
@@ -303,6 +303,7 @@ func Run(
 	}
 
 	if utils.IsReviewpadCommand(env.EventDetails) {
+		// reviewpad-an: fixme: this is specific to github and only works for issues
 		command := eventDetails.Payload.(*github.IssueCommentEvent).GetComment().GetBody()
 		if utils.IsReviewpadCommandDryRun(command) {
 			return runReviewpadCommandDryRun(log, collector, gitHubClient, targetEntity, reviewpadFile, env)

--- a/runner.go
+++ b/runner.go
@@ -205,7 +205,7 @@ func runReviewpadCommand(
 	return exitStatus, program, "", nil
 }
 
-func runReviewpadFile(env *engine.Env, reviewpadFile *engine.ReviewpadFile, safeMode bool) (engine.ExitStatus, *engine.Program, error) {
+func runReviewpadFile(env *engine.Env, reviewpadFile *engine.ReviewpadFile, safeMode bool) (engine.ExitStatus, *engine.Program, string, error) {
 	err := env.Collector.Collect("Trigger Analysis", map[string]interface{}{
 		"project":        fmt.Sprintf("%s/%s", env.TargetEntity.Owner, env.TargetEntity.Repo),
 		"mode":           reviewpadFile.Mode,
@@ -228,14 +228,14 @@ func runReviewpadFile(env *engine.Env, reviewpadFile *engine.ReviewpadFile, safe
 	exitStatus, program, err := engine.ExecConfigurationFile(env, reviewpadFile)
 	if err != nil {
 		logErrorAndCollect(env.Logger, env.Collector, "error executing configuration file", err)
-		return engine.ExitStatusFailure, nil, aladinoInterpreter.GetCheckRunConclusion(), err
+		return engine.ExitStatusFailure, nil, env.Interpreter.GetCheckRunConclusion(), err
 	}
 
 	if safeMode || !env.DryRun {
 		err = env.Interpreter.Report(reviewpadFile.Mode, safeMode)
 		if err != nil {
 			logErrorAndCollect(env.Logger, env.Collector, "error reporting results", err)
-			return engine.ExitStatusFailure, nil, aladinoInterpreter.GetCheckRunConclusion(), err
+			return engine.ExitStatusFailure, nil, env.Interpreter.GetCheckRunConclusion(), err
 		}
 	}
 
@@ -244,7 +244,7 @@ func runReviewpadFile(env *engine.Env, reviewpadFile *engine.ReviewpadFile, safe
 			err = env.Interpreter.ReportMetrics()
 			if err != nil {
 				logErrorAndCollect(env.Logger, env.Collector, "error reporting metrics", err)
-				return engine.ExitStatusFailure, nil, aladinoInterpreter.GetCheckRunConclusion(), err
+				return engine.ExitStatusFailure, nil, env.Interpreter.GetCheckRunConclusion(), err
 			}
 		}
 	}
@@ -254,7 +254,7 @@ func runReviewpadFile(env *engine.Env, reviewpadFile *engine.ReviewpadFile, safe
 		env.Logger.WithError(err).Errorf("error collecting completed analysis")
 	}
 
-	return exitStatus, program, aladinoInterpreter.GetCheckRunConclusion(), nil
+	return exitStatus, program, env.Interpreter.GetCheckRunConclusion(), nil
 }
 
 func Run(


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 May 23 12:19 UTC
This pull request includes multiple changes across different files to improve functionality. 

In the first file diff, the `runReviewpadFile` function has been modified to remove the `aladinoInterpreter` variable and use the `env.Interpreter` field instead. Additionally, a check for `MetricsOnMerge` has been added to the `if utils.IsPullRequestReadyForReportMetrics` block.

The second file diff changes the name of the `EvalConfigurationFile` function to `ExecConfigurationFile` and adds new helper functions to process labels, groups, rules, workflows, pipelines, and execute a program of statements based on the command and workflow actions. The `getActionsFromRunBlock` and `getActionsFromRunBlocks` functions have also been updated.

Finally, changes in the `interpreter.go` file in the `aladino` directory add functionality to update the target based on the type of the current target entity. If the entity is an issue, the issue is fetched from Github and used to create the new target. If it is a pull request, the pull request is fetched from the code host and used.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e6af4b2</samp>

This pull request refactors the logic of processing and executing the `reviewpad` file, the main configuration file for the reviewpad tool. It introduces a new function `ExecConfigurationFile` in the `engine` package, which handles the labels, groups, rules, workflows, and pipelines from the file and returns a program of actions. It also simplifies the `runReviewpadFile` and `Run` functions in the `reviewpad` package, and adds a code block to the `aladino` package to update the target entity after each action. These changes aim to improve the modularity, readability, and correctness of the reviewpad code.

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e6af4b2</samp>

*  Refactor the logic of processing the reviewpad file into a separate function `ExecConfigurationFile` in the `engine` package, which returns both the program and the exit status ([link](https://github.com/reviewpad/reviewpad/pull/885/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL220-R415))
*  Update the target entity of the interpreter's environment after executing an action in the `aladino` package, to ensure the latest information is available ([link](https://github.com/reviewpad/reviewpad/pull/885/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becR166-R191))
*  Simplify the function signature and use the new function `ExecConfigurationFile` in the `reviewpad` package, which executes a reviewpad file for a given target entity and environment ([link](https://github.com/reviewpad/reviewpad/pull/885/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L208-R209), [link](https://github.com/reviewpad/reviewpad/pull/885/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L243-R228), [link](https://github.com/reviewpad/reviewpad/pull/885/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L250-R235), [link](https://github.com/reviewpad/reviewpad/pull/885/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L259-R244))
*  Enforce the constraint that safe mode and dry run mode must be both set when running the reviewpad tool, and return an error otherwise ([link](https://github.com/reviewpad/reviewpad/pull/885/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283R272-R275))
*  Document a limitation of the current implementation that only works for GitHub issues and mark it as a potential fixme ([link](https://github.com/reviewpad/reviewpad/pull/885/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283R294))
*  Remove the unnecessary `aladinoInterpreter` parameter from the calls to `runReviewpadFile` and `runReviewpadCommand` in the `reviewpad` package, and use the interpreter from the environment ([link](https://github.com/reviewpad/reviewpad/pull/885/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L311-R306))
