### PR TITLE
feat: dictionaries

### DIFF
--- a/engine/env.go
+++ b/engine/env.go
@@ -44,8 +44,9 @@ type Interpreter interface {
 	Report(mode string, safeMode bool) error
 	ReportMetrics() error
 	GetCheckRunConclusion() string
-	ProcessList(expr string) (lang.Value, error)
+	ProcessIterable(expr string) (lang.Value, error)
 	StoreTemporaryVariable(name string, value lang.Value)
+	ProcessDictionary(name string, dictionary map[string]string) error
 }
 
 type Env struct {

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -302,6 +302,19 @@ func ExecConfigurationFile(env *Env, file *ReviewpadFile) (ExitStatus, *Program,
 		}
 	}
 
+	// process dictionaries
+	for _, dictionary := range file.Dictionaries {
+		transformedSpec := make(map[string]string)
+		for key, value := range dictionary.Spec {
+			transformedSpec[key] = transformAladinoExpression(value)
+		}
+
+		err := interpreter.ProcessDictionary(dictionary.Name, transformedSpec)
+		if err != nil {
+			return ExitStatusFailure, nil, err
+		}
+	}
+
 	// a program is a list of statements to be executed based on the command, workflow rules and actions.
 	program := BuildProgram(make([]*Statement, 0))
 

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -369,6 +369,38 @@ func TestExecConfigurationFile(t *testing.T) {
 			targetEntity:   engine.DefaultMockTargetEntity,
 			wantExitStatus: engine.ExitStatusSuccess,
 		},
+		"reviewpad with dictionaries and for each": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_dictionary_and_foreach_workflow.yml",
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(`$addLabel($teamName)`),
+					engine.BuildStatement(`$addLabel($teamMember)`),
+					engine.BuildStatement(`$addLabel($teamMember)`),
+					engine.BuildStatement(`$addLabel($teamName)`),
+					engine.BuildStatement(`$addLabel($teamMember)`),
+					engine.BuildStatement(`$addLabel($teamMember)`),
+				},
+			),
+			targetEntity:   engine.DefaultMockTargetEntity,
+			wantExitStatus: engine.ExitStatusSuccess,
+		},
+		"reviewpad with referenced dictionaries and for each": {
+			inputReviewpadFilePath: "testdata/exec/reviewpad_with_referenced_dictionary_and_foreach_workflow.yml",
+			wantProgram: engine.BuildProgram(
+				[]*engine.Statement{
+					engine.BuildStatement(`$addLabel($groupMember)`),
+					engine.BuildStatement(`$addLabel($groupMember)`),
+					engine.BuildStatement(`$addLabel($groupMember)`),
+					engine.BuildStatement(`$addLabel($groupMember)`),
+					engine.BuildStatement(`$addLabel($groupMember)`),
+					engine.BuildStatement(`$addLabel($groupMember)`),
+					engine.BuildStatement(`$addLabel($groupMember)`),
+					engine.BuildStatement(`$addLabel($groupMember)`),
+				},
+			),
+			targetEntity:   engine.DefaultMockTargetEntity,
+			wantExitStatus: engine.ExitStatusSuccess,
+		},
 	}
 
 	codehostClient := aladino.GetDefaultCodeHostClient(t, aladino.GetDefaultPullRequestDetails(), aladino.GetDefaultPullRequestFileList(), nil, nil)
@@ -390,8 +422,9 @@ func TestExecConfigurationFile(t *testing.T) {
 					"assignReviewer": plugins_aladino_actions.AssignReviewer(),
 				},
 				Functions: map[string]*aladino.BuiltInFunction{
-					"group": plugins_aladino_functions.Group(),
-					"team":  plugins_aladino_functions.Team(),
+					"group":      plugins_aladino_functions.Group(),
+					"team":       plugins_aladino_functions.Team(),
+					"dictionary": plugins_aladino_functions.Dictionary(),
 				},
 			}
 

--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -235,12 +235,12 @@ func normalizeRun(run any, currentRules []PadRule) ([]PadWorkflowRunBlock, []Pad
 
 			value, ok := forEach["value"].(string)
 			if !ok {
-				return nil, nil, fmt.Errorf("forEach block must contain a value")
+				return nil, nil, fmt.Errorf("forEach block must contain a string value")
 			}
 
 			in, ok := forEach["in"].(string)
 			if !ok {
-				return nil, nil, fmt.Errorf("forEach block must contain an in")
+				return nil, nil, fmt.Errorf("forEach block must contain a string in")
 			}
 
 			do, ok := forEach["do"]

--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -29,6 +29,7 @@ func inlineModificator(file *ReviewpadFile) (*ReviewpadFile, error) {
 		Workflows:      file.Workflows,
 		Pipelines:      file.Pipelines,
 		Recipes:        file.Recipes,
+		Dictionaries:   file.Dictionaries,
 	}
 
 	for i, workflow := range reviewpadFile.Workflows {
@@ -250,11 +251,17 @@ func normalizeRun(run any, currentRules []PadRule) ([]PadWorkflowRunBlock, []Pad
 				return nil, nil, err
 			}
 
-			mapBlock.ForEach = &PadWorkflowRunForEachBlock{
+			padWorkflowRunForEachBlock := &PadWorkflowRunForEachBlock{
 				Value: value.(string),
 				In:    in.(string),
 				Do:    processedDo,
 			}
+
+			if key, ok := forEachBlock.(map[string]interface{})["key"].(string); ok {
+				padWorkflowRunForEachBlock.Key = key
+			}
+
+			mapBlock.ForEach = padWorkflowRunForEachBlock
 
 			rules = append(rules, processedDoRules...)
 

--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -231,17 +231,19 @@ func normalizeRun(run any, currentRules []PadRule) ([]PadWorkflowRunBlock, []Pad
 				return nil, nil, fmt.Errorf("forEach block must be a map")
 			}
 
-			value, ok := forEachBlock.(map[string]interface{})["value"]
+			forEach := forEachBlock.(map[string]interface{})
+
+			value, ok := forEach["value"].(string)
 			if !ok {
 				return nil, nil, fmt.Errorf("forEach block must contain a value")
 			}
 
-			in, ok := forEachBlock.(map[string]interface{})["in"]
+			in, ok := forEach["in"].(string)
 			if !ok {
 				return nil, nil, fmt.Errorf("forEach block must contain an in")
 			}
 
-			do, ok := forEachBlock.(map[string]interface{})["do"]
+			do, ok := forEach["do"]
 			if !ok {
 				return nil, nil, fmt.Errorf("forEach block must contain a do")
 			}
@@ -252,12 +254,12 @@ func normalizeRun(run any, currentRules []PadRule) ([]PadWorkflowRunBlock, []Pad
 			}
 
 			padWorkflowRunForEachBlock := &PadWorkflowRunForEachBlock{
-				Value: value.(string),
-				In:    in.(string),
+				Value: value,
+				In:    in,
 				Do:    processedDo,
 			}
 
-			if key, ok := forEachBlock.(map[string]interface{})["key"].(string); ok {
+			if key, ok := forEach["key"].(string); ok {
 				padWorkflowRunForEachBlock.Key = key
 			}
 

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -378,6 +378,16 @@ func (r *ReviewpadFile) equals(o *ReviewpadFile) bool {
 		}
 	}
 
+	if len(r.Dictionaries) != len(o.Dictionaries) {
+		return false
+	}
+	for i, rD := range r.Dictionaries {
+		oD := o.Dictionaries[i]
+		if !rD.equals(oD) {
+			return false
+		}
+	}
+
 	return reflect.DeepEqual(r.Recipes, o.Recipes)
 }
 

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -122,6 +122,7 @@ type PadWorkflowRunBlock struct {
 }
 
 type PadWorkflowRunForEachBlock struct {
+	Key   string
 	Value string
 	In    string
 	Do    []PadWorkflowRunBlock
@@ -226,6 +227,30 @@ type ReviewpadFile struct {
 	Workflows      []PadWorkflow       `yaml:"workflows"`
 	Pipelines      []PadPipeline       `yaml:"pipelines"`
 	Recipes        map[string]*bool    `yaml:"recipes"`
+	Dictionaries   []PadDictionary     `yaml:"dictionaries"`
+}
+
+type PadDictionary struct {
+	Name string            `yaml:"name"`
+	Spec map[string]string `yaml:"spec"`
+}
+
+func (p PadDictionary) equals(o PadDictionary) bool {
+	if p.Name != o.Name {
+		return false
+	}
+
+	if len(p.Spec) != len(o.Spec) {
+		return false
+	}
+
+	for key, value := range p.Spec {
+		if o.Spec[key] != value {
+			return false
+		}
+	}
+
+	return true
 }
 
 type PadPipeline struct {
@@ -424,6 +449,10 @@ func (r *ReviewpadFile) appendRecipes(o *ReviewpadFile) {
 	}
 }
 
+func (r *ReviewpadFile) appendDictionaries(o *ReviewpadFile) {
+	r.Dictionaries = append(r.Dictionaries, o.Dictionaries...)
+}
+
 func (r *ReviewpadFile) extend(o *ReviewpadFile) {
 	if o.Mode != "" {
 		r.Mode = o.Mode
@@ -443,6 +472,7 @@ func (r *ReviewpadFile) extend(o *ReviewpadFile) {
 	r.appendWorkflows(o)
 	r.appendPipelines(o)
 	r.appendRecipes(o)
+	r.appendDictionaries(o)
 }
 
 func findGroup(groups []PadGroup, name string) (*PadGroup, bool) {

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -450,7 +450,15 @@ func (r *ReviewpadFile) appendRecipes(o *ReviewpadFile) {
 }
 
 func (r *ReviewpadFile) appendDictionaries(o *ReviewpadFile) {
-	r.Dictionaries = append(r.Dictionaries, o.Dictionaries...)
+	updatedDictionaries := make([]PadDictionary, 0)
+
+	for _, dictionary := range r.Dictionaries {
+		if _, ok := findDictionary(o.Dictionaries, dictionary.Name); !ok {
+			updatedDictionaries = append(updatedDictionaries, dictionary)
+		}
+	}
+
+	r.Dictionaries = append(updatedDictionaries, o.Dictionaries...)
 }
 
 func (r *ReviewpadFile) extend(o *ReviewpadFile) {
@@ -509,6 +517,16 @@ func findPipeline(pipelines []PadPipeline, name string) (*PadPipeline, bool) {
 	for _, pipeline := range pipelines {
 		if pipeline.Name == name {
 			return &pipeline, true
+		}
+	}
+
+	return nil, false
+}
+
+func findDictionary(dictionaries []PadDictionary, name string) (*PadDictionary, bool) {
+	for _, dictionary := range dictionaries {
+		if dictionary.Name == name {
+			return &dictionary, true
 		}
 	}
 

--- a/engine/linter.go
+++ b/engine/linter.go
@@ -296,9 +296,8 @@ func lintShadowedVariablesInRuns(runs []PadWorkflowRunBlock, definedVariables ma
 }
 
 func lintShadowedVariables(workflows []PadWorkflow) error {
-	definedVariables := map[string]bool{}
-
 	for _, workflow := range workflows {
+		definedVariables := map[string]bool{}
 		err := lintShadowedVariablesInRuns(workflow.Runs, definedVariables)
 		if err != nil {
 			return err

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -258,6 +258,7 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 		Workflows:      transformedWorkflows,
 		Pipelines:      transformedPipelines,
 		Recipes:        file.Recipes,
+		Dictionaries:   file.Dictionaries,
 	}
 }
 

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -87,6 +87,29 @@ func TestLoadWithAST(t *testing.T) {
 		IgnoreErrors:   &noIgnoreErrors,
 		MetricsOnMerge: &noMetricsOnMerge,
 		Extends:        []string{},
+		Dictionaries: []engine.PadDictionary{
+			{
+				Name: "teams",
+				Spec: map[string]string{
+					"team1": `["john", "jane"]`,
+					"team2": `["jill", "james"]`,
+				},
+			},
+			{
+				Name: "groups",
+				Spec: map[string]string{
+					"group1": `"group1"`,
+					"group2": `"group2"`,
+				},
+			},
+			{
+				Name: "owners",
+				Spec: map[string]string{
+					"dir1": `["jane", "john"]`,
+					"dir2": `["jill", "james"]`,
+				},
+			},
+		},
 		Labels: map[string]engine.PadLabel{
 			"small": {
 				Color: "#aa12ab",

--- a/engine/testdata/exec/reviewpad_with_dictionary_and_foreach_workflow.yml
+++ b/engine/testdata/exec/reviewpad_with_dictionary_and_foreach_workflow.yml
@@ -1,0 +1,23 @@
+# Copyright (C) 2023 Explore.dev, Unipessoal Lda - All Rights Reserved
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+dictionaries:
+  - name: teams
+    spec:
+      team1: '["john", "jane"]'
+      team2: '["jill", "james"]'
+
+workflows:
+  - name: test
+    run:
+      - forEach:
+          key: $teamName
+          value: $teamMembers
+          in: $dictionary("teams")
+          do:
+            - $addLabel($teamName)
+            - forEach:
+                value: $teamMember
+                in: $teamMembers
+                do: $addLabel($teamMember)

--- a/engine/testdata/exec/reviewpad_with_referenced_dictionary_and_foreach_workflow.yml
+++ b/engine/testdata/exec/reviewpad_with_referenced_dictionary_and_foreach_workflow.yml
@@ -1,0 +1,37 @@
+# Copyright (C) 2023 Explore.dev, Unipessoal Lda - All Rights Reserved
+# Use of this source code is governed by a license that can be
+# found in the LICENSE file.
+
+dictionaries:
+  - name: security teams
+    spec:
+      secteam1: '["john", "jane"]'
+      secteam2: '["jill", "james"]'
+
+  - name: devops teams
+    spec:
+      devopsteam1: '["john", "jane"]'
+      devopsteam2: '["jill", "james"]'
+
+  - name: groups
+    spec:
+      security: $dictionary("security teams")
+      devops: $dictionary("devops teams")
+
+workflows:
+  - name: test
+    run:
+      - forEach:
+          key: $groupName
+          value: $groupMembers
+          in: $dictionary("groups")
+          do:
+            - forEach:
+                value: $groupMemberTeams
+                in: $groupMembers
+                do:
+                  - forEach:
+                      value: $groupMember
+                      in: $groupMemberTeams
+                      do: $addLabel($groupMember)
+                      

--- a/engine/testdata/exec/reviewpad_with_referenced_dictionary_and_foreach_workflow.yml
+++ b/engine/testdata/exec/reviewpad_with_referenced_dictionary_and_foreach_workflow.yml
@@ -34,4 +34,3 @@ workflows:
                       value: $groupMember
                       in: $groupMemberTeams
                       do: $addLabel($groupMember)
-                      

--- a/engine/testdata/loader/process/reviewpad_with_extends_after_processing.yml
+++ b/engine/testdata/loader/process/reviewpad_with_extends_after_processing.yml
@@ -8,6 +8,22 @@ edition: enterprise
 ignore-errors: true
 metrics-on-merge: true
 
+dictionaries:
+  - name: teams
+    spec:
+      team1: '["john", "jane"]'
+      team2: '["jill", "james"]'
+
+  - name: groups
+    spec:
+      group1: '"group1"'
+      group2: '"group2"'
+      
+  - name: owners
+    spec:
+      dir1: '["jane", "john"]'
+      dir2: '["jill", "james"]'
+
 labels:
   small:
     color: '#aa12ab'

--- a/engine/testdata/loader/reviewpad_with_extends.yml
+++ b/engine/testdata/loader/reviewpad_with_extends.yml
@@ -12,6 +12,12 @@ labels:
   small:
     color: '#aa12ab'
 
+dictionaries:
+  - name: owners
+    spec:
+      dir1: '["jane", "john"]'
+      dir2: '["jill", "james"]'
+
 groups:
   - name: owners
     kind: developers

--- a/engine/testdata/loader/reviewpad_with_no_extends_a.yml
+++ b/engine/testdata/loader/reviewpad_with_no_extends_a.yml
@@ -8,6 +8,12 @@ mode: verbose
 
 metrics-on-merge: true
 
+dictionaries:
+  - name: teams
+    spec:
+      team1: '["john", "jane"]'
+      team2: '["jill", "james"]'
+
 labels:
   small:
     color: '#aaf1aa'

--- a/engine/testdata/loader/reviewpad_with_no_extends_b.yml
+++ b/engine/testdata/loader/reviewpad_with_no_extends_b.yml
@@ -8,6 +8,12 @@ ignore-errors: true
 
 edition: enterprise
 
+dictionaries:
+  - name: groups
+    spec:
+      group1: '"group1"'
+      group2: '"group2"'
+
 groups:
   - name: owners
     kind: developers

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -65,6 +65,24 @@ func (i *Interpreter) ProcessGroup(groupName string, kind engine.GroupKind, type
 	return nil
 }
 
+func (i *Interpreter) ProcessIterable(expr string) (lang.Value, error) {
+	exprAST, err := Parse(expr)
+	if err != nil {
+		return nil, fmt.Errorf("ProcessIterable:Parse: %v", err)
+	}
+
+	exprType, err := TypeInference(i.Env, exprAST)
+	if err != nil {
+		return nil, err
+	}
+
+	if exprType.Kind() != lang.ARRAY_TYPE && exprType.Kind() != lang.ARRAY_OF_TYPE && exprType.Kind() != lang.DICTIONARY_TYPE {
+		return nil, fmt.Errorf("expression is not a valid iterable")
+	}
+
+	return Eval(i.Env, exprAST)
+}
+
 func (i *Interpreter) ProcessDictionary(name string, dictionary map[string]string) error {
 	processedDictionary := make(map[string]lang.Value)
 

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -65,18 +65,26 @@ func (i *Interpreter) ProcessGroup(groupName string, kind engine.GroupKind, type
 	return nil
 }
 
-func (i *Interpreter) ProcessList(expr string) (lang.Value, error) {
-	exprAST, err := Parse(expr)
-	if err != nil {
-		return nil, fmt.Errorf("ProcessList:Parse: %v", err)
+func (i *Interpreter) ProcessDictionary(name string, dictionary map[string]string) error {
+	processedDictionary := make(map[string]lang.Value)
+
+	for key, expr := range dictionary {
+		exprAST, err := Parse(expr)
+		if err != nil {
+			return fmt.Errorf("ProcessDictionary:Parse: %v", err)
+		}
+
+		value, err := Eval(i.Env, exprAST)
+		if err != nil {
+			return fmt.Errorf("ProcessDictionary:Eval: %v", err)
+		}
+
+		processedDictionary[key] = value
 	}
 
-	value, err := evalGroup(i.Env, exprAST)
-	if err != nil {
-		return nil, fmt.Errorf("ProcessList:evalGroup %v", err)
-	}
+	i.Env.GetRegisterMap()[fmt.Sprintf("@dictionary:%s", name)] = lang.BuildDictionaryValue(processedDictionary)
 
-	return value, nil
+	return nil
 }
 
 func (i *Interpreter) StoreTemporaryVariable(name string, value lang.Value) {

--- a/lang/type.go
+++ b/lang/type.go
@@ -18,6 +18,7 @@ const (
 	ARRAY_OF_TYPE      string = "ArrayOfType"
 	JSON_TYPE          string = "JSONType"
 	DYNAMIC_ARRAY_TYPE string = "DynamicArrayType"
+	DICTIONARY_TYPE    string = "DictionaryType"
 )
 
 type StringType struct{}
@@ -44,6 +45,8 @@ type DynamicArrayType struct{}
 
 type JSONType struct{}
 
+type DictionaryType struct{}
+
 func BuildStringType() *StringType { return &StringType{} }
 func BuildIntType() *IntType       { return &IntType{} }
 func BuildBoolType() *BoolType     { return &BoolType{} }
@@ -63,6 +66,10 @@ func BuildArrayType(elemsTypes []Type) *ArrayType {
 func BuildJSONType() *JSONType { return &JSONType{} }
 
 func BuildDynamicArrayType() *DynamicArrayType { return &DynamicArrayType{} }
+
+func BuildDictionaryType() *DictionaryType {
+	return &DictionaryType{}
+}
 
 func (bTy *BoolType) Kind() string {
 	return BOOL_TYPE
@@ -94,6 +101,10 @@ func (jTy *JSONType) Kind() string {
 
 func (dATy *DynamicArrayType) Kind() string {
 	return DYNAMIC_ARRAY_TYPE
+}
+
+func (dTy *DictionaryType) Kind() string {
+	return DICTIONARY_TYPE
 }
 
 // Equals
@@ -174,6 +185,10 @@ func (thisTy *JSONType) Equals(thatTy Type) bool {
 }
 
 func (thisTy *DynamicArrayType) Equals(thatTy Type) bool {
+	return thisTy.Kind() == thatTy.Kind()
+}
+
+func (thisTy *DictionaryType) Equals(thatTy Type) bool {
 	return thisTy.Kind() == thatTy.Kind()
 }
 

--- a/lang/value.go
+++ b/lang/value.go
@@ -16,13 +16,14 @@ type Value interface {
 }
 
 const (
-	INT_VALUE      string = "IntValue"
-	BOOL_VALUE     string = "BoolValue"
-	STRING_VALUE   string = "StringValue"
-	TIME_VALUE     string = "TimeValue"
-	ARRAY_VALUE    string = "ArrayValue"
-	FUNCTION_VALUE string = "FunctionValue"
-	JSON_VALUE     string = "JSONValue"
+	INT_VALUE        string = "IntValue"
+	BOOL_VALUE       string = "BoolValue"
+	STRING_VALUE     string = "StringValue"
+	TIME_VALUE       string = "TimeValue"
+	ARRAY_VALUE      string = "ArrayValue"
+	FUNCTION_VALUE   string = "FunctionValue"
+	JSON_VALUE       string = "JSONValue"
+	DICTIONARY_VALUE string = "DictionaryValue"
 )
 
 // IntValue represents an integer value
@@ -251,4 +252,45 @@ func (jVal *JSONValue) Equals(other Value) bool {
 
 func (jVal *JSONValue) Type() Type {
 	return BuildJSONType()
+}
+
+type DictionaryValue struct {
+	Vals map[string]Value
+}
+
+func BuildDictionaryValue(vals map[string]Value) *DictionaryValue {
+	return &DictionaryValue{Vals: vals}
+}
+
+func (dVal *DictionaryValue) Kind() string {
+	return DICTIONARY_VALUE
+}
+
+func (dVal *DictionaryValue) HasKindOf(ty string) bool {
+	return dVal.Kind() == ty
+}
+
+func (dVal *DictionaryValue) Equals(other Value) bool {
+	if dVal.Kind() != other.Kind() {
+		return false
+	}
+
+	otherDict := other.(*DictionaryValue)
+
+	if len(dVal.Vals) != len(otherDict.Vals) {
+		return false
+	}
+
+	for key, val := range dVal.Vals {
+		otherVal := otherDict.Vals[key]
+		if !val.Equals(otherVal) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (dVal *DictionaryValue) Type() Type {
+	return BuildDictionaryType()
 }

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -134,8 +134,9 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"toNumber":                      functions.ToNumber(),
 			"toStringArray":                 functions.ToStringArray(),
 			// Engine
-			"group": functions.Group(),
-			"rule":  functions.Rule(),
+			"dictionary": functions.Dictionary(),
+			"group":      functions.Group(),
+			"rule":       functions.Rule(),
 			// Internal
 			"filter": functions.Filter(),
 		},

--- a/plugins/aladino/functions/dictionary.go
+++ b/plugins/aladino/functions/dictionary.go
@@ -1,0 +1,31 @@
+// Copyright 2023 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"fmt"
+
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+)
+
+func Dictionary() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           lang.BuildFunctionType([]lang.Type{lang.BuildStringType()}, lang.BuildDictionaryType()),
+		Code:           dictionaryCode,
+		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest, entities.Issue},
+	}
+}
+
+func dictionaryCode(e aladino.Env, args []lang.Value) (lang.Value, error) {
+	dictionaryName := args[0].(*lang.StringValue).Val
+
+	if val, ok := e.GetRegisterMap()[fmt.Sprintf("@dictionary:%s", dictionaryName)]; ok {
+		return val, nil
+	}
+
+	return nil, fmt.Errorf("getDictionary: no dictionary with name %v in state %+q", dictionaryName, e.GetRegisterMap())
+}


### PR DESCRIPTION
## Description
Adds support for defining dictionaries and iterating over them.
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Jun 23 08:06 UTC
This pull request contains multiple changes to different files in the codebase. Some changes involve the addition of new structs, dictionaries, functions, and workflows while others involve modifications to existing code. These changes provide new functionality for processing iterable expressions and dictionaries, implementing linting checks for shadowed variables in workflows, defining mappings between keys and values, and adding new labels for small pull requests. Additionally, some functions and methods were renamed, rearranged, or modified to handle loops and dictionaries more efficiently. Overall, these changes improve the usability and maintainability of the codebase.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c01f675</samp>

This pull request adds support for dictionaries in the configuration file and the `run.ForEach` expression. Dictionaries are named collections of key-value pairs that can be used to iterate over different values in a loop. The pull request modifies the `lang` package to define a new type and value for dictionaries, the `engine` package to process and transform dictionaries in the configuration file and the loop expression, and the `plugins/aladino` package to provide a built-in function to access dictionaries.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c01f675</samp>

*  Modify the `Interpreter` interface to add `ProcessIterable` and `ProcessDictionary` methods ([link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-bd383b1ff56f0a02ff20cb2df318417891c9954441067394d8ad3ec8a30638c2L47-R49), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL68-R107))
*  Implement the `DictionaryType` and `DictionaryValue` structs and their methods in the `lang` package ([link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-24bf037bc54d54c21157b33cdce512baba5f6501ffaac51e1eae63303e3b26a3R21), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-24bf037bc54d54c21157b33cdce512baba5f6501ffaac51e1eae63303e3b26a3R48-R49), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-24bf037bc54d54c21157b33cdce512baba5f6501ffaac51e1eae63303e3b26a3R70-R73), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-24bf037bc54d54c21157b33cdce512baba5f6501ffaac51e1eae63303e3b26a3R106-R109), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-24bf037bc54d54c21157b33cdce512baba5f6501ffaac51e1eae63303e3b26a3R191-R194), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-ce341657e8b632e1b6776bd372c3681bc8bfab32873adfcb03d78ef798b66b78L19-R26), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-ce341657e8b632e1b6776bd372c3681bc8bfab32873adfcb03d78ef798b66b78R256-R296))
*  Add the `dictionary` built-in function to the `plugins/aladino` package and define its code and type in the `functions/dictionary.go` file ([link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-ae30c911aa5a3b55cfee228b859bba3476c5700d9d3141d6180f16846399945cL137-R139), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-569d19f649000114c04fa104c325a068f68ea24a1651fdc641621ee883ebf412R1-R31))
*  Modify the `ExecConfigurationFile` function in `engine/exec.go` to process the dictionaries defined in the configuration file and store them in the register map ([link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fR306-R318))
*  Modify the `execStatement` function in `engine/exec.go` to handle the case of a dictionary expression in a `run.ForEach` block and store the key and value temporary variables ([link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL437-R476))
*  Modify the `transform` function in `engine/loader.go` to transform the dictionary expressions using the `transformAladinoExpression` function ([link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-31e0d9a2beee99e1ca91227b4cf55fc6b934b0d3bfef25a56fdf5fbf28879c92R261))
*  Modify the `inlineModificator` function in `engine/inline_rules_normalizer.go` to add the dictionaries to the `ReviewpadFile` struct ([link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-ea18868fc6cfa08e95023e74934900b2af69a653d53a65a962abe70616a132f6R32))
*  Modify the `normalizeRun` function in `engine/inline_rules_normalizer.go` to check for the `key` field in the `forEachBlock` map and assign it to the `Key` field of the `padWorkflowRunForEachBlock` struct ([link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-ea18868fc6cfa08e95023e74934900b2af69a653d53a65a962abe70616a132f6L253-R254), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-ea18868fc6cfa08e95023e74934900b2af69a653d53a65a962abe70616a132f6R260-R265))
*  Modify the `PadWorkflowRunBlock` and `ReviewpadFile` structs in `engine/lang.go` to add the `Key` and `Dictionaries` fields, respectively, and define the `PadDictionary` struct and its methods ([link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R125), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701L229-R255), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R452-R455), [link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R475))
*  Modify the `extend` function in `engine/lang.go` to append the dictionaries from the other file to the receiver file ([link](https://github.com/reviewpad/reviewpad/pull/930/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R475))
