### PR TITLE
fix: pipeline execution

### DIFF
--- a/engine/exec.go
+++ b/engine/exec.go
@@ -399,15 +399,19 @@ func ExecConfigurationFile(env *Env, file *ReviewpadFile) (ExitStatus, *Program,
 
 				if isStageCompleted {
 					pipelineLog.Info("pipeline stage 'until' condition was met, skipping stage")
-				} else {
-					pipelineLog.Info("pipeline stage 'until' condition was not met, executing actions")
-
-					program.append(stage.Actions)
-					retStatus, err := execActions(interpreter, stage.Actions)
-					if err != nil || retStatus == ExitStatusFailure {
-						return retStatus, nil, err
-					}
+					continue
 				}
+
+				pipelineLog.Info("pipeline stage 'until' condition was not met, executing actions")
+
+				program.append(stage.Actions)
+				retStatus, err := execActions(interpreter, stage.Actions)
+				if err != nil || retStatus == ExitStatusFailure {
+					return retStatus, nil, err
+				}
+
+				// If the stage was been executed, the pipeline should stop
+				break
 			}
 		}
 	}

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -363,6 +363,7 @@ func TestExecConfigurationFile(t *testing.T) {
 					engine.BuildStatement(`$addLabel("pipeline with multiple stages and multiple actions - stage 2 - 2/2")`),
 					engine.BuildStatement(`$addLabel("pipeline with single stage and concise actions")`),
 					engine.BuildStatement(`$addLabel("pipeline with multiple stages and concise actions - stage 2")`),
+					engine.BuildStatement(`$addLabel("pipeline with more than 2 stages - stage 2")`),
 				},
 			),
 			targetEntity:   engine.DefaultMockTargetEntity,

--- a/engine/testdata/exec/reviewpad_with_pipelines.yml
+++ b/engine/testdata/exec/reviewpad_with_pipelines.yml
@@ -63,3 +63,14 @@ pipelines:
       - actions: $addLabel("pipeline with multiple stages and concise actions - stage 1")
         until: 1 == 1
       - actions: $addLabel("pipeline with multiple stages and concise actions - stage 2")
+
+  - name: pipeline with more than 2 stages
+    trigger: 1 == 1
+    stages:
+      - actions: $addLabel("pipeline with more than 2 stages - stage 1")
+        until: 1 == 1
+      - actions: $addLabel("pipeline with more than 2 stages - stage 2")
+        until: 1 == 2
+      - actions: $addLabel("pipeline with more than 2 stages - stage 3")
+        until: 1 == 3
+      - action: $addLabel("pipeline with more than 2 stages - stage 4")


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Jun 23 11:24 UTC
This pull request fixes a pipeline execution issue. The patch modifies the until condition evaluation in the pipeline stage and the execution of the stage actions. Specifically, if the until condition is met, the patch continues to the next stage. If the until condition is not met, the patch executes the stage actions. Additionally, the patch includes unit tests for pipeline with multiple stages and concise actions, and pipeline with more than two stages.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74811e2</samp>

Fix a bug in the execution of pipeline stages with `until` conditions and add a test case to verify the fix. The test case uses a new pipeline definition in `engine/testdata/exec/reviewpad_with_pipelines.yml` with four stages and different `until` conditions.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74811e2</samp>

* Fix bug in pipeline execution with `until` conditions ([link](https://github.com/reviewpad/reviewpad/pull/935/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL402-R414))
* Add test case for pipeline execution with multiple stages and `until` conditions ([link](https://github.com/reviewpad/reviewpad/pull/935/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2R366), [link](https://github.com/reviewpad/reviewpad/pull/935/files?diff=unified&w=0#diff-edd198d086f5758636a86b64e997108c665cf3ec612253c8b26feec2d03b8440R66-R76))
