### PR TITLE
chore: update log

### DIFF
--- a/engine/exec.go
+++ b/engine/exec.go
@@ -140,7 +140,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 
 	// process workflows
 	for _, workflow := range file.Workflows {
-		log.Infof("evaluating workflow '%v'", workflow.Name)
+		log.Infof("executing workflow `%v`", workflow.Name)
 		workflowLog := log.WithField("workflow", workflow.Name)
 
 		if !workflow.AlwaysRun && triggeredExclusiveWorkflow {
@@ -157,7 +157,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 		}
 
 		if !shouldRun {
-			workflowLog.Infof("skipping workflow because event kind is '%v' and workflow is on '%v'", env.TargetEntity.Kind, workflow.On)
+			workflowLog.Infof("skipping workflow because event kind is `%v` and workflow is on `%v`", env.TargetEntity.Kind, workflow.On)
 			continue
 		}
 
@@ -181,7 +181,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 	if env.TargetEntity.Kind == entities.PullRequest {
 		// process pipelines
 		for _, pipeline := range file.Pipelines {
-			log.Infof("evaluating pipeline '%v':", pipeline.Name)
+			log.Infof("executing pipeline `%v`:", pipeline.Name)
 			pipelineLog := log.WithField("pipeline", pipeline.Name)
 
 			var err error
@@ -195,7 +195,7 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 
 			if activated {
 				for num, stage := range pipeline.Stages {
-					pipelineLog.Infof("evaluating pipeline stage '%v'", num)
+					pipelineLog.Infof("executing pipeline stage `%v`", num)
 					if stage.Until == "" {
 						program.append(stage.Actions)
 						break
@@ -222,7 +222,6 @@ func EvalConfigurationFile(file *ReviewpadFile, env *Env) (*Program, error) {
 // Pre-condition Lint(file) == nil
 func ExecConfigurationFile(env *Env, file *ReviewpadFile) (ExitStatus, *Program, error) {
 	log := env.Logger
-	log.Infoln("exec configuration file")
 
 	interpreter := env.Interpreter
 
@@ -320,7 +319,7 @@ func ExecConfigurationFile(env *Env, file *ReviewpadFile) (ExitStatus, *Program,
 
 	// process workflows
 	for _, workflow := range file.Workflows {
-		log.Infof("evaluating workflow '%v'", workflow.Name)
+		log.Infof("executing workflow `%v`", workflow.Name)
 		workflowLog := log.WithField("workflow", workflow.Name)
 
 		if !workflow.AlwaysRun && triggeredExclusiveWorkflow {
@@ -337,7 +336,7 @@ func ExecConfigurationFile(env *Env, file *ReviewpadFile) (ExitStatus, *Program,
 		}
 
 		if !shouldRun {
-			workflowLog.Infof("skipping workflow because event kind is '%v' and workflow is on '%v'", env.TargetEntity.Kind, workflow.On)
+			workflowLog.Infof("skipping workflow because event kind is `%v` and workflow is on `%v`", env.TargetEntity.Kind, workflow.On)
 			continue
 		}
 
@@ -362,7 +361,7 @@ func ExecConfigurationFile(env *Env, file *ReviewpadFile) (ExitStatus, *Program,
 		for _, pipeline := range file.Pipelines {
 			pipelineLog := log.WithField("pipeline", pipeline.Name)
 
-			pipelineLog.Infof("processing pipeline '%v':", pipeline.Name)
+			pipelineLog.Infof("executing pipeline `%v`:", pipeline.Name)
 
 			var err error
 			activated := pipeline.Trigger == ""

--- a/engine/linter.go
+++ b/engine/linter.go
@@ -121,13 +121,13 @@ func lintWorkflows(log *logrus.Entry, rules []PadRule, padWorkflows []PadWorkflo
 	workflowHasExtraActions := false
 
 	for _, workflow := range padWorkflows {
-		log.Infof("analyzing workflow '%v'", workflow.Name)
+		log.Infof("linting workflow `%v`", workflow.Name)
 
 		workflowHasActions := len(workflow.Actions) > 0
 
 		for _, workflowName := range workflowsName {
 			if workflowName == workflow.Name {
-				return fmt.Errorf("workflow with the name '%v' already exists", workflow.Name)
+				return fmt.Errorf("workflow with the name `%v` already exists", workflow.Name)
 			}
 		}
 
@@ -139,17 +139,17 @@ func lintWorkflows(log *logrus.Entry, rules []PadRule, padWorkflows []PadWorkflo
 
 			_, exists := findRule(rules, ruleName)
 			if !exists {
-				return fmt.Errorf("rule '%v' is unknown", ruleName)
+				return fmt.Errorf("rule `%v` is unknown", ruleName)
 			}
 
 			workflowHasExtraActions = len(rule.ExtraActions) > 0
 			if !workflowHasExtraActions && !workflowHasActions {
-				log.Warnf("rule '%v' will be ignored since it has no actions", ruleName)
+				log.Warnf("rule `%v` will be ignored since it has no actions", ruleName)
 			}
 		}
 
 		if !workflowHasActions && !workflowHasExtraActions {
-			log.Warn("workflow has no actions")
+			log.Debug("workflow has no actions")
 		}
 
 		workflowsName = append(workflowsName, workflow.Name)
@@ -180,7 +180,7 @@ func validateWorkflowRun(run *PadWorkflowRunBlock, workflow *PadWorkflow) error 
 	// The old style workflow allows if blocks to have extra actions.
 	// Because of this, a run block can have extra actions.
 	if !hasThenActions && !hasActions && !hasExtraActions && !hasForEachBlock {
-		return fmt.Errorf("workflow '%v' has a run block without a 'then' block, no actions, no extra actions or a for each block", workflow.Name)
+		return fmt.Errorf("workflow `%v` has a run block without a 'then' block, no actions, no extra actions or a for each block", workflow.Name)
 	}
 
 	for _, thenRun := range run.Then {

--- a/lang/aladino/exec.go
+++ b/lang/aladino/exec.go
@@ -46,7 +46,7 @@ func (fc *FunctionCall) exec(env Env) error {
 	}
 
 	if action.Disabled {
-		env.GetLogger().Infof("action %v is disabled - skipping", fc.name.ident)
+		env.GetLogger().Infof("action `%v` is disabled - skipping", fc.name.ident)
 		return nil
 	}
 

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -132,8 +132,6 @@ func (i *Interpreter) EvalExpr(kind, expr string) (bool, error) {
 }
 
 func (i *Interpreter) ExecProgram(program *engine.Program) (engine.ExitStatus, error) {
-	i.Env.GetLogger().Info("executing program")
-
 	retStatus := engine.ExitStatusSuccess
 	var retErr error
 
@@ -163,8 +161,6 @@ func (i *Interpreter) ExecProgram(program *engine.Program) (engine.ExitStatus, e
 	if i.Env.GetExecFatalErrorOccurred() != nil {
 		return engine.ExitStatusFailure, i.Env.GetExecFatalErrorOccurred()
 	}
-
-	i.Env.GetLogger().Info("execution done")
 
 	return retStatus, retErr
 }
@@ -216,7 +212,7 @@ func (i *Interpreter) ExecStatement(statement *engine.Statement) error {
 
 	i.Env.GetReport().addToReport(statement)
 
-	i.Env.GetLogger().Infof("action %v executed", statRaw)
+	i.Env.GetLogger().Infof("action `%v` executed", statRaw)
 	return nil
 }
 

--- a/plugins/aladino/actions/commitLint.go
+++ b/plugins/aladino/actions/commitLint.go
@@ -39,7 +39,7 @@ func commitLintCode(e aladino.Env, _ []lang.Value) error {
 		res, err := parser.NewMachine(conventionalcommits.WithTypes(conventionalcommits.TypesConventional)).Parse([]byte(commitMsg))
 
 		if err != nil || !res.Ok() {
-			body := fmt.Sprintf("**Unconventional commit detected**: '%v' (%v)", commitMsg, ghCommit.GetSHA())
+			body := fmt.Sprintf("**Unconventional commit detected**: `%v` (%v)", commitMsg, ghCommit.GetSHA())
 			reportedMessages := e.GetBuiltInsReportedMessages()
 			reportedMessages[aladino.SEVERITY_ERROR] = append(reportedMessages[aladino.SEVERITY_ERROR], body)
 		}

--- a/plugins/aladino/actions/titleLint.go
+++ b/plugins/aladino/actions/titleLint.go
@@ -27,9 +27,9 @@ func titleLintCode(e aladino.Env, _ []lang.Value) error {
 
 	res, err := parser.NewMachine(conventionalcommits.WithTypes(conventionalcommits.TypesConventional)).Parse([]byte(title))
 	if err != nil || !res.Ok() {
-		body := fmt.Sprintf("**Unconventional title detected**: '%v'", title)
+		body := fmt.Sprintf("**Unconventional title detected**: `%v`", title)
 		if err != nil {
-			body = fmt.Sprintf("**Unconventional title detected**: '%v' %v", title, err)
+			body = fmt.Sprintf("**Unconventional title detected**: `%v` %v", title, err)
 		}
 
 		reportedMessages := e.GetBuiltInsReportedMessages()

--- a/runner.go
+++ b/runner.go
@@ -25,7 +25,7 @@ import (
 )
 
 func logErrorAndCollect(logger *logrus.Entry, collector collector.Collector, message string, err error) {
-	logger.WithError(err).Errorln(message)
+	logger.WithError(err).Errorln(fmt.Sprintf("%s `%s`", message, err.Error()))
 
 	if ghError, isGitHubError := err.(*github.ErrorResponse); isGitHubError {
 		err = collector.CollectError(fmt.Errorf("%s: %s", message, ghError.Message))
@@ -33,7 +33,7 @@ func logErrorAndCollect(logger *logrus.Entry, collector collector.Collector, mes
 		err = collector.CollectError(fmt.Errorf("%s: %s", message, err.Error()))
 	}
 	if err != nil {
-		logger.WithError(err).Errorln("failed to collect error")
+		logger.WithError(err).Errorf("failed to collect error `%s`", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Jun 23 10:02 UTC
This pull request updates the log in various files to use backticks and improve consistency. Overall, this improves the readability and clarity of log messages.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 330620f</samp>

This pull request improves the log and error messages in various files of the reviewpad engine and plugins. It makes them more consistent, clear, and readable by using backticks, reducing redundancy, and adjusting terminology and formatting.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 330620f</samp>

*  Change log messages from "evaluating" to "executing" to reflect the actual behavior of the `EvalConfigurationFile` and `ExecConfigurationFile` functions in `engine/exec.go` ([link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL143-R143), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL184-R184), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL323-R322))
*  Change log messages to use backticks instead of single quotes for consistency and to avoid escaping issues in `engine/exec.go`, `engine/linter.go`, `lang/aladino/exec.go`, `lang/aladino/interpreter.go`, `plugins/aladino/actions/commitLint.go`, and `plugins/aladino/actions/titleLint.go` ([link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL160-R160), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL198-R198), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL340-R339), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-dda45b7998c92f7c70e9a774157f5b9abd5b0be9437877b326064648d39964daL130-R130), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-dda45b7998c92f7c70e9a774157f5b9abd5b0be9437877b326064648d39964daL142-R152), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-dda45b7998c92f7c70e9a774157f5b9abd5b0be9437877b326064648d39964daL183-R183), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-ccd0f6eb139760590a619908dbdcaca639bc998003a2e26079152a8bdc0c2fddL49-R49), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL219-R215), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-98c96263abcec712cae24fec4be00166a2a4a1363fdbacdf80c6ea6f5ef75621L42-R42), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-cbfc5271f34f3e066d46980ef7365a7d811eaa2e10a52776c3ff7c91cea5ea24L30-R32))
*  Remove redundant log messages in the `EvalExpr` and `ExecProgram` functions in `lang/aladino/interpreter.go` ([link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL135-L136), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL167-L168))
*  Remove redundant log message in the `ExecConfigurationFile` function in `engine/exec.go` ([link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL225))
*  Change log message from "processing" to "executing" to avoid confusion with the `ProcessPipeline` function in the `ExecConfigurationFile` function in `engine/exec.go` ([link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL365-R364))
*  Change log message from a warning to a debug level for a rule without actions in the `lintWorkflows` function in `engine/linter.go` ([link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-dda45b7998c92f7c70e9a774157f5b9abd5b0be9437877b326064648d39964daL142-R152))
*  Change log messages to include error messages in backticks for better readability in the `logErrorAndCollect` function in `runner.go` ([link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L28-R28), [link](https://github.com/reviewpad/reviewpad/pull/933/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L36-R36))
