### PR TITLE
fix: process check suit event from merge queue

### DIFF
--- a/handler/processors.go
+++ b/handler/processors.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -503,8 +504,26 @@ func processCheckSuiteEvent(log *logrus.Entry, token string, event *github.Check
 
 		log.Infof("fetched %d pull requests", len(prs))
 
+		headSha := event.CheckSuite.GetHeadSHA()
+
+		if event.Sender.GetLogin() == "github-merge-queue[bot]" {
+			prInfo := strings.Split(event.GetCheckSuite().GetHeadBranch(), "/")[2]
+			prNumberInt, err := strconv.Atoi(strings.Split(prInfo, "-")[1])
+			if err != nil {
+				return nil, nil, fmt.Errorf("error converting pr number to int: %w", err)
+			}
+
+			// get the head sha from the pull request
+			for _, pr := range prs {
+				if pr.GetNumber() == prNumberInt {
+					headSha = pr.GetHead().GetSHA()
+					break
+				}
+			}
+		}
+
 		for _, pr := range prs {
-			if pr.GetHead().GetSHA() == event.CheckSuite.GetHeadSHA() {
+			if pr.GetHead().GetSHA() == headSha {
 				log.Infof("found pull request %v", pr.GetNumber())
 				return []*entities.TargetEntity{
 					{

--- a/handler/processors.go
+++ b/handler/processors.go
@@ -492,8 +492,8 @@ func processCheckSuiteEvent(log *logrus.Entry, token string, event *github.Check
 		Payload:     event,
 	}
 
-	// When the check suite is from a head of a forked repository the pull_requests array will be empty
-	// We need to fetch all the pull requests for the repository and find the one that matches the head sha
+	// When the check suite is from a head of a forked repository or the head of a temporary branch created by github-merge-queue[bot]
+	// the pull_requests array will be empty. We need to fetch all the pull requests for the repository and find the one that matches the head sha.
 	if len(event.CheckSuite.PullRequests) == 0 {
 		log.Infof("no pull requests found in check suite event. fetching all pull requests for repository %v", event.GetRepo().GetFullName())
 
@@ -507,15 +507,15 @@ func processCheckSuiteEvent(log *logrus.Entry, token string, event *github.Check
 		headSha := event.CheckSuite.GetHeadSHA()
 
 		if event.Sender.GetLogin() == "github-merge-queue[bot]" {
+			// The format of a GitHub Merge Queue temporary branch is: gh-readonly-queue/{target_branch}/pr-{pr_number}-{head_sha_temporary_branch}
 			prInfo := strings.Split(event.GetCheckSuite().GetHeadBranch(), "/")[2]
-			prNumberInt, err := strconv.Atoi(strings.Split(prInfo, "-")[1])
+			prNumber, err := strconv.Atoi(strings.Split(prInfo, "-")[1])
 			if err != nil {
 				return nil, nil, fmt.Errorf("error converting pr number to int: %w", err)
 			}
 
-			// get the head sha from the pull request
 			for _, pr := range prs {
-				if pr.GetNumber() == prNumberInt {
+				if pr.GetNumber() == prNumber {
 					headSha = pr.GetHead().GetSHA()
 					break
 				}


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 May 23 19:36 UTC
This pull request contains two patches. 

The first patch fixes an issue with processing check suit events from the merge queue. When the pull requests array is empty, the code now fetches all pull requests for the repository and finds the one that matches the head SHA. 

The second patch adds comments to the code explaining the changes made in the first patch. It also updates the comment describing the process of finding the head SHA when the check suite is from a temporary branch created by the merge queue.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4f4974</samp>

Added support for check suite events from `github-merge-queue[bot]`. Updated `handler/processors.go` to handle temporary branch names and extract pull request numbers.

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4f4974</samp>

* Import `strconv` package to convert string to integer ([link](https://github.com/reviewpad/reviewpad/pull/906/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3R11))
* Handle check suite events from github-merge-queue[bot] service ([link](https://github.com/reviewpad/reviewpad/pull/906/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L494-R496), [link](https://github.com/reviewpad/reviewpad/pull/906/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L506-R526))
  - Update comment to explain the case where check suite is from a temporary branch ([link](https://github.com/reviewpad/reviewpad/pull/906/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L494-R496))
  - Modify logic to extract pull request number from branch name and find corresponding pull request ([link](https://github.com/reviewpad/reviewpad/pull/906/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L506-R526))
  - Use head sha of pull request to match target entity ([link](https://github.com/reviewpad/reviewpad/pull/906/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L506-R526))
