### PR TITLE
fix: filter reviewpad reviews

### DIFF
--- a/plugins/aladino/actions/assignCodeAuthorReviewers.go
+++ b/plugins/aladino/actions/assignCodeAuthorReviewers.go
@@ -53,13 +53,22 @@ func assignCodeAuthorReviewersCode(env aladino.Env, args []lang.Value) error {
 
 	// since github removes users from the requested reviewers list
 	// after they've submitted a review, we need to check here that
-	// there are no there are no reviews submitted as well
+	// there are no reviews submitted as well
 	reviews, err := pr.GetReviews()
 	if err != nil {
 		return fmt.Errorf("error getting reviews: %s", err)
 	}
 
-	if len(reviews) > 0 {
+	filteredReviews := make([]*codehost.Review, 0)
+	for _, review := range reviews {
+		if strings.HasPrefix(review.User.Login, "reviewpad") {
+			continue
+		}
+
+		filteredReviews = append(filteredReviews, review)
+	}
+
+	if len(filteredReviews) > 0 {
 		return nil
 	}
 


### PR DESCRIPTION
## Description

Closes #913.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 May 23 10:33 UTC
This pull request fixes an issue where reviewpad reviews were not being filtered out, causing false positives in the pull request review process. The fix adds a filter to remove any review from a user whose login starts with "reviewpad".
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fb3178</samp>

Improve aladino plugin by filtering out bot reviews. This affects the `assignCodeAuthorReviewers` action and the file `plugins/aladino/actions/assignCodeAuthorReviewers.go`.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require a code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0fb3178</samp>

*  Filter out bot reviews from pull request reviews ([link](https://github.com/reviewpad/reviewpad/pull/921/files?diff=unified&w=0#diff-acd9551bb4313dcc36ef244051ab652050f97e37e9a907c5bfbccc9f171a90d0L62-R71))
*  Assign code author reviewers based on code ownership rules and existing reviews ([link](https://github.com/reviewpad/reviewpad/pull/921/files?diff=unified&w=0#diff-acd9551bb4313dcc36ef244051ab652050f97e37e9a907c5bfbccc9f171a90d0L56-R56))
