### PR TITLE
refactor: merge and fail check run messages

### DIFF
--- a/plugins/aladino/actions/failCheckStatus.go
+++ b/plugins/aladino/actions/failCheckStatus.go
@@ -43,7 +43,7 @@ func failCheckStatusCode(e aladino.Env, args []aladino.Value) error {
 			Status:     github.String("completed"),
 			Conclusion: github.String("failure"),
 			Output: &github.CheckRunOutput{
-				Title:   github.String("Reviewpad policy failed"),
+				Title:   github.String("Reviewpad failed"),
 				Summary: github.String(summary.String()),
 			},
 		})


### PR DESCRIPTION
## Description
Adjusts the `$merge` and `$failCheckStatus` built-in check run messages to make it a bit more clear to the user.
reviewpad:summary 

copilot:summary

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

copilot:walkthrough
