### PR TITLE
fix: multiple pipelines execution

### DIFF
--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -349,6 +349,25 @@ func TestExecConfigurationFile(t *testing.T) {
 			targetEntity:   engine.DefaultMockTargetEntity,
 			wantExitStatus: engine.ExitStatusSuccess,
 		},
+		"reviewpad with pipelines": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_pipelines.yml",
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(`$addLabel("pipeline with no trigger")`),
+					engine.BuildStatement(`$addLabel("pipeline with trigger")`),
+					engine.BuildStatement(`$addLabel("pipeline with single stage and single action")`),
+					engine.BuildStatement(`$addLabel("pipeline with single stage and multiple actions - 1/2")`),
+					engine.BuildStatement(`$addLabel("pipeline with single stage and multiple actions - 2/2")`),
+					engine.BuildStatement(`$addLabel("pipeline with multiple stages - stage 2")`),
+					engine.BuildStatement(`$addLabel("pipeline with multiple stages and multiple actions - stage 2 - 1/2")`),
+					engine.BuildStatement(`$addLabel("pipeline with multiple stages and multiple actions - stage 2 - 2/2")`),
+					engine.BuildStatement(`$addLabel("pipeline with single stage and concise actions")`),
+					engine.BuildStatement(`$addLabel("pipeline with multiple stages and concise actions - stage 2")`),
+				},
+			),
+			targetEntity:   engine.DefaultMockTargetEntity,
+			wantExitStatus: engine.ExitStatusSuccess,
+		},
 	}
 
 	codehostClient := aladino.GetDefaultCodeHostClient(t, aladino.GetDefaultPullRequestDetails(), aladino.GetDefaultPullRequestFileList(), nil, nil)

--- a/engine/testdata/exec/reviewpad_with_pipelines.yml
+++ b/engine/testdata/exec/reviewpad_with_pipelines.yml
@@ -1,0 +1,65 @@
+# Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+pipelines:
+  - name: pipeline with no trigger
+    stages:
+      - actions:
+          - $addLabel("pipeline with no trigger")
+
+  - name: pipeline with trigger
+    trigger: 1 == 1
+    stages:
+      - actions:
+          - $addLabel("pipeline with trigger")
+
+  - name: pipeline with failing trigger
+    trigger: 1 == 2
+    stages:
+      - actions:
+          - $addLabel("pipeline with failing trigger")
+
+  - name: pipeline with single stage and single action
+    trigger: 1 == 1
+    stages:
+      - actions:
+          - $addLabel("pipeline with single stage and single action")
+
+  - name: pipeline with single stage and multiple actions
+    trigger: 1 == 1
+    stages:
+      - actions:
+          - $addLabel("pipeline with single stage and multiple actions - 1/2")
+          - $addLabel("pipeline with single stage and multiple actions - 2/2")
+
+  - name: pipeline with multiple stages
+    trigger: 1 == 1
+    stages:
+      - actions:
+          - $addLabel("pipeline with multiple stages - stage 1")
+        until: 1 == 1
+      - actions:
+          - $addLabel("pipeline with multiple stages - stage 2")
+
+  - name: pipeline with multiple stages and multiple actions
+    trigger: 1 == 1
+    stages:
+      - actions:
+          - $addLabel("pipeline with multiple stages and multiple actions - stage 1")
+        until: 1 == 1
+      - actions:
+          - $addLabel("pipeline with multiple stages and multiple actions - stage 2 - 1/2")
+          - $addLabel("pipeline with multiple stages and multiple actions - stage 2 - 2/2")
+
+  - name: pipeline with single stage and concise actions
+    trigger: 1 == 1
+    stages:
+      - actions: $addLabel("pipeline with single stage and concise actions")
+
+  - name: pipeline with multiple stages and concise actions
+    trigger: 1 == 1
+    stages:
+      - actions: $addLabel("pipeline with multiple stages and concise actions - stage 1")
+        until: 1 == 1
+      - actions: $addLabel("pipeline with multiple stages and concise actions - stage 2")

--- a/lang/aladino/parser.go
+++ b/lang/aladino/parser.go
@@ -92,7 +92,7 @@ const AladinoInitialStackSize = 16
 
 /*  start  of  programs  */
 
-var AladinoExca = [...]int8{
+var AladinoExca = [...]int{
 	-1, 1,
 	1, -1,
 	-2, 0,
@@ -102,7 +102,7 @@ const AladinoPrivate = 57344
 
 const AladinoLast = 106
 
-var AladinoAct = [...]int8{
+var AladinoAct = [...]int{
 	53, 52, 22, 2, 20, 21, 18, 19, 55, 44,
 	45, 5, 6, 32, 8, 54, 24, 25, 26, 27,
 	28, 48, 46, 34, 31, 7, 11, 12, 23, 17,
@@ -116,7 +116,7 @@ var AladinoAct = [...]int8{
 	0, 0, 0, 13, 15, 16,
 }
 
-var AladinoPact = [...]int16{
+var AladinoPact = [...]int{
 	7, -1000, 75, 7, 7, -1000, -1000, -1000, -1000, 7,
 	22, -1000, -1000, 7, 7, 7, 7, 7, -1000, 21,
 	15, -16, 46, -3, 28, 81, -1000, -1000, -1000, -1000,
@@ -125,25 +125,25 @@ var AladinoPact = [...]int16{
 	42, -1000, -12, -23, 67, 67, -1000, -1000,
 }
 
-var AladinoPgo = [...]int8{
+var AladinoPgo = [...]int{
 	0, 2, 5, 4, 0, 1, 30,
 }
 
-var AladinoR1 = [...]int8{
+var AladinoR1 = [...]int{
 	0, 6, 1, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 4,
 	4, 4, 4, 4, 5, 5, 3, 3, 3, 2,
 	2, 2,
 }
 
-var AladinoR2 = [...]int8{
+var AladinoR2 = [...]int{
 	0, 1, 2, 3, 3, 3, 3, 3, 3, 1,
 	1, 1, 1, 3, 2, 1, 1, 5, 5, 1,
 	1, 1, 3, 5, 3, 1, 5, 3, 0, 3,
 	1, 0,
 }
 
-var AladinoChk = [...]int16{
+var AladinoChk = [...]int{
 	-1000, -6, -1, 25, 26, 4, 5, 18, 7, 28,
 	30, 19, 20, 22, 21, 23, 24, 8, -1, -1,
 	-3, -2, -1, 6, -1, -1, -1, -1, -1, 27,
@@ -152,7 +152,7 @@ var AladinoChk = [...]int16{
 	-1, -4, -5, -4, 27, 31, -4, -5,
 }
 
-var AladinoDef = [...]int8{
+var AladinoDef = [...]int{
 	0, -2, 1, 0, 28, 9, 10, 11, 12, 31,
 	0, 15, 16, 0, 0, 0, 0, 0, 2, 0,
 	0, 0, 30, 14, 3, 4, 5, 6, 7, 8,
@@ -161,7 +161,7 @@ var AladinoDef = [...]int8{
 	0, 22, 0, 25, 0, 0, 23, 24,
 }
 
-var AladinoTok1 = [...]int8{
+var AladinoTok1 = [...]int{
 	1, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -174,13 +174,13 @@ var AladinoTok1 = [...]int8{
 	3, 28, 3, 29,
 }
 
-var AladinoTok2 = [...]int8{
+var AladinoTok2 = [...]int{
 	2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 	12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
 	22, 23, 24, 25,
 }
 
-var AladinoTok3 = [...]int8{
+var AladinoTok3 = [...]int{
 	0,
 }
 
@@ -260,9 +260,9 @@ func AladinoErrorMessage(state, lookAhead int) string {
 	expected := make([]int, 0, 4)
 
 	// Look for shiftable tokens.
-	base := int(AladinoPact[state])
+	base := AladinoPact[state]
 	for tok := TOKSTART; tok-1 < len(AladinoToknames); tok++ {
-		if n := base + tok; n >= 0 && n < AladinoLast && int(AladinoChk[int(AladinoAct[n])]) == tok {
+		if n := base + tok; n >= 0 && n < AladinoLast && AladinoChk[AladinoAct[n]] == tok {
 			if len(expected) == cap(expected) {
 				return res
 			}
@@ -272,13 +272,13 @@ func AladinoErrorMessage(state, lookAhead int) string {
 
 	if AladinoDef[state] == -2 {
 		i := 0
-		for AladinoExca[i] != -1 || int(AladinoExca[i+1]) != state {
+		for AladinoExca[i] != -1 || AladinoExca[i+1] != state {
 			i += 2
 		}
 
 		// Look for tokens that we accept or reduce.
 		for i += 2; AladinoExca[i] >= 0; i += 2 {
-			tok := int(AladinoExca[i])
+			tok := AladinoExca[i]
 			if tok < TOKSTART || AladinoExca[i+1] == 0 {
 				continue
 			}
@@ -309,30 +309,30 @@ func Aladinolex1(lex AladinoLexer, lval *AladinoSymType) (char, token int) {
 	token = 0
 	char = lex.Lex(lval)
 	if char <= 0 {
-		token = int(AladinoTok1[0])
+		token = AladinoTok1[0]
 		goto out
 	}
 	if char < len(AladinoTok1) {
-		token = int(AladinoTok1[char])
+		token = AladinoTok1[char]
 		goto out
 	}
 	if char >= AladinoPrivate {
 		if char < AladinoPrivate+len(AladinoTok2) {
-			token = int(AladinoTok2[char-AladinoPrivate])
+			token = AladinoTok2[char-AladinoPrivate]
 			goto out
 		}
 	}
 	for i := 0; i < len(AladinoTok3); i += 2 {
-		token = int(AladinoTok3[i+0])
+		token = AladinoTok3[i+0]
 		if token == char {
-			token = int(AladinoTok3[i+1])
+			token = AladinoTok3[i+1]
 			goto out
 		}
 	}
 
 out:
 	if token == 0 {
-		token = int(AladinoTok2[1]) /* unknown char */
+		token = AladinoTok2[1] /* unknown char */
 	}
 	if AladinoDebug >= 3 {
 		__yyfmt__.Printf("lex %s(%d)\n", AladinoTokname(token), uint(char))
@@ -387,7 +387,7 @@ Aladinostack:
 	AladinoS[Aladinop].yys = Aladinostate
 
 Aladinonewstate:
-	Aladinon = int(AladinoPact[Aladinostate])
+	Aladinon = AladinoPact[Aladinostate]
 	if Aladinon <= AladinoFlag {
 		goto Aladinodefault /* simple state */
 	}
@@ -398,8 +398,8 @@ Aladinonewstate:
 	if Aladinon < 0 || Aladinon >= AladinoLast {
 		goto Aladinodefault
 	}
-	Aladinon = int(AladinoAct[Aladinon])
-	if int(AladinoChk[Aladinon]) == Aladinotoken { /* valid shift */
+	Aladinon = AladinoAct[Aladinon]
+	if AladinoChk[Aladinon] == Aladinotoken { /* valid shift */
 		Aladinorcvr.char = -1
 		Aladinotoken = -1
 		AladinoVAL = Aladinorcvr.lval
@@ -412,7 +412,7 @@ Aladinonewstate:
 
 Aladinodefault:
 	/* default state action */
-	Aladinon = int(AladinoDef[Aladinostate])
+	Aladinon = AladinoDef[Aladinostate]
 	if Aladinon == -2 {
 		if Aladinorcvr.char < 0 {
 			Aladinorcvr.char, Aladinotoken = Aladinolex1(Aladinolex, &Aladinorcvr.lval)
@@ -421,18 +421,18 @@ Aladinodefault:
 		/* look through exception table */
 		xi := 0
 		for {
-			if AladinoExca[xi+0] == -1 && int(AladinoExca[xi+1]) == Aladinostate {
+			if AladinoExca[xi+0] == -1 && AladinoExca[xi+1] == Aladinostate {
 				break
 			}
 			xi += 2
 		}
 		for xi += 2; ; xi += 2 {
-			Aladinon = int(AladinoExca[xi+0])
+			Aladinon = AladinoExca[xi+0]
 			if Aladinon < 0 || Aladinon == Aladinotoken {
 				break
 			}
 		}
-		Aladinon = int(AladinoExca[xi+1])
+		Aladinon = AladinoExca[xi+1]
 		if Aladinon < 0 {
 			goto ret0
 		}
@@ -454,10 +454,10 @@ Aladinodefault:
 
 			/* find a state where "error" is a legal shift action */
 			for Aladinop >= 0 {
-				Aladinon = int(AladinoPact[AladinoS[Aladinop].yys]) + AladinoErrCode
+				Aladinon = AladinoPact[AladinoS[Aladinop].yys] + AladinoErrCode
 				if Aladinon >= 0 && Aladinon < AladinoLast {
-					Aladinostate = int(AladinoAct[Aladinon]) /* simulate a shift of "error" */
-					if int(AladinoChk[Aladinostate]) == AladinoErrCode {
+					Aladinostate = AladinoAct[Aladinon] /* simulate a shift of "error" */
+					if AladinoChk[Aladinostate] == AladinoErrCode {
 						goto Aladinostack
 					}
 				}
@@ -493,7 +493,7 @@ Aladinodefault:
 	Aladinopt := Aladinop
 	_ = Aladinopt // guard against "declared and not used"
 
-	Aladinop -= int(AladinoR2[Aladinon])
+	Aladinop -= AladinoR2[Aladinon]
 	// Aladinop is now the index of $0. Perform the default action. Iff the
 	// reduced production is ε, $1 is possibly out of range.
 	if Aladinop+1 >= len(AladinoS) {
@@ -504,16 +504,16 @@ Aladinodefault:
 	AladinoVAL = AladinoS[Aladinop+1]
 
 	/* consult goto table to find next state */
-	Aladinon = int(AladinoR1[Aladinon])
-	Aladinog := int(AladinoPgo[Aladinon])
+	Aladinon = AladinoR1[Aladinon]
+	Aladinog := AladinoPgo[Aladinon]
 	Aladinoj := Aladinog + AladinoS[Aladinop].yys + 1
 
 	if Aladinoj >= AladinoLast {
-		Aladinostate = int(AladinoAct[Aladinog])
+		Aladinostate = AladinoAct[Aladinog]
 	} else {
-		Aladinostate = int(AladinoAct[Aladinoj])
-		if int(AladinoChk[Aladinostate]) != -Aladinon {
-			Aladinostate = int(AladinoAct[Aladinog])
+		Aladinostate = AladinoAct[Aladinoj]
+		if AladinoChk[Aladinostate] != -Aladinon {
+			Aladinostate = AladinoAct[Aladinog]
 		}
 	}
 	// dummy call; replaced with literal code


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 May 23 13:48 UTC
This pull request contains changes to multiple files. It adds new YAML pipelines for testing with various triggers and stages, modifies the "ExecConfigurationFile" function in "engine/exec.go" to check for activation and "until" conditions, and adds a new test case for the "exec" package with expected output.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at abf01e3</samp>

This pull request enhances the pipeline execution feature in `reviewpad`, by improving the logging, performance, and testing of the `./engine/exec.go` module. It adds log messages, refactors the stage execution logic, and introduces a new test case and test data file.

## Related to

#924 

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at abf01e3</samp>

* Add a test case for the exec configuration file function ([link](https://github.com/reviewpad/reviewpad/pull/926/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2R302-R320))
  - Use a test data file with different pipeline configurations (`engine/testdata/exec/reviewpad_with_pipelines.yml`) ([link](https://github.com/reviewpad/reviewpad/pull/926/files?diff=unified&w=0#diff-edd198d086f5758636a86b64e997108c665cf3ec612253c8b26feec2d03b8440R1-R65))
* Refactor the logic of executing pipeline stages ([link](https://github.com/reviewpad/reviewpad/pull/926/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL375-R408))
* Improve the log output of the pipeline processing ([link](https://github.com/reviewpad/reviewpad/pull/926/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL361-R365))
