### PR TITLE
feat: stack fail messages along with failCheckStatus messages

### DIFF
--- a/plugins/aladino/actions/fail.go
+++ b/plugins/aladino/actions/fail.go
@@ -5,6 +5,10 @@
 package plugins_aladino_actions
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v52/github"
 	"github.com/reviewpad/go-lib/entities"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 )
@@ -18,9 +22,34 @@ func Fail() *aladino.BuiltInAction {
 }
 
 func failCode(e aladino.Env, args []aladino.Value) error {
+	targetEntity := e.GetTarget().GetTargetEntity()
 	failMessage := args[0].(*aladino.StringValue).Val
 
 	e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL] = append(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FATAL], failMessage)
+	// Because we want to stack the messages from $failCheckStatus and $fail as well, we are going to add the message to the fail list as well.
+	e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL] = append(e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL], failMessage)
+
+	if e.GetCheckRunID() != nil {
+		e.SetCheckRunConclusion("failure")
+
+		summary := strings.Builder{}
+		summary.WriteString("#### Here are the reasons for Reviewpad's failure:\n\n")
+
+		for _, msg := range e.GetBuiltInsReportedMessages()[aladino.SEVERITY_FAIL] {
+			summary.WriteString(fmt.Sprintf("- %s\n", msg))
+		}
+
+		_, _, err := e.GetGithubClient().GetClientREST().Checks.UpdateCheckRun(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, *e.GetCheckRunID(), github.UpdateCheckRunOptions{
+			Name:       "reviewpad",
+			Status:     github.String("completed"),
+			Conclusion: github.String("failure"),
+			Output: &github.CheckRunOutput{
+				Title:   github.String("Reviewpad failed"),
+				Summary: github.String(summary.String()),
+			},
+		})
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description

Updates the `fail` built-in so that it will stack it's messages together with the `$failCheckStatus` built-in and then update the check run.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 May 23 07:36 UTC
This pull request adds the feature of stacking fail messages along with failCheckStatus messages and displaying them on a check run. The code now includes an update to the UpdateCheckRun function that sets the conclusion of the check run as "failure" and includes the combined messages from the fail and failCheckStatus in the summary.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5c8995</samp>

Improve aladino plugin error handling. The plugin now reports script failures to GitHub as check run updates with `fail.go`.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f5c8995</samp>

* Send a check run update to GitHub with the failure message and details ([link](https://github.com/reviewpad/reviewpad/pull/891/files?diff=unified&w=0#diff-58d38d6f1311e488197b318ccf3ed98a9109b0a7a7b3066637c9456558e6e22cR8-R11),[link](https://github.com/reviewpad/reviewpad/pull/891/files?diff=unified&w=0#diff-58d38d6f1311e488197b318ccf3ed98a9109b0a7a7b3066637c9456558e6e22cL21-R53))
