### PR TITLE
fix: ignore pull request author as reviewer

### DIFF
--- a/plugins/aladino/functions/reviewers.go
+++ b/plugins/aladino/functions/reviewers.go
@@ -22,18 +22,23 @@ func Reviewers() *aladino.BuiltInFunction {
 func reviewersCode(e aladino.Env, _ []lang.Value) (lang.Value, error) {
 	t := e.GetTarget().(*target.PullRequestTarget)
 	reviewers := make([]lang.Value, 0)
-	existsInReviewersList := make(map[string]bool)
 
 	reviews, err := t.GetReviews()
 	if err != nil {
 		return nil, err
 	}
 
+	visited := make(map[string]bool)
 	for _, review := range reviews {
 		reviewer := review.User.Login
-		if _, ok := existsInReviewersList[reviewer]; !ok {
+
+		if reviewer == t.PullRequest.Author.Login {
+			continue
+		}
+
+		if _, ok := visited[reviewer]; !ok {
 			reviewers = append(reviewers, lang.BuildStringValue(reviewer))
-			existsInReviewersList[reviewer] = true
+			visited[reviewer] = true
 		}
 	}
 


### PR DESCRIPTION
## Description

Closes #888.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 May 23 14:57 UTC
This pull request contains two patches for fixing an issue in the Aladino plugin. The first patch adds logic to exclude the pull request author from the reviewers list. The second patch adds a unit test to ensure that the author is indeed being excluded.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a159382</samp>

This pull request improves the `reviewers` function in the `aladino` plugin, which assigns reviewers to pull requests based on code ownership. It adds and updates tests, refactors the logic to avoid author and duplicate reviewers, and imports the `codehost` package for mocking.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a159382</samp>

* Skip pull request author from reviewers list and use visited map to avoid duplicates in `reviewersCode` function ([link](https://github.com/reviewpad/reviewpad/pull/918/files?diff=unified&w=0#diff-9a8c3c715fc746d5809ab09fd0f69b8b95897da5736caaf3b532d5087833e9a9L32-R41))
* Remove unused variable `existsInReviewersList` from `reviewersCode` function ([link](https://github.com/reviewpad/reviewpad/pull/918/files?diff=unified&w=0#diff-9a8c3c715fc746d5809ab09fd0f69b8b95897da5736caaf3b532d5087833e9a9L25))
* Add import statement for `codehost` package to `reviewers_test.go` file ([link](https://github.com/reviewpad/reviewpad/pull/918/files?diff=unified&w=0#diff-ebc5ce3447d88ee5d566a55afdb0ded1e0a534bf953551e396aa60798f007d9dR14))
* Add variable `pullRequestAuthor` and use it to mock pull request author in `TestReviewers_WhenListReviewsRequestFails` function ([link](https://github.com/reviewpad/reviewpad/pull/918/files?diff=unified&w=0#diff-ebc5ce3447d88ee5d566a55afdb0ded1e0a534bf953551e396aa60798f007d9dR48-R54))
* Add new test case "when pull request has a comment from its author" to `TestReviewers` function, to test the new logic in `reviewersCode` function ([link](https://github.com/reviewpad/reviewpad/pull/918/files?diff=unified&w=0#diff-ebc5ce3447d88ee5d566a55afdb0ded1e0a534bf953551e396aa60798f007d9dL140-R191))
