### PR TITLE
fix(GetDiscussionComments): afterCursor initialization

### DIFF
--- a/codehost/github/discussions.go
+++ b/codehost/github/discussions.go
@@ -92,7 +92,7 @@ func (c *GithubClient) GetDiscussionComments(ctx context.Context, owner, repo st
 		"owner":       githubv4.String(owner),
 		"name":        githubv4.String(repo),
 		"number":      githubv4.Int(discussionNum),
-		"afterCursor": githubv4.String(""),
+		"afterCursor": (*githubv4.String)(nil),
 	}
 
 	comments := make([]DiscussionComment, 0)

--- a/codehost/github/discussions_test.go
+++ b/codehost/github/discussions_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGetDiscussionComments(t *testing.T) {
 	mockedGetDiscussionCommentsQuery := `{
-        "query": "query($afterCursor:String! $name:String! $number:Int! $owner:String!) {
+        "query": "query($afterCursor:String $name:String! $number:Int! $owner:String!) {
             repository(owner: $owner, name: $name) {
                 discussion(number: $number) {
                     id, 
@@ -42,7 +42,7 @@ func TestGetDiscussionComments(t *testing.T) {
             }
         }",
         "variables": {
-            "afterCursor": "",
+            "afterCursor": null,
             "name":"default-mock-repo",
             "number":82,
             "owner":"foobar"


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 May 23 16:23 UTC
This pull request fixes an issue in GetDiscussionComments where the afterCursor is incorrectly initialized. The afterCursor field now defaults to nil, resolving the issue.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54da112</samp>

This pull request fixes a bug in the `codehost/github` package that prevented fetching discussion comments from GitHub with optional pagination. It updates the `GetDiscussionComments` function and its test to handle nil cursor values correctly.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 54da112</samp>

* Fix a bug in `GetDiscussionComments` that caused an error with empty cursor value ([link](https://github.com/reviewpad/reviewpad/pull/905/files?diff=unified&w=0#diff-659707376eeeeb2c219de2e60ccd6397d97308873bddd457a83d3495214d5ae6L95-R95), [link](https://github.com/reviewpad/reviewpad/pull/905/files?diff=unified&w=0#diff-9b20b765b19397201f9f009bfaa545dfe57c8b68301c3dc5b6b32de5e92910ccL20-R20), [link](https://github.com/reviewpad/reviewpad/pull/905/files?diff=unified&w=0#diff-9b20b765b19397201f9f009bfaa545dfe57c8b68301c3dc5b6b32de5e92910ccL45-R45))
  - Replace empty string with nil pointer for `afterCursor` variable in GraphQL query ([link](https://github.com/reviewpad/reviewpad/pull/905/files?diff=unified&w=0#diff-659707376eeeeb2c219de2e60ccd6397d97308873bddd457a83d3495214d5ae6L95-R95))
  - Update test function `TestGetDiscussionComments` to match the change ([link](https://github.com/reviewpad/reviewpad/pull/905/files?diff=unified&w=0#diff-9b20b765b19397201f9f009bfaa545dfe57c8b68301c3dc5b6b32de5e92910ccL20-R20), [link](https://github.com/reviewpad/reviewpad/pull/905/files?diff=unified&w=0#diff-9b20b765b19397201f9f009bfaa545dfe57c8b68301c3dc5b6b32de5e92910ccL45-R45))
    - Remove exclamation mark from `afterCursor` variable type to make it optional ([link](https://github.com/reviewpad/reviewpad/pull/905/files?diff=unified&w=0#diff-9b20b765b19397201f9f009bfaa545dfe57c8b68301c3dc5b6b32de5e92910ccL20-R20))
    - Replace empty string with null as `afterCursor` variable value in test cases ([link](https://github.com/reviewpad/reviewpad/pull/905/files?diff=unified&w=0#diff-9b20b765b19397201f9f009bfaa545dfe57c8b68301c3dc5b6b32de5e92910ccL45-R45))
