### PR TITLE
fix: refactor is updated with base branch implementation

### DIFF
--- a/plugins/aladino/functions/isUpdatedWithBaseBranch.go
+++ b/plugins/aladino/functions/isUpdatedWithBaseBranch.go
@@ -24,17 +24,15 @@ func isUpdatedWithBaseBranchCode(e aladino.Env, _ []aladino.Value) (aladino.Valu
 	pullRequest := e.GetTarget().(*target.PullRequestTarget).PullRequest
 	targetEntity := e.GetTarget().GetTargetEntity()
 
-	headBehindBy, err := e.GetGithubClient().GetHeadBehindBy(
+	pullRequestUpToDate, err := e.GetGithubClient().GetPullRequestUpToDate(
 		e.GetCtx(),
 		targetEntity.Owner,
 		targetEntity.Repo,
-		pullRequest.GetHead().GetRepo().GetOwner(),
-		pullRequest.GetHead().GetName(),
 		int(pullRequest.GetNumber()),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error getting head behind by information: %s", err.Error())
+		return nil, fmt.Errorf("error getting pull request outdated information: %s", err.Error())
 	}
 
-	return aladino.BuildBoolValue(headBehindBy == 0), nil
+	return aladino.BuildBoolValue(pullRequestUpToDate), nil
 }

--- a/plugins/aladino/functions/isUpdatedWithBaseBranch_test.go
+++ b/plugins/aladino/functions/isUpdatedWithBaseBranch_test.go
@@ -23,11 +23,11 @@ func TestIsUpdatedWithBaseBranch(t *testing.T) {
 		wantErr        error
 		wantIsUpdated  aladino.Value
 	}{
-		"when get head behind by query fails": {
+		"when get pull request update to date query fails": {
 			graphQLHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnprocessableEntity)
 			},
-			wantErr: errors.New("error getting head behind by information: non-200 OK status code: 422 Unprocessable Entity body: \"\""),
+			wantErr: errors.New("error getting pull request outdated information: non-200 OK status code: 422 Unprocessable Entity body: \"\""),
 		},
 		"when head is behind": {
 			graphQLHandler: func(w http.ResponseWriter, r *http.Request) {
@@ -35,9 +35,16 @@ func TestIsUpdatedWithBaseBranch(t *testing.T) {
 					"data": {
 						"repository": {
 							"pullRequest": {
+								"baseRefOid": "oldBaseRefOid",
 								"baseRef": {
-									"compare": {
-										"behindBy": 1
+									"target": {
+										"history": {
+											"nodes": [
+												{
+													"oid": "baseRefOid"
+												}
+											]
+										}
 									}
 								}
 							}
@@ -53,9 +60,16 @@ func TestIsUpdatedWithBaseBranch(t *testing.T) {
 					"data": {
 						"repository": {
 							"pullRequest": {
+								"baseRefOid": "baseRefOid",
 								"baseRef": {
-									"compare": {
-										"behindBy": 0
+									"target": {
+										"history": {
+											"nodes": [
+												{
+													"oid": "baseRefOid"
+												}
+											]
+										}
 									}
 								}
 							}


### PR DESCRIPTION
## Description
The current `$isUpdatedWithBaseBranch` built-in implementation seems to have issues with pull requests from private forks, this pull request refactors the implementation so that it uses a different query.

Closes reviewpad/raas-event-handler#144

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 May 23 08:30 UTC
This pull request refactors the implementation of checking whether a pull request is updated with its base branch by making it work on private forks as well. It modifies the following files:  
- codehost/github/pull_requests.go 
- plugins/aladino/functions/isUpdatedWithBaseBranch.go  
- plugins/aladino/functions/isUpdatedWithBaseBranch_test.go.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f784f4</samp>

Updated the logic and method for checking if a pull request is up to date with the base branch. Replaced the `behindBy` field with the `baseRefOid` and `headRefOid` fields in the `codehost/github/pull_requests.go` file and the corresponding test and plugin files.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f784f4</samp>

*  Simplify the logic of checking if a pull request is up to date with the base branch by using the base ref oid and the head ref oid instead of the behindBy field, which can be unreliable in some cases ([link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09L166-R176), [link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09L732-R751), [link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-0a02a490bc10d7dd4d13a5bd3ccf5d6e71054912de48b0c8d63647af4f3c3f12L26-R30), [link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-0a02a490bc10d7dd4d13a5bd3ccf5d6e71054912de48b0c8d63647af4f3c3f12L38-R47), [link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-0a02a490bc10d7dd4d13a5bd3ccf5d6e71054912de48b0c8d63647af4f3c3f12L56-R72), [link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-fbbe599716d4db32d95d6ffeabd6861b230b00eb51a161b269f15a992775096aL27-R37))
  * Modify the `CompareBaseAndHeadQuery` type in `codehost/github/pull_requests.go` to use the `baseRefOid` and `baseRef.target.commit.history.nodes[0].oid` fields instead of the `baseRef.compare.behindBy` field ([link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09L166-R176))
  * Replace the `GetHeadBehindBy` method with the `GetPullRequestUpToDate` method in `codehost/github/pull_requests.go`, which returns a boolean value indicating if the pull request head ref is equal to the base ref oid ([link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09L732-R751))
  * Update the `TestIsUpdatedWithBaseBranch` test function in `plugins/aladino/functions/isUpdatedWithBaseBranch_test.go` to reflect the new method name, error message, and query response format ([link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-0a02a490bc10d7dd4d13a5bd3ccf5d6e71054912de48b0c8d63647af4f3c3f12L26-R30), [link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-0a02a490bc10d7dd4d13a5bd3ccf5d6e71054912de48b0c8d63647af4f3c3f12L38-R47), [link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-0a02a490bc10d7dd4d13a5bd3ccf5d6e71054912de48b0c8d63647af4f3c3f12L56-R72))
  * Update the `isUpdatedWithBaseBranchCode` function in `plugins/aladino/functions/isUpdatedWithBaseBranch.go` to use the new `GetPullRequestUpToDate` method instead of the `GetHeadBehindBy` method ([link](https://github.com/reviewpad/reviewpad/pull/887/files?diff=unified&w=0#diff-fbbe599716d4db32d95d6ffeabd6861b230b00eb51a161b269f15a992775096aL27-R37))
