### PR TITLE
feat: download gh repo contents through commit SHA

### DIFF
--- a/codehost/github/repositories.go
+++ b/codehost/github/repositories.go
@@ -37,7 +37,7 @@ func (c *GithubClient) GetDefaultRepositoryBranch(ctx context.Context, owner str
 	return repository.GetDefaultBranch(), nil
 }
 
-func (c *GithubClient) DownloadContents(ctx context.Context, filePath string, branch *pbc.Branch, options DownloadContentsOptions) ([]byte, error) {
+func (c *GithubClient) DownloadContents(ctx context.Context, filePath string, branch *pbc.Branch, options *DownloadContentsOptions) ([]byte, error) {
 	branchRepoOwner := branch.Repo.Owner
 	branchRepoName := branch.Repo.Name
 

--- a/codehost/github/repositories.go
+++ b/codehost/github/repositories.go
@@ -25,7 +25,7 @@ func (c *GithubClient) GetDefaultRepositoryBranch(ctx context.Context, owner str
 	return repository.GetDefaultBranch(), nil
 }
 
-func (c *GithubClient) DownloadContents(ctx context.Context, filePath string, branch *pbc.Branch) ([]byte, error) {
+func (c *GithubClient) DownloadContentsFromBranchName(ctx context.Context, filePath string, branch *pbc.Branch) ([]byte, error) {
 	branchRepoOwner := branch.Repo.Owner
 	branchRepoName := branch.Repo.Name
 	branchRef := branch.Name

--- a/codehost/github/repositories.go
+++ b/codehost/github/repositories.go
@@ -25,26 +25,16 @@ func (c *GithubClient) GetDefaultRepositoryBranch(ctx context.Context, owner str
 	return repository.GetDefaultBranch(), nil
 }
 
-func (c *GithubClient) DownloadContentsFromBranchName(ctx context.Context, filePath string, branch *pbc.Branch) ([]byte, error) {
+func (c *GithubClient) DownloadContents(ctx context.Context, filePath string, branch *pbc.Branch, useSHA bool) ([]byte, error) {
 	branchRepoOwner := branch.Repo.Owner
 	branchRepoName := branch.Repo.Name
-	branchRef := branch.Name
 
-	ioReader, _, err := c.clientREST.Repositories.DownloadContents(ctx, branchRepoOwner, branchRepoName, filePath, &github.RepositoryContentGetOptions{
-		Ref: branchRef,
-	})
-
-	if err != nil {
-		return nil, err
+	var branchRef string
+	if useSHA {
+		branchRef = branch.Sha
+	} else {
+		branchRef = branch.Name
 	}
-
-	return io.ReadAll(ioReader)
-}
-
-func (c *GithubClient) DownloadContentsFromCommitSHA(ctx context.Context, filePath string, branch *pbc.Branch) ([]byte, error) {
-	branchRepoOwner := branch.Repo.Owner
-	branchRepoName := branch.Repo.Name
-	branchRef := branch.Sha
 
 	ioReader, _, err := c.clientREST.Repositories.DownloadContents(ctx, branchRepoOwner, branchRepoName, filePath, &github.RepositoryContentGetOptions{
 		Ref: branchRef,

--- a/codehost/github/repositories.go
+++ b/codehost/github/repositories.go
@@ -40,3 +40,19 @@ func (c *GithubClient) DownloadContents(ctx context.Context, filePath string, br
 
 	return io.ReadAll(ioReader)
 }
+
+func (c *GithubClient) DownloadContentsFromCommitSHA(ctx context.Context, filePath string, branch *pbc.Branch) ([]byte, error) {
+	branchRepoOwner := branch.Repo.Owner
+	branchRepoName := branch.Repo.Name
+	branchRef := branch.Sha
+
+	ioReader, _, err := c.clientREST.Repositories.DownloadContents(ctx, branchRepoOwner, branchRepoName, filePath, &github.RepositoryContentGetOptions{
+		Ref: branchRef,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return io.ReadAll(ioReader)
+}

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -335,7 +335,7 @@ func loadExtension(ctx context.Context, githubClient *gh.GithubClient, extension
 		return nil, "", err
 	}
 
-	content, err := githubClient.DownloadContents(ctx, filePath, branch)
+	content, err := githubClient.DownloadContentsFromBranchName(ctx, filePath, branch)
 	if err != nil {
 		if responseErr, ok := err.(*github.ErrorResponse); ok && responseErr.Response.StatusCode == 404 {
 			return nil, "", errors.New("we encountered an error while processing the 'extends' property in your Reviewpad configuration. This problem may be due to an incorrect URL or unauthenticated access. Please ensure that you have Reviewpad GitHub App installed in all repositories you are trying to extend from and that the file URL is correct. If you still encounter this error, please reach out to us at #help on https://reviewpad.com/discord for additional support.")

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -335,7 +335,7 @@ func loadExtension(ctx context.Context, githubClient *gh.GithubClient, extension
 		return nil, "", err
 	}
 
-	content, err := githubClient.DownloadContents(ctx, filePath, branch, gh.DownloadContentsOptions{
+	content, err := githubClient.DownloadContents(ctx, filePath, branch, &gh.DownloadContentsOptions{
 		Method: gh.DownloadMethodBranchName,
 	})
 	if err != nil {

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -335,7 +335,9 @@ func loadExtension(ctx context.Context, githubClient *gh.GithubClient, extension
 		return nil, "", err
 	}
 
-	content, err := githubClient.DownloadContents(ctx, filePath, branch, false)
+	content, err := githubClient.DownloadContents(ctx, filePath, branch, gh.DownloadContentsOptions{
+		Method: gh.DownloadMethodBranchName,
+	})
 	if err != nil {
 		if responseErr, ok := err.(*github.ErrorResponse); ok && responseErr.Response.StatusCode == 404 {
 			return nil, "", errors.New("we encountered an error while processing the 'extends' property in your Reviewpad configuration. This problem may be due to an incorrect URL or unauthenticated access. Please ensure that you have Reviewpad GitHub App installed in all repositories you are trying to extend from and that the file URL is correct. If you still encounter this error, please reach out to us at #help on https://reviewpad.com/discord for additional support.")

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -335,7 +335,7 @@ func loadExtension(ctx context.Context, githubClient *gh.GithubClient, extension
 		return nil, "", err
 	}
 
-	content, err := githubClient.DownloadContentsFromBranchName(ctx, filePath, branch)
+	content, err := githubClient.DownloadContents(ctx, filePath, branch, false)
 	if err != nil {
 		if responseErr, ok := err.(*github.ErrorResponse); ok && responseErr.Response.StatusCode == 404 {
 			return nil, "", errors.New("we encountered an error while processing the 'extends' property in your Reviewpad configuration. This problem may be due to an incorrect URL or unauthenticated access. Please ensure that you have Reviewpad GitHub App installed in all repositories you are trying to extend from and that the file URL is correct. If you still encounter this error, please reach out to us at #help on https://reviewpad.com/discord for additional support.")

--- a/lang/aladino/parser.go
+++ b/lang/aladino/parser.go
@@ -92,7 +92,7 @@ const AladinoInitialStackSize = 16
 
 /*  start  of  programs  */
 
-var AladinoExca = [...]int8{
+var AladinoExca = [...]int{
 	-1, 1,
 	1, -1,
 	-2, 0,
@@ -102,7 +102,7 @@ const AladinoPrivate = 57344
 
 const AladinoLast = 106
 
-var AladinoAct = [...]int8{
+var AladinoAct = [...]int{
 	53, 52, 22, 2, 20, 21, 18, 19, 55, 44,
 	45, 5, 6, 32, 8, 54, 24, 25, 26, 27,
 	28, 48, 46, 34, 31, 7, 11, 12, 23, 17,
@@ -116,7 +116,7 @@ var AladinoAct = [...]int8{
 	0, 0, 0, 13, 15, 16,
 }
 
-var AladinoPact = [...]int16{
+var AladinoPact = [...]int{
 	7, -1000, 75, 7, 7, -1000, -1000, -1000, -1000, 7,
 	22, -1000, -1000, 7, 7, 7, 7, 7, -1000, 21,
 	15, -16, 46, -3, 28, 81, -1000, -1000, -1000, -1000,
@@ -125,25 +125,25 @@ var AladinoPact = [...]int16{
 	42, -1000, -12, -23, 67, 67, -1000, -1000,
 }
 
-var AladinoPgo = [...]int8{
+var AladinoPgo = [...]int{
 	0, 2, 5, 4, 0, 1, 30,
 }
 
-var AladinoR1 = [...]int8{
+var AladinoR1 = [...]int{
 	0, 6, 1, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 4,
 	4, 4, 4, 4, 5, 5, 3, 3, 3, 2,
 	2, 2,
 }
 
-var AladinoR2 = [...]int8{
+var AladinoR2 = [...]int{
 	0, 1, 2, 3, 3, 3, 3, 3, 3, 1,
 	1, 1, 1, 3, 2, 1, 1, 5, 5, 1,
 	1, 1, 3, 5, 3, 1, 5, 3, 0, 3,
 	1, 0,
 }
 
-var AladinoChk = [...]int16{
+var AladinoChk = [...]int{
 	-1000, -6, -1, 25, 26, 4, 5, 18, 7, 28,
 	30, 19, 20, 22, 21, 23, 24, 8, -1, -1,
 	-3, -2, -1, 6, -1, -1, -1, -1, -1, 27,
@@ -152,7 +152,7 @@ var AladinoChk = [...]int16{
 	-1, -4, -5, -4, 27, 31, -4, -5,
 }
 
-var AladinoDef = [...]int8{
+var AladinoDef = [...]int{
 	0, -2, 1, 0, 28, 9, 10, 11, 12, 31,
 	0, 15, 16, 0, 0, 0, 0, 0, 2, 0,
 	0, 0, 30, 14, 3, 4, 5, 6, 7, 8,
@@ -161,7 +161,7 @@ var AladinoDef = [...]int8{
 	0, 22, 0, 25, 0, 0, 23, 24,
 }
 
-var AladinoTok1 = [...]int8{
+var AladinoTok1 = [...]int{
 	1, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -174,13 +174,13 @@ var AladinoTok1 = [...]int8{
 	3, 28, 3, 29,
 }
 
-var AladinoTok2 = [...]int8{
+var AladinoTok2 = [...]int{
 	2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 	12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
 	22, 23, 24, 25,
 }
 
-var AladinoTok3 = [...]int8{
+var AladinoTok3 = [...]int{
 	0,
 }
 
@@ -260,9 +260,9 @@ func AladinoErrorMessage(state, lookAhead int) string {
 	expected := make([]int, 0, 4)
 
 	// Look for shiftable tokens.
-	base := int(AladinoPact[state])
+	base := AladinoPact[state]
 	for tok := TOKSTART; tok-1 < len(AladinoToknames); tok++ {
-		if n := base + tok; n >= 0 && n < AladinoLast && int(AladinoChk[int(AladinoAct[n])]) == tok {
+		if n := base + tok; n >= 0 && n < AladinoLast && AladinoChk[AladinoAct[n]] == tok {
 			if len(expected) == cap(expected) {
 				return res
 			}
@@ -272,13 +272,13 @@ func AladinoErrorMessage(state, lookAhead int) string {
 
 	if AladinoDef[state] == -2 {
 		i := 0
-		for AladinoExca[i] != -1 || int(AladinoExca[i+1]) != state {
+		for AladinoExca[i] != -1 || AladinoExca[i+1] != state {
 			i += 2
 		}
 
 		// Look for tokens that we accept or reduce.
 		for i += 2; AladinoExca[i] >= 0; i += 2 {
-			tok := int(AladinoExca[i])
+			tok := AladinoExca[i]
 			if tok < TOKSTART || AladinoExca[i+1] == 0 {
 				continue
 			}
@@ -309,30 +309,30 @@ func Aladinolex1(lex AladinoLexer, lval *AladinoSymType) (char, token int) {
 	token = 0
 	char = lex.Lex(lval)
 	if char <= 0 {
-		token = int(AladinoTok1[0])
+		token = AladinoTok1[0]
 		goto out
 	}
 	if char < len(AladinoTok1) {
-		token = int(AladinoTok1[char])
+		token = AladinoTok1[char]
 		goto out
 	}
 	if char >= AladinoPrivate {
 		if char < AladinoPrivate+len(AladinoTok2) {
-			token = int(AladinoTok2[char-AladinoPrivate])
+			token = AladinoTok2[char-AladinoPrivate]
 			goto out
 		}
 	}
 	for i := 0; i < len(AladinoTok3); i += 2 {
-		token = int(AladinoTok3[i+0])
+		token = AladinoTok3[i+0]
 		if token == char {
-			token = int(AladinoTok3[i+1])
+			token = AladinoTok3[i+1]
 			goto out
 		}
 	}
 
 out:
 	if token == 0 {
-		token = int(AladinoTok2[1]) /* unknown char */
+		token = AladinoTok2[1] /* unknown char */
 	}
 	if AladinoDebug >= 3 {
 		__yyfmt__.Printf("lex %s(%d)\n", AladinoTokname(token), uint(char))
@@ -387,7 +387,7 @@ Aladinostack:
 	AladinoS[Aladinop].yys = Aladinostate
 
 Aladinonewstate:
-	Aladinon = int(AladinoPact[Aladinostate])
+	Aladinon = AladinoPact[Aladinostate]
 	if Aladinon <= AladinoFlag {
 		goto Aladinodefault /* simple state */
 	}
@@ -398,8 +398,8 @@ Aladinonewstate:
 	if Aladinon < 0 || Aladinon >= AladinoLast {
 		goto Aladinodefault
 	}
-	Aladinon = int(AladinoAct[Aladinon])
-	if int(AladinoChk[Aladinon]) == Aladinotoken { /* valid shift */
+	Aladinon = AladinoAct[Aladinon]
+	if AladinoChk[Aladinon] == Aladinotoken { /* valid shift */
 		Aladinorcvr.char = -1
 		Aladinotoken = -1
 		AladinoVAL = Aladinorcvr.lval
@@ -412,7 +412,7 @@ Aladinonewstate:
 
 Aladinodefault:
 	/* default state action */
-	Aladinon = int(AladinoDef[Aladinostate])
+	Aladinon = AladinoDef[Aladinostate]
 	if Aladinon == -2 {
 		if Aladinorcvr.char < 0 {
 			Aladinorcvr.char, Aladinotoken = Aladinolex1(Aladinolex, &Aladinorcvr.lval)
@@ -421,18 +421,18 @@ Aladinodefault:
 		/* look through exception table */
 		xi := 0
 		for {
-			if AladinoExca[xi+0] == -1 && int(AladinoExca[xi+1]) == Aladinostate {
+			if AladinoExca[xi+0] == -1 && AladinoExca[xi+1] == Aladinostate {
 				break
 			}
 			xi += 2
 		}
 		for xi += 2; ; xi += 2 {
-			Aladinon = int(AladinoExca[xi+0])
+			Aladinon = AladinoExca[xi+0]
 			if Aladinon < 0 || Aladinon == Aladinotoken {
 				break
 			}
 		}
-		Aladinon = int(AladinoExca[xi+1])
+		Aladinon = AladinoExca[xi+1]
 		if Aladinon < 0 {
 			goto ret0
 		}
@@ -454,10 +454,10 @@ Aladinodefault:
 
 			/* find a state where "error" is a legal shift action */
 			for Aladinop >= 0 {
-				Aladinon = int(AladinoPact[AladinoS[Aladinop].yys]) + AladinoErrCode
+				Aladinon = AladinoPact[AladinoS[Aladinop].yys] + AladinoErrCode
 				if Aladinon >= 0 && Aladinon < AladinoLast {
-					Aladinostate = int(AladinoAct[Aladinon]) /* simulate a shift of "error" */
-					if int(AladinoChk[Aladinostate]) == AladinoErrCode {
+					Aladinostate = AladinoAct[Aladinon] /* simulate a shift of "error" */
+					if AladinoChk[Aladinostate] == AladinoErrCode {
 						goto Aladinostack
 					}
 				}
@@ -493,7 +493,7 @@ Aladinodefault:
 	Aladinopt := Aladinop
 	_ = Aladinopt // guard against "declared and not used"
 
-	Aladinop -= int(AladinoR2[Aladinon])
+	Aladinop -= AladinoR2[Aladinon]
 	// Aladinop is now the index of $0. Perform the default action. Iff the
 	// reduced production is ε, $1 is possibly out of range.
 	if Aladinop+1 >= len(AladinoS) {
@@ -504,16 +504,16 @@ Aladinodefault:
 	AladinoVAL = AladinoS[Aladinop+1]
 
 	/* consult goto table to find next state */
-	Aladinon = int(AladinoR1[Aladinon])
-	Aladinog := int(AladinoPgo[Aladinon])
+	Aladinon = AladinoR1[Aladinon]
+	Aladinog := AladinoPgo[Aladinon]
 	Aladinoj := Aladinog + AladinoS[Aladinop].yys + 1
 
 	if Aladinoj >= AladinoLast {
-		Aladinostate = int(AladinoAct[Aladinog])
+		Aladinostate = AladinoAct[Aladinog]
 	} else {
-		Aladinostate = int(AladinoAct[Aladinoj])
-		if int(AladinoChk[Aladinostate]) != -Aladinon {
-			Aladinostate = int(AladinoAct[Aladinog])
+		Aladinostate = AladinoAct[Aladinoj]
+		if AladinoChk[Aladinostate] != -Aladinon {
+			Aladinostate = AladinoAct[Aladinog]
 		}
 	}
 	// dummy call; replaced with literal code

--- a/lang/aladino/parser.go
+++ b/lang/aladino/parser.go
@@ -92,7 +92,7 @@ const AladinoInitialStackSize = 16
 
 /*  start  of  programs  */
 
-var AladinoExca = [...]int{
+var AladinoExca = [...]int8{
 	-1, 1,
 	1, -1,
 	-2, 0,
@@ -102,7 +102,7 @@ const AladinoPrivate = 57344
 
 const AladinoLast = 106
 
-var AladinoAct = [...]int{
+var AladinoAct = [...]int8{
 	53, 52, 22, 2, 20, 21, 18, 19, 55, 44,
 	45, 5, 6, 32, 8, 54, 24, 25, 26, 27,
 	28, 48, 46, 34, 31, 7, 11, 12, 23, 17,
@@ -116,7 +116,7 @@ var AladinoAct = [...]int{
 	0, 0, 0, 13, 15, 16,
 }
 
-var AladinoPact = [...]int{
+var AladinoPact = [...]int16{
 	7, -1000, 75, 7, 7, -1000, -1000, -1000, -1000, 7,
 	22, -1000, -1000, 7, 7, 7, 7, 7, -1000, 21,
 	15, -16, 46, -3, 28, 81, -1000, -1000, -1000, -1000,
@@ -125,25 +125,25 @@ var AladinoPact = [...]int{
 	42, -1000, -12, -23, 67, 67, -1000, -1000,
 }
 
-var AladinoPgo = [...]int{
+var AladinoPgo = [...]int8{
 	0, 2, 5, 4, 0, 1, 30,
 }
 
-var AladinoR1 = [...]int{
+var AladinoR1 = [...]int8{
 	0, 6, 1, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 4,
 	4, 4, 4, 4, 5, 5, 3, 3, 3, 2,
 	2, 2,
 }
 
-var AladinoR2 = [...]int{
+var AladinoR2 = [...]int8{
 	0, 1, 2, 3, 3, 3, 3, 3, 3, 1,
 	1, 1, 1, 3, 2, 1, 1, 5, 5, 1,
 	1, 1, 3, 5, 3, 1, 5, 3, 0, 3,
 	1, 0,
 }
 
-var AladinoChk = [...]int{
+var AladinoChk = [...]int16{
 	-1000, -6, -1, 25, 26, 4, 5, 18, 7, 28,
 	30, 19, 20, 22, 21, 23, 24, 8, -1, -1,
 	-3, -2, -1, 6, -1, -1, -1, -1, -1, 27,
@@ -152,7 +152,7 @@ var AladinoChk = [...]int{
 	-1, -4, -5, -4, 27, 31, -4, -5,
 }
 
-var AladinoDef = [...]int{
+var AladinoDef = [...]int8{
 	0, -2, 1, 0, 28, 9, 10, 11, 12, 31,
 	0, 15, 16, 0, 0, 0, 0, 0, 2, 0,
 	0, 0, 30, 14, 3, 4, 5, 6, 7, 8,
@@ -161,7 +161,7 @@ var AladinoDef = [...]int{
 	0, 22, 0, 25, 0, 0, 23, 24,
 }
 
-var AladinoTok1 = [...]int{
+var AladinoTok1 = [...]int8{
 	1, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -174,13 +174,13 @@ var AladinoTok1 = [...]int{
 	3, 28, 3, 29,
 }
 
-var AladinoTok2 = [...]int{
+var AladinoTok2 = [...]int8{
 	2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 	12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
 	22, 23, 24, 25,
 }
 
-var AladinoTok3 = [...]int{
+var AladinoTok3 = [...]int8{
 	0,
 }
 
@@ -260,9 +260,9 @@ func AladinoErrorMessage(state, lookAhead int) string {
 	expected := make([]int, 0, 4)
 
 	// Look for shiftable tokens.
-	base := AladinoPact[state]
+	base := int(AladinoPact[state])
 	for tok := TOKSTART; tok-1 < len(AladinoToknames); tok++ {
-		if n := base + tok; n >= 0 && n < AladinoLast && AladinoChk[AladinoAct[n]] == tok {
+		if n := base + tok; n >= 0 && n < AladinoLast && int(AladinoChk[int(AladinoAct[n])]) == tok {
 			if len(expected) == cap(expected) {
 				return res
 			}
@@ -272,13 +272,13 @@ func AladinoErrorMessage(state, lookAhead int) string {
 
 	if AladinoDef[state] == -2 {
 		i := 0
-		for AladinoExca[i] != -1 || AladinoExca[i+1] != state {
+		for AladinoExca[i] != -1 || int(AladinoExca[i+1]) != state {
 			i += 2
 		}
 
 		// Look for tokens that we accept or reduce.
 		for i += 2; AladinoExca[i] >= 0; i += 2 {
-			tok := AladinoExca[i]
+			tok := int(AladinoExca[i])
 			if tok < TOKSTART || AladinoExca[i+1] == 0 {
 				continue
 			}
@@ -309,30 +309,30 @@ func Aladinolex1(lex AladinoLexer, lval *AladinoSymType) (char, token int) {
 	token = 0
 	char = lex.Lex(lval)
 	if char <= 0 {
-		token = AladinoTok1[0]
+		token = int(AladinoTok1[0])
 		goto out
 	}
 	if char < len(AladinoTok1) {
-		token = AladinoTok1[char]
+		token = int(AladinoTok1[char])
 		goto out
 	}
 	if char >= AladinoPrivate {
 		if char < AladinoPrivate+len(AladinoTok2) {
-			token = AladinoTok2[char-AladinoPrivate]
+			token = int(AladinoTok2[char-AladinoPrivate])
 			goto out
 		}
 	}
 	for i := 0; i < len(AladinoTok3); i += 2 {
-		token = AladinoTok3[i+0]
+		token = int(AladinoTok3[i+0])
 		if token == char {
-			token = AladinoTok3[i+1]
+			token = int(AladinoTok3[i+1])
 			goto out
 		}
 	}
 
 out:
 	if token == 0 {
-		token = AladinoTok2[1] /* unknown char */
+		token = int(AladinoTok2[1]) /* unknown char */
 	}
 	if AladinoDebug >= 3 {
 		__yyfmt__.Printf("lex %s(%d)\n", AladinoTokname(token), uint(char))
@@ -387,7 +387,7 @@ Aladinostack:
 	AladinoS[Aladinop].yys = Aladinostate
 
 Aladinonewstate:
-	Aladinon = AladinoPact[Aladinostate]
+	Aladinon = int(AladinoPact[Aladinostate])
 	if Aladinon <= AladinoFlag {
 		goto Aladinodefault /* simple state */
 	}
@@ -398,8 +398,8 @@ Aladinonewstate:
 	if Aladinon < 0 || Aladinon >= AladinoLast {
 		goto Aladinodefault
 	}
-	Aladinon = AladinoAct[Aladinon]
-	if AladinoChk[Aladinon] == Aladinotoken { /* valid shift */
+	Aladinon = int(AladinoAct[Aladinon])
+	if int(AladinoChk[Aladinon]) == Aladinotoken { /* valid shift */
 		Aladinorcvr.char = -1
 		Aladinotoken = -1
 		AladinoVAL = Aladinorcvr.lval
@@ -412,7 +412,7 @@ Aladinonewstate:
 
 Aladinodefault:
 	/* default state action */
-	Aladinon = AladinoDef[Aladinostate]
+	Aladinon = int(AladinoDef[Aladinostate])
 	if Aladinon == -2 {
 		if Aladinorcvr.char < 0 {
 			Aladinorcvr.char, Aladinotoken = Aladinolex1(Aladinolex, &Aladinorcvr.lval)
@@ -421,18 +421,18 @@ Aladinodefault:
 		/* look through exception table */
 		xi := 0
 		for {
-			if AladinoExca[xi+0] == -1 && AladinoExca[xi+1] == Aladinostate {
+			if AladinoExca[xi+0] == -1 && int(AladinoExca[xi+1]) == Aladinostate {
 				break
 			}
 			xi += 2
 		}
 		for xi += 2; ; xi += 2 {
-			Aladinon = AladinoExca[xi+0]
+			Aladinon = int(AladinoExca[xi+0])
 			if Aladinon < 0 || Aladinon == Aladinotoken {
 				break
 			}
 		}
-		Aladinon = AladinoExca[xi+1]
+		Aladinon = int(AladinoExca[xi+1])
 		if Aladinon < 0 {
 			goto ret0
 		}
@@ -454,10 +454,10 @@ Aladinodefault:
 
 			/* find a state where "error" is a legal shift action */
 			for Aladinop >= 0 {
-				Aladinon = AladinoPact[AladinoS[Aladinop].yys] + AladinoErrCode
+				Aladinon = int(AladinoPact[AladinoS[Aladinop].yys]) + AladinoErrCode
 				if Aladinon >= 0 && Aladinon < AladinoLast {
-					Aladinostate = AladinoAct[Aladinon] /* simulate a shift of "error" */
-					if AladinoChk[Aladinostate] == AladinoErrCode {
+					Aladinostate = int(AladinoAct[Aladinon]) /* simulate a shift of "error" */
+					if int(AladinoChk[Aladinostate]) == AladinoErrCode {
 						goto Aladinostack
 					}
 				}
@@ -493,7 +493,7 @@ Aladinodefault:
 	Aladinopt := Aladinop
 	_ = Aladinopt // guard against "declared and not used"
 
-	Aladinop -= AladinoR2[Aladinon]
+	Aladinop -= int(AladinoR2[Aladinon])
 	// Aladinop is now the index of $0. Perform the default action. Iff the
 	// reduced production is ε, $1 is possibly out of range.
 	if Aladinop+1 >= len(AladinoS) {
@@ -504,16 +504,16 @@ Aladinodefault:
 	AladinoVAL = AladinoS[Aladinop+1]
 
 	/* consult goto table to find next state */
-	Aladinon = AladinoR1[Aladinon]
-	Aladinog := AladinoPgo[Aladinon]
+	Aladinon = int(AladinoR1[Aladinon])
+	Aladinog := int(AladinoPgo[Aladinon])
 	Aladinoj := Aladinog + AladinoS[Aladinop].yys + 1
 
 	if Aladinoj >= AladinoLast {
-		Aladinostate = AladinoAct[Aladinog]
+		Aladinostate = int(AladinoAct[Aladinog])
 	} else {
-		Aladinostate = AladinoAct[Aladinoj]
-		if AladinoChk[Aladinostate] != -Aladinon {
-			Aladinostate = AladinoAct[Aladinog]
+		Aladinostate = int(AladinoAct[Aladinoj])
+		if int(AladinoChk[Aladinostate]) != -Aladinon {
+			Aladinostate = int(AladinoAct[Aladinog])
 		}
 	}
 	// dummy call; replaced with literal code

--- a/plugins/aladino/semantic/symbols.go
+++ b/plugins/aladino/semantic/symbols.go
@@ -13,6 +13,7 @@ import (
 	"github.com/reviewpad/api/go/entities"
 	api "github.com/reviewpad/api/go/services"
 	"github.com/reviewpad/reviewpad/v4/codehost"
+	"github.com/reviewpad/reviewpad/v4/codehost/github"
 	"github.com/reviewpad/reviewpad/v4/codehost/github/target"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 	plugins_aladino_services "github.com/reviewpad/reviewpad/v4/plugins/aladino/services"
@@ -31,11 +32,15 @@ func GetSymbolsFromPatch(e aladino.Env) (map[string]*entities.Symbols, error) {
 	lastCommit := head.Sha
 
 	for fp, commitFile := range patch {
-		blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, head, true)
+		blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, head, github.DownloadContentsOptions{
+			Method: github.DownloadMethodSHA,
+		})
 		if err != nil {
 			// If fails to download the file from head, then tries to download it from base.
 			// This happens when a file has been removed.
-			blob, err = e.GetGithubClient().DownloadContents(e.GetCtx(), fp, base, true)
+			blob, err = e.GetGithubClient().DownloadContents(e.GetCtx(), fp, base, github.DownloadContentsOptions{
+				Method: github.DownloadMethodSHA,
+			})
 
 			if err != nil {
 				return nil, err
@@ -144,7 +149,9 @@ func joinSymbols(current *entities.Symbols, new *entities.Symbols) {
 func GetSymbolsFromFileInBranch(e aladino.Env, commitFile *codehost.File, branch *pbc.Branch) (*entities.Symbols, string, error) {
 	fp := commitFile.Repr.GetFilename()
 
-	blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, branch, true)
+	blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, branch, github.DownloadContentsOptions{
+		Method: github.DownloadMethodSHA,
+	})
 	if err != nil {
 		return nil, "", err
 	}

--- a/plugins/aladino/semantic/symbols.go
+++ b/plugins/aladino/semantic/symbols.go
@@ -32,13 +32,13 @@ func GetSymbolsFromPatch(e aladino.Env) (map[string]*entities.Symbols, error) {
 	lastCommit := head.Sha
 
 	for fp, commitFile := range patch {
-		blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, head, github.DownloadContentsOptions{
+		blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, head, &github.DownloadContentsOptions{
 			Method: github.DownloadMethodSHA,
 		})
 		if err != nil {
 			// If fails to download the file from head, then tries to download it from base.
 			// This happens when a file has been removed.
-			blob, err = e.GetGithubClient().DownloadContents(e.GetCtx(), fp, base, github.DownloadContentsOptions{
+			blob, err = e.GetGithubClient().DownloadContents(e.GetCtx(), fp, base, &github.DownloadContentsOptions{
 				Method: github.DownloadMethodSHA,
 			})
 
@@ -149,7 +149,7 @@ func joinSymbols(current *entities.Symbols, new *entities.Symbols) {
 func GetSymbolsFromFileInBranch(e aladino.Env, commitFile *codehost.File, branch *pbc.Branch) (*entities.Symbols, string, error) {
 	fp := commitFile.Repr.GetFilename()
 
-	blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, branch, github.DownloadContentsOptions{
+	blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, branch, &github.DownloadContentsOptions{
 		Method: github.DownloadMethodSHA,
 	})
 	if err != nil {

--- a/plugins/aladino/semantic/symbols.go
+++ b/plugins/aladino/semantic/symbols.go
@@ -31,11 +31,11 @@ func GetSymbolsFromPatch(e aladino.Env) (map[string]*entities.Symbols, error) {
 	lastCommit := head.Sha
 
 	for fp, commitFile := range patch {
-		blob, err := e.GetGithubClient().DownloadContentsFromBranchName(e.GetCtx(), fp, head)
+		blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, head, true)
 		if err != nil {
 			// If fails to download the file from head, then tries to download it from base.
 			// This happens when a file has been removed.
-			blob, err = e.GetGithubClient().DownloadContentsFromBranchName(e.GetCtx(), fp, base)
+			blob, err = e.GetGithubClient().DownloadContents(e.GetCtx(), fp, base, true)
 
 			if err != nil {
 				return nil, err
@@ -144,7 +144,7 @@ func joinSymbols(current *entities.Symbols, new *entities.Symbols) {
 func GetSymbolsFromFileInBranch(e aladino.Env, commitFile *codehost.File, branch *pbc.Branch) (*entities.Symbols, string, error) {
 	fp := commitFile.Repr.GetFilename()
 
-	blob, err := e.GetGithubClient().DownloadContentsFromBranchName(e.GetCtx(), fp, branch)
+	blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, branch, true)
 	if err != nil {
 		return nil, "", err
 	}

--- a/plugins/aladino/semantic/symbols.go
+++ b/plugins/aladino/semantic/symbols.go
@@ -31,11 +31,11 @@ func GetSymbolsFromPatch(e aladino.Env) (map[string]*entities.Symbols, error) {
 	lastCommit := head.Sha
 
 	for fp, commitFile := range patch {
-		blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, head)
+		blob, err := e.GetGithubClient().DownloadContentsFromBranchName(e.GetCtx(), fp, head)
 		if err != nil {
 			// If fails to download the file from head, then tries to download it from base.
 			// This happens when a file has been removed.
-			blob, err = e.GetGithubClient().DownloadContents(e.GetCtx(), fp, base)
+			blob, err = e.GetGithubClient().DownloadContentsFromBranchName(e.GetCtx(), fp, base)
 
 			if err != nil {
 				return nil, err
@@ -144,7 +144,7 @@ func joinSymbols(current *entities.Symbols, new *entities.Symbols) {
 func GetSymbolsFromFileInBranch(e aladino.Env, commitFile *codehost.File, branch *pbc.Branch) (*entities.Symbols, string, error) {
 	fp := commitFile.Repr.GetFilename()
 
-	blob, err := e.GetGithubClient().DownloadContents(e.GetCtx(), fp, branch)
+	blob, err := e.GetGithubClient().DownloadContentsFromBranchName(e.GetCtx(), fp, branch)
 	if err != nil {
 		return nil, "", err
 	}

--- a/utils/file.go
+++ b/utils/file.go
@@ -37,7 +37,7 @@ func FileExt(fp string) string {
 // Otherwise, we download the pull request files and check the filePath exists in them.
 func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, filePath string, pullRequest *pbc.PullRequest) (bool, error) {
 	if pullRequest.ChangedFilesCount > pullRequestFileLimit {
-		rawHeadFile, err := githubClient.DownloadContents(ctx, filePath, pullRequest.Head, github.DownloadContentsOptions{
+		rawHeadFile, err := githubClient.DownloadContents(ctx, filePath, pullRequest.Head, &github.DownloadContentsOptions{
 			Method: github.DownloadMethodSHA,
 		})
 		if err != nil {
@@ -47,7 +47,7 @@ func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, fi
 			return false, err
 		}
 
-		rawBaseFile, err := githubClient.DownloadContents(ctx, filePath, pullRequest.Base, github.DownloadContentsOptions{
+		rawBaseFile, err := githubClient.DownloadContents(ctx, filePath, pullRequest.Base, &github.DownloadContentsOptions{
 			Method: github.DownloadMethodSHA,
 		})
 		if err != nil {
@@ -84,7 +84,7 @@ func DownloadReviewpadFileFromGitHub(
 	githubClient *gh.GithubClient,
 	filePath string,
 	branch *pbc.Branch,
-	options github.DownloadContentsOptions,
+	options *github.DownloadContentsOptions,
 ) (*bytes.Buffer, error) {
 	reviewpadFileContent, err := githubClient.DownloadContents(ctx, filePath, branch, options)
 	if err != nil {

--- a/utils/file.go
+++ b/utils/file.go
@@ -36,7 +36,7 @@ func FileExt(fp string) string {
 // Otherwise, we download the pull request files and check the filePath exists in them.
 func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, filePath string, pullRequest *pbc.PullRequest) (bool, error) {
 	if pullRequest.ChangedFilesCount > pullRequestFileLimit {
-		rawHeadFile, err := githubClient.DownloadContents(ctx, filePath, pullRequest.Head)
+		rawHeadFile, err := githubClient.DownloadContentsFromBranchName(ctx, filePath, pullRequest.Head)
 		if err != nil {
 			if strings.HasPrefix(err.Error(), "no file named") {
 				return true, nil
@@ -44,7 +44,7 @@ func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, fi
 			return false, err
 		}
 
-		rawBaseFile, err := githubClient.DownloadContents(ctx, filePath, pullRequest.Base)
+		rawBaseFile, err := githubClient.DownloadContentsFromCommitSHA(ctx, filePath, pullRequest.Base)
 		if err != nil {
 			if strings.HasPrefix(err.Error(), "no file named") {
 				return true, nil
@@ -73,8 +73,8 @@ func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, fi
 	return false, nil
 }
 
-func DownloadReviewpadFileFromGitHub(ctx context.Context, logger *logrus.Entry, githubClient *gh.GithubClient, filePath string, branch *pbc.Branch) (*bytes.Buffer, error) {
-	reviewpadFileContent, err := githubClient.DownloadContents(ctx, filePath, branch)
+func DownloadReviewpadFileFromGitHubThroughBranchName(ctx context.Context, logger *logrus.Entry, githubClient *gh.GithubClient, filePath string, branch *pbc.Branch) (*bytes.Buffer, error) {
+	reviewpadFileContent, err := githubClient.DownloadContentsFromBranchName(ctx, filePath, branch)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/file.go
+++ b/utils/file.go
@@ -36,7 +36,7 @@ func FileExt(fp string) string {
 // Otherwise, we download the pull request files and check the filePath exists in them.
 func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, filePath string, pullRequest *pbc.PullRequest) (bool, error) {
 	if pullRequest.ChangedFilesCount > pullRequestFileLimit {
-		rawHeadFile, err := githubClient.DownloadContentsFromCommitSHA(ctx, filePath, pullRequest.Head)
+		rawHeadFile, err := githubClient.DownloadContents(ctx, filePath, pullRequest.Head, true)
 		if err != nil {
 			if strings.HasPrefix(err.Error(), "no file named") {
 				return true, nil
@@ -44,7 +44,7 @@ func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, fi
 			return false, err
 		}
 
-		rawBaseFile, err := githubClient.DownloadContentsFromCommitSHA(ctx, filePath, pullRequest.Base)
+		rawBaseFile, err := githubClient.DownloadContents(ctx, filePath, pullRequest.Base, true)
 		if err != nil {
 			if strings.HasPrefix(err.Error(), "no file named") {
 				return true, nil
@@ -73,17 +73,8 @@ func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, fi
 	return false, nil
 }
 
-func DownloadReviewpadFileFromGitHubThroughBranchName(ctx context.Context, logger *logrus.Entry, githubClient *gh.GithubClient, filePath string, branch *pbc.Branch) (*bytes.Buffer, error) {
-	reviewpadFileContent, err := githubClient.DownloadContentsFromBranchName(ctx, filePath, branch)
-	if err != nil {
-		return nil, err
-	}
-
-	return bytes.NewBuffer(reviewpadFileContent), nil
-}
-
-func DownloadReviewpadFileFromGitHubThroughCommitSHA(ctx context.Context, logger *logrus.Entry, githubClient *gh.GithubClient, filePath string, branch *pbc.Branch) (*bytes.Buffer, error) {
-	reviewpadFileContent, err := githubClient.DownloadContentsFromCommitSHA(ctx, filePath, branch)
+func DownloadReviewpadFileFromGitHub(ctx context.Context, logger *logrus.Entry, githubClient *gh.GithubClient, filePath string, branch *pbc.Branch, useSHA bool) (*bytes.Buffer, error) {
+	reviewpadFileContent, err := githubClient.DownloadContents(ctx, filePath, branch, useSHA)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/file.go
+++ b/utils/file.go
@@ -81,3 +81,12 @@ func DownloadReviewpadFileFromGitHub(ctx context.Context, logger *logrus.Entry, 
 
 	return bytes.NewBuffer(reviewpadFileContent), nil
 }
+
+func DownloadReviewpadFileFromGitHubThroughCommitSHA(ctx context.Context, logger *logrus.Entry, githubClient *gh.GithubClient, filePath string, branch *pbc.Branch) (*bytes.Buffer, error) {
+	reviewpadFileContent, err := githubClient.DownloadContentsFromCommitSHA(ctx, filePath, branch)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes.NewBuffer(reviewpadFileContent), nil
+}

--- a/utils/file.go
+++ b/utils/file.go
@@ -36,7 +36,7 @@ func FileExt(fp string) string {
 // Otherwise, we download the pull request files and check the filePath exists in them.
 func ReviewpadFileChanged(ctx context.Context, githubClient *gh.GithubClient, filePath string, pullRequest *pbc.PullRequest) (bool, error) {
 	if pullRequest.ChangedFilesCount > pullRequestFileLimit {
-		rawHeadFile, err := githubClient.DownloadContentsFromBranchName(ctx, filePath, pullRequest.Head)
+		rawHeadFile, err := githubClient.DownloadContentsFromCommitSHA(ctx, filePath, pullRequest.Head)
 		if err != nil {
 			if strings.HasPrefix(err.Error(), "no file named") {
 				return true, nil


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 May 23 13:03 UTC
This pull request adds a new DownloadMethod enum to the GithubClient struct, along with a DownloadContentsOptions struct for more flexibility in downloading files with either the branch name or SHA. It also updates several functions to use this new functionality, including loadExtension, GetSymbolsFromPatch, GetSymbolsFromFileInBranch, ReviewpadFileChanged, and DownloadReviewpadFileFromGitHub.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at be76732</samp>

This pull request improves the functionality and readability of the code that downloads files from GitHub for reviewpad. It adds a new method to `GithubClient` to download files by commit SHA, renames another method to specify its parameter, and updates the usages of these methods in various files. It also enhances the detection of changes in reviewpad configuration files across pull requests.

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before the merge

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at be76732</samp>

*  Rename `DownloadContents` method to `DownloadContentsFromBranchName` in `GithubClient` struct to clarify parameter ([link](https://github.com/reviewpad/reviewpad/pull/920/files?diff=unified&w=0#diff-f9e687e63b05187bfdfd229d9b91ed75493fc738345d364140579ce582981cf6L28-R28), [link](https://github.com/reviewpad/reviewpad/pull/920/files?diff=unified&w=0#diff-31e0d9a2beee99e1ca91227b4cf55fc6b934b0d3bfef25a56fdf5fbf28879c92L338-R338), [link](https://github.com/reviewpad/reviewpad/pull/920/files?diff=unified&w=0#diff-25cb8cf0c0338cea0ba7a047c455dc21eea362dcbc6b2a7f970168bd44d198c0L34-R38), [link](https://github.com/reviewpad/reviewpad/pull/920/files?diff=unified&w=0#diff-25cb8cf0c0338cea0ba7a047c455dc21eea362dcbc6b2a7f970168bd44d198c0L147-R147), [link](https://github.com/reviewpad/reviewpad/pull/920/files?diff=unified&w=0#diff-58662a9d9d3d78f19267179291bb312908ef0b867fd88b523b9d950161e5ceb5L39-R39))
* Add `DownloadContentsFromCommitSHA` method to `GithubClient` struct to download file contents from a specific commit ([link](https://github.com/reviewpad/reviewpad/pull/920/files?diff=unified&w=0#diff-f9e687e63b05187bfdfd229d9b91ed75493fc738345d364140579ce582981cf6R43-R58), [link](https://github.com/reviewpad/reviewpad/pull/920/files?diff=unified&w=0#diff-58662a9d9d3d78f19267179291bb312908ef0b867fd88b523b9d950161e5ceb5L47-R47))
* Rename `DownloadReviewpadFileFromGitHub` function to `DownloadReviewpadFileFromGitHubThroughBranchName` in `utils/file.go` to clarify parameter ([link](https://github.com/reviewpad/reviewpad/pull/920/files?diff=unified&w=0#diff-58662a9d9d3d78f19267179291bb312908ef0b867fd88b523b9d950161e5ceb5L76-R77))
* Add `DownloadReviewpadFileFromGitHubThroughCommitSHA` function in `utils/file.go` to download reviewpad configuration file from a specific commit ([link](https://github.com/reviewpad/reviewpad/pull/920/files?diff=unified&w=0#diff-58662a9d9d3d78f19267179291bb312908ef0b867fd88b523b9d950161e5ceb5R84-R92))
