### PR TITLE
chore: uncomment unit test

### DIFF
--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -299,17 +299,17 @@ func TestExecConfigurationFile(t *testing.T) {
 			targetEntity:   engine.DefaultMockTargetEntity,
 			wantExitStatus: engine.ExitStatusSuccess,
 		},
-		// "reviewpad with workflow else": {
-		// 	inputReviewpadFilePath: "testdata/exec/reviewpad_with_workflow_else.yml",
-		// 	wantProgram: engine.BuildProgram(
-		// 		[]*engine.Statement{
-		// 			engine.BuildStatement(`$addLabel("else-clause")`),
-		// 			engine.BuildStatement(`$addLabel("after-if")`),
-		// 		},
-		// 	),
-		// 	targetEntity:   engine.DefaultMockTargetEntity,
-		// 	wantExitStatus: engine.ExitStatusSuccess,
-		// },
+		"reviewpad with workflow else": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_workflow_else.yml",
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(`$addLabel("else-clause")`),
+					engine.BuildStatement(`$addLabel("after-if")`),
+				},
+			),
+			targetEntity:   engine.DefaultMockTargetEntity,
+			wantExitStatus: engine.ExitStatusSuccess,
+		},
 	}
 
 	codehostClient := aladino.GetDefaultCodeHostClient(t, aladino.GetDefaultPullRequestDetails(), aladino.GetDefaultPullRequestFileList(), nil, nil)


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 May 23 13:32 UTC
This pull request includes a trivial change that only comments a previously uncommented unit test located in exec_test.go file.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2ef8ce</samp>

Enable a test case for `else` clauses in configuration files. The test case checks the execution of `reviewpad` with a configuration file that contains an `if` statement with an `else` clause.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2ef8ce</samp>

* Add support for `else` clauses in configuration files (F0L37R
