### PR TITLE
fix: failing unit tests on commit and title lint

### DIFF
--- a/plugins/aladino/actions/commitLint.go
+++ b/plugins/aladino/actions/commitLint.go
@@ -39,7 +39,7 @@ func commitLintCode(e aladino.Env, _ []lang.Value) error {
 		res, err := parser.NewMachine(conventionalcommits.WithTypes(conventionalcommits.TypesConventional)).Parse([]byte(commitMsg))
 
 		if err != nil || !res.Ok() {
-			body := fmt.Sprintf("**Unconventional commit detected**: `%v` (%v)", commitMsg, ghCommit.GetSHA())
+			body := fmt.Sprintf("**Unconventional commit detected**: '%v' (%v)", commitMsg, ghCommit.GetSHA())
 			reportedMessages := e.GetBuiltInsReportedMessages()
 			reportedMessages[aladino.SEVERITY_ERROR] = append(reportedMessages[aladino.SEVERITY_ERROR], body)
 		}

--- a/plugins/aladino/actions/titleLint.go
+++ b/plugins/aladino/actions/titleLint.go
@@ -27,9 +27,9 @@ func titleLintCode(e aladino.Env, _ []lang.Value) error {
 
 	res, err := parser.NewMachine(conventionalcommits.WithTypes(conventionalcommits.TypesConventional)).Parse([]byte(title))
 	if err != nil || !res.Ok() {
-		body := fmt.Sprintf("**Unconventional title detected**: `%v`", title)
+		body := fmt.Sprintf("**Unconventional title detected**: '%v'", title)
 		if err != nil {
-			body = fmt.Sprintf("**Unconventional title detected**: `%v` %v", title, err)
+			body = fmt.Sprintf("**Unconventional title detected**: '%v' %v", title, err)
 		}
 
 		reportedMessages := e.GetBuiltInsReportedMessages()


### PR DESCRIPTION
## Description
Fixes failing unit tests.
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Jun 23 11:14 UTC
This pull request fixes failing unit tests on commit and title lint. The commit and title lint functions have been updated to print error messages with conventional quotes.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfe7603</samp>

Enclose commit and title messages in single quotes in `commitLint.go` and `titleLint.go` to fix Markdown formatting issues. This improves the readability and consistency of the linting messages.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cfe7603</samp>

* Enclose commit message and title in single quotes to avoid formatting issues with Markdown ([link](https://github.com/reviewpad/reviewpad/pull/934/files?diff=unified&w=0#diff-98c96263abcec712cae24fec4be00166a2a4a1363fdbacdf80c6ea6f5ef75621L42-R42), [link](https://github.com/reviewpad/reviewpad/pull/934/files?diff=unified&w=0#diff-cbfc5271f34f3e066d46980ef7365a7d811eaa2e10a52776c3ff7c91cea5ea24L30-R32))
