### PR TITLE
refactor: check if gh merge queue is enabled in a different graphql request

### DIFF
--- a/plugins/aladino/actions/merge_test.go
+++ b/plugins/aladino/actions/merge_test.go
@@ -7,6 +7,7 @@ package plugins_aladino_actions_test
 import (
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"testing"
 
@@ -253,6 +254,8 @@ func TestMerge_WhenGitHubMergeQueueEntriesRequestFails(t *testing.T) {
 		nil,
 		func(w http.ResponseWriter, req *http.Request) {
 			query := utils.MinifyQuery(utils.MustRead(req.Body))
+			log.Printf("query: %v\n", query)
+			log.Printf("mockedIsGitHubMergeQueueEnabledGQLQuery: %v\n", utils.MinifyQuery(mockedGitHubMergeQueueEntriesGQLQuery))
 			switch query {
 			case utils.MinifyQuery(mockedIsGitHubMergeQueueEnabledGQLQuery):
 				utils.MustWrite(w, mockedIsGitHubMergeQueueEnabledGQLQueryBody)
@@ -301,6 +304,7 @@ func TestMerge_WhenGitHubMergeQueueIsONAndPullRequestIsNotOnTheQueue(t *testing.
 		"data": {
 			"repository": {
 				"mergeQueue": {
+					"id": "test",
 					"entries": {
 						"nodes": []
 					}
@@ -379,6 +383,7 @@ func TestMerge_WhenGitHubMergeQueueIsONAndPullRequestIsNotOnTheQueueAndEnqueueFa
 		"data": {
 			"repository": {
 				"mergeQueue": {
+					"id": "test",
 					"entries": {
 						"nodes": []
 					}
@@ -454,6 +459,7 @@ func TestMerge_WhenPullRequestIsOnGitHubMergeQueue(t *testing.T) {
 		"data": {
 			"repository": {
 				"mergeQueue": {
+					"id": "test",
 					"entries": {
 						"nodes": [
 							{
@@ -514,6 +520,7 @@ func getMockedGitHubMergeQueueEntriesGQLQuery(mockBranch, mockRepo, mockOwner st
 		"query":"query($branchName:String!$cursor:String$repositoryName:String!$repositoryOwner:String!) {
 			repository(owner:$repositoryOwner,name:$repositoryName) {
 				mergeQueue(branch:$branchName) {
+					id,
 					entries(first:100,after:$cursor) {
 						nodes {
 							pullRequest {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 May 23 17:09 UTC
This pull request includes changes to the `mergeCode` function in `plugins/aladino/actions/merge.go` and the `GithubClient` struct. The changes include updating the `mergeCode` function to handle merge queue, adding a new method `IsGithubMergeQueueEnabled` to `GithubClient`, and improvements to `GetGitHubMergeQueueEntries`. The modification introduces pagination for merge queue entries and returns an error if the merge queue is not found for the given branch.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ddb6f4</samp>

Refactored and simplified the code and tests related to the GitHub merge queue feature in the `codehost/github` and `plugins/aladino` packages. Used more specific GraphQL queries to check the merge queue status and handle errors. Removed unused code and fields.

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before the merge

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ddb6f4</samp>

*  Simplify and split the GraphQL query for checking and fetching the GitHub merge queue ([link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09L185-R193), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09L795-R825), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09L810-R835), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09L823-R857))
*  Update the `mergeCode` function to use the new `IsGithubMergeQueueEnabled` function instead of the `GetGitHubMergeQueueEntries` function, and remove the unused `totalRetryCount` variable ([link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-26a95b4cf217b7be91710ac65c7d91ec151c36b235096cb01800e162299b35abL29), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-26a95b4cf217b7be91710ac65c7d91ec151c36b235096cb01800e162299b35abL45-R56))
*  Update the `processMergeForGitHubMergeQueue` function to take only the `aladino.Env` parameter and call the `GetGitHubMergeQueueEntries` function inside the function body ([link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-26a95b4cf217b7be91710ac65c7d91ec151c36b235096cb01800e162299b35abL107-R126))
*  Update the test functions in `plugins/aladino/actions/merge_test.go` to use and mock the new `IsGithubMergeQueueEnabled` query and the new `MergeQueueEntriesQuery` type, and to test the error handling of the `IsGithubMergeQueueEnabled` function ([link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fL54-R56), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fL107-R83), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fL132-R109), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fL160-R136), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fR195-R227), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fR237-R248), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fR257-R258), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fR286-R297), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fL270), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fR333-R334), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fR364-R375), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fL335), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fR409-R410), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fR439-R450), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fL397), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fR477-R478), [link](https://github.com/reviewpad/reviewpad/pull/916/files?diff=unified&w=0#diff-b7e6e6b449632eeab770d42177778989c64c3927b8c48a4376d73332fecdff9fL434-R516))
