### PR TITLE
fix: execute extra-actions in run clause

### DIFF
--- a/engine/testdata/exec/reviewpad_with_workflow_else.yml
+++ b/engine/testdata/exec/reviewpad_with_workflow_else.yml
@@ -1,0 +1,18 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+api-version: reviewpad.com/v3.x
+
+workflows:
+  - name: basic-workflow
+    run:
+      - if:
+          - rule: "false"
+            extra-actions:
+              - $addLabel("extra-actions")
+        then:
+          - $addLabel("then-clause")
+        else:
+          - $addLabel("else-clause")
+      - $addLabel("after-if")

--- a/engine/testdata/exec/reviewpad_with_workflow_extra_actions_then.yml
+++ b/engine/testdata/exec/reviewpad_with_workflow_extra_actions_then.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+api-version: reviewpad.com/v3.x
+
+workflows:
+  - name: basic-workflow
+    if:
+      - rule: "true"
+        extra-actions:
+          - $addLabel("extra-actions")
+    then:
+      - $addLabel("then-clause")


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 May 23 17:42 UTC
This pull request fixes a bug where extra-actions were not being executed in the run clause. It includes modifications to the exec and exec_test files, as well as the addition of two reviewpad example files for testing.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f39da14</samp>

This pull request adds support for extra actions in workflows that can be executed after the `then` clause of an `if` statement. It also improves the test coverage for the `engine` package by adding a new test function and test data files. It modifies the files `engine/exec.go`, `engine/exec_test.go`, and adds two files to the `engine/testdata/exec` directory.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f39da14</samp>

*  Add test function `TestExecConfigurationFile` to test execution of different reviewpad configuration files ([link](https://github.com/reviewpad/reviewpad/pull/895/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2R277-R376))
  * Use test data files `reviewpad_with_workflow_else.yml` and `reviewpad_with_workflow_extra_actions_then.yml` as inputs ([link](https://github.com/reviewpad/reviewpad/pull/895/files?diff=unified&w=0#diff-ecad5ecaa05077d21350768d9c3d8f67216d8a04ed5617f67c58d5088811a92aR1-R18), [link](https://github.com/reviewpad/reviewpad/pull/895/files?diff=unified&w=0#diff-681e5da5720754b23149c7dc0c7e8684488be8bd1a3e7e5b56779d01ca15cca6R1-R14))
* Modify `execStatement` function to execute extra actions in `if` clause of workflow after `then` clause ([link](https://github.com/reviewpad/reviewpad/pull/895/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL428-R434))
  * Remove `extraActions` parameter from `execStatementBlock` function call and definition ([link](https://github.com/reviewpad/reviewpad/pull/895/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL435-R441), [link](https://github.com/reviewpad/reviewpad/pull/895/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL442-R448))
  * Fix bug of duplicating extra actions by returning only current statement block actions ([link](https://github.com/reviewpad/reviewpad/pull/895/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL450-R456))
