### PR TITLE
feat: get discussion comments and add-rem reactions

### DIFF
--- a/codehost/github/discussions.go
+++ b/codehost/github/discussions.go
@@ -15,6 +15,12 @@ var (
 	ErrDiscussionNotFound = errors.New("discussion not found")
 )
 
+type AddDiscussionCommentMutation struct {
+	AddDiscussionComment struct {
+		ClientMutationID string
+	} `graphql:"addDiscussionComment(input: $input)"`
+}
+
 type AddReactionMutation struct {
 	AddReaction struct {
 		ClientMutationID string
@@ -125,6 +131,16 @@ func (c *GithubClient) GetDiscussionComments(ctx context.Context, owner, repo st
 	}
 
 	return comments, ErrDiscussionNotFound
+}
+
+func (c *GithubClient) AddCommentToDiscussion(ctx context.Context, discussionID, body string) error {
+	var addDiscussionCommentMutation AddDiscussionCommentMutation
+	addDiscussionCommentInput := githubv4.AddDiscussionCommentInput{
+		DiscussionID: discussionID,
+		Body:         githubv4.String(body),
+	}
+
+	return c.clientGQL.Mutate(ctx, &addDiscussionCommentMutation, addDiscussionCommentInput, nil)
 }
 
 func (c *GithubClient) AddReactionToDiscussionComment(ctx context.Context, subjectID string, reaction githubv4.ReactionContent) error {

--- a/codehost/github/discussions.go
+++ b/codehost/github/discussions.go
@@ -1,0 +1,120 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file
+
+package github
+
+import (
+	"context"
+
+	"github.com/shurcooL/githubv4"
+)
+
+type AddReactionMutation struct {
+	AddReaction struct {
+		ClientMutationID string
+	} `graphql:"addReaction(input: $input)"`
+}
+
+type RemoveReactionMutation struct {
+	RemoveReaction struct {
+		ClientMutationID string
+	} `graphql:"removeReaction(input: $input)"`
+}
+
+type DiscussionComment struct {
+	ID          string
+	Body        string
+	AuthorLogin string
+}
+
+type GetDiscussionCommentsQuery struct {
+	Repository struct {
+		Discussion struct {
+			ID     string
+			Body   string
+			Author struct {
+				Login string
+			}
+			Comments struct {
+				PageInfo PageInfo
+				Nodes    []struct {
+					DiscussionComment struct {
+						ID     string
+						Body   string
+						Author struct {
+							Login string
+						}
+					}
+					ID string
+				}
+			} `graphql:"comments(first: 50, after: $afterCursor)"`
+		} `graphql:"discussion(number: $number)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// GetDiscussionComments returns the discussion comments for a given discussion number.
+// The first element of the list is the body of the discussion.
+func (c *GithubClient) GetDiscussionComments(ctx context.Context, owner, repo string, discussionNum int) ([]DiscussionComment, error) {
+	var getDiscussionCommentsQuery GetDiscussionCommentsQuery
+	varGQLGetDiscussionCommentsQuery := map[string]interface{}{
+		"owner":       githubv4.String(owner),
+		"name":        githubv4.String(repo),
+		"number":      githubv4.Int(discussionNum),
+		"afterCursor": githubv4.String(""),
+	}
+
+	comments := make([]DiscussionComment, 0)
+
+	i := 0
+	for {
+		if err := c.clientGQL.Query(ctx, &getDiscussionCommentsQuery, varGQLGetDiscussionCommentsQuery); err != nil {
+			return nil, err
+		}
+
+		if i == 0 {
+			comments = append(comments, DiscussionComment{
+				ID:          getDiscussionCommentsQuery.Repository.Discussion.ID,
+				Body:        getDiscussionCommentsQuery.Repository.Discussion.Body,
+				AuthorLogin: getDiscussionCommentsQuery.Repository.Discussion.Author.Login,
+			})
+		}
+		i++
+
+		for _, node := range getDiscussionCommentsQuery.Repository.Discussion.Comments.Nodes {
+			comments = append(comments, DiscussionComment{
+				ID:          node.DiscussionComment.ID,
+				Body:        node.DiscussionComment.Body,
+				AuthorLogin: node.DiscussionComment.Author.Login,
+			})
+		}
+
+		if !getDiscussionCommentsQuery.Repository.Discussion.Comments.PageInfo.HasNextPage {
+			break
+		}
+
+		varGQLGetDiscussionCommentsQuery["afterCursor"] = githubv4.String(getDiscussionCommentsQuery.Repository.Discussion.Comments.PageInfo.EndCursor)
+	}
+
+	return comments, ErrProjectItemNotFound
+}
+
+func (c *GithubClient) AddReactionToDiscussionComment(ctx context.Context, subjectID string, reaction githubv4.ReactionContent) error {
+	var addReactionMutation AddReactionMutation
+	addReactionMutationInput := githubv4.AddReactionInput{
+		SubjectID: subjectID,
+		Content:   reaction,
+	}
+
+	return c.clientGQL.Mutate(ctx, &addReactionMutation, addReactionMutationInput, nil)
+}
+
+func (c *GithubClient) RemoveReactionToDiscussionComment(ctx context.Context, subjectID string, reaction githubv4.ReactionContent) error {
+	var removeReactionMutation RemoveReactionMutation
+	removeReactionMutationInput := githubv4.RemoveReactionInput{
+		SubjectID: subjectID,
+		Content:   reaction,
+	}
+
+	return c.clientGQL.Mutate(ctx, &removeReactionMutation, removeReactionMutationInput, nil)
+}


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 May 23 16:59 UTC
This pull request adds new features related to GitHub discussions, including getting discussion comments, adding and removing reactions, getting discussion IDs, and adding comments to discussions.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e97d2d</samp>

This change adds a new `github` package that allows reviewpad to interact with GitHub discussions using the GraphQL API. The change defines types and methods for fetching and manipulating discussion comments and reactions. The change enables reviewpad to support GitHub discussions as a feedback source.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e97d2d</samp>

* Implement methods to interact with GitHub discussions using the GraphQL API (`codehost/github/discussions.go`)
