### PR TITLE
test: codehost/github/repositories.go unit tests

### DIFF
--- a/codehost/github/repositories_test.go
+++ b/codehost/github/repositories_test.go
@@ -1,0 +1,238 @@
+// Copyright (C) 2023 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package github_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v52/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	pbc "github.com/reviewpad/api/go/codehost"
+	gh "github.com/reviewpad/reviewpad/v4/codehost/github"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+	"github.com/reviewpad/reviewpad/v4/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDefaultRepositoryBranch_WhenGetRepositoryRequestFails(t *testing.T) {
+	failMessage := "GetRepositoryRequestFail"
+	mockedGithubClient := aladino.MockDefaultGithubClient(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposByOwnerByRepo,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mock.WriteError(
+						w,
+						http.StatusInternalServerError,
+						failMessage,
+					)
+				}),
+			),
+		},
+		nil,
+	)
+
+	mockedCodeReview := aladino.GetDefaultPullRequestDetails()
+	defaultBranch, err := mockedGithubClient.GetDefaultRepositoryBranch(
+		context.Background(),
+		mockedCodeReview.Base.Repo.Owner,
+		mockedCodeReview.Base.Repo.GetName(),
+	)
+
+	assert.Equal(t, "", defaultBranch)
+	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
+}
+
+func TestGetDefaultRepositoryBranch(t *testing.T) {
+	mockedCodeReview := aladino.GetDefaultPullRequestDetails()
+	expectedDefaultBranch := mockedCodeReview.Base.Name
+
+	mockedGithubClient := aladino.MockDefaultGithubClient(
+		[]mock.MockBackendOption{
+			mock.WithRequestMatch(
+				mock.GetReposByOwnerByRepo,
+				&github.Repository{
+					DefaultBranch: github.String(expectedDefaultBranch),
+				},
+			),
+		},
+		nil,
+	)
+
+	defaultBranch, err := mockedGithubClient.GetDefaultRepositoryBranch(
+		context.Background(),
+		mockedCodeReview.Base.Repo.Owner,
+		mockedCodeReview.Base.Repo.Name,
+	)
+
+	assert.Equal(t, expectedDefaultBranch, defaultBranch)
+	assert.Nil(t, err)
+}
+
+func TestDownloadContents_WhenInvalidDownloadMethodIsProvided(t *testing.T) {
+	mockedCodeReview := aladino.GetDefaultPullRequestDetails()
+
+	mockedGithubClient := aladino.MockDefaultGithubClient(
+		nil,
+		nil,
+	)
+
+	contents, err := mockedGithubClient.DownloadContents(
+		context.Background(),
+		"test/crawler.go",
+		&pbc.Branch{
+			Repo: &pbc.Repository{
+				Owner: mockedCodeReview.Base.Repo.Owner,
+				Name:  mockedCodeReview.Base.Repo.Name,
+			},
+		},
+		&gh.DownloadContentsOptions{
+			Method: "invalid",
+		},
+	)
+
+	assert.Nil(t, contents)
+	assert.Equal(t, err.Error(), "invalid download method specified")
+}
+
+func TestDownloadContents_WhenDownloadContentsRequestFails(t *testing.T) {
+	failMessage := "DownloadContentsRequestFail"
+
+	mockedPRRepoOwner := aladino.DefaultMockPrOwner
+	mockedPRRepoName := aladino.DefaultMockPrRepoName
+	mockedPRNumber := aladino.DefaultMockPrNum
+	mockedPRUrl := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls/%d", mockedPRRepoOwner, mockedPRRepoName, mockedPRNumber)
+	mockedPRBaseSHA := "abc123"
+	mockedPRBaseBranchName := "master"
+
+	mockedCodeReview := aladino.GetDefaultMockPullRequestDetailsWith(&pbc.PullRequest{
+		Base: &pbc.Branch{
+			Repo: &pbc.Repository{
+				Owner: mockedPRRepoOwner,
+				Uri:   mockedPRUrl,
+				Name:  mockedPRRepoName,
+			},
+			Name: mockedPRBaseBranchName,
+			Sha:  mockedPRBaseSHA,
+		},
+	})
+
+	mockedPatchFilePath := "test/crawler.go"
+
+	mockedFiles := []*pbc.File{
+		{Filename: mockedPatchFilePath},
+	}
+
+	mockedEnv := aladino.MockDefaultEnvWithPullRequestAndFiles(
+		t,
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposContentsByOwnerByRepoByPath,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mock.WriteError(
+						w,
+						http.StatusInternalServerError,
+						failMessage,
+					)
+				}),
+			),
+		},
+		nil,
+		mockedCodeReview,
+		mockedFiles,
+		aladino.MockBuiltIns(),
+		nil,
+	)
+
+	contents, err := mockedEnv.GetGithubClient().DownloadContents(
+		context.Background(),
+		mockedPatchFilePath,
+		mockedCodeReview.Base,
+		&gh.DownloadContentsOptions{
+			Method: gh.DownloadMethodSHA,
+		},
+	)
+
+	assert.Nil(t, contents)
+	assert.Equal(t, err.(*github.ErrorResponse).Message, failMessage)
+}
+
+func TestDownloadContents(t *testing.T) {
+	mockedPRRepoOwner := aladino.DefaultMockPrOwner
+	mockedPRRepoName := aladino.DefaultMockPrRepoName
+	mockedPRNumber := aladino.DefaultMockPrNum
+	mockedPRUrl := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls/%d", mockedPRRepoOwner, mockedPRRepoName, mockedPRNumber)
+	mockedPRBaseSHA := "abc123"
+	mockedPRBaseBranchName := "master"
+
+	mockedCodeReview := aladino.GetDefaultMockPullRequestDetailsWith(&pbc.PullRequest{
+		Base: &pbc.Branch{
+			Repo: &pbc.Repository{
+				Owner: mockedPRRepoOwner,
+				Uri:   mockedPRUrl,
+				Name:  mockedPRRepoName,
+			},
+			Name: mockedPRBaseBranchName,
+			Sha:  mockedPRBaseSHA,
+		},
+	})
+
+	mockedPatchFilePath := "test"
+	mockedPatchFileName := "crawler.go"
+	mockedPatchFileRelativeName := fmt.Sprintf("%s/crawler.go", mockedPatchFilePath)
+	mockedPatchLocation := fmt.Sprintf("/%s/%s/%s", mockedPRRepoOwner, mockedPRRepoName, mockedPatchFileName)
+
+	mockedFiles := []*pbc.File{
+		{Filename: mockedPatchFileRelativeName},
+	}
+
+	mockedBlob := "test-blob"
+	expectedContents := []byte(string("\"" + mockedBlob + "\""))
+
+	mockedEnv := aladino.MockDefaultEnvWithPullRequestAndFiles(
+		t,
+		[]mock.MockBackendOption{
+			mock.WithRequestMatchHandler(
+				mock.GetReposContentsByOwnerByRepoByPath,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					utils.MustWriteBytes(w, mock.MustMarshal([]github.RepositoryContent{
+						{
+							Name:        github.String(mockedPatchFileName),
+							Path:        github.String(mockedPatchFilePath),
+							DownloadURL: github.String(fmt.Sprintf("https://raw.githubusercontent.com/%s", mockedPatchLocation)),
+						},
+					}))
+				}),
+			),
+			mock.WithRequestMatch(
+				mock.EndpointPattern{
+					Pattern: mockedPatchLocation,
+					Method:  "GET",
+				},
+				mockedBlob,
+			),
+		},
+		nil,
+		mockedCodeReview,
+		mockedFiles,
+		aladino.MockBuiltIns(),
+		nil,
+	)
+
+	contents, err := mockedEnv.GetGithubClient().DownloadContents(
+		context.Background(),
+		mockedPatchFileRelativeName,
+		mockedCodeReview.Base,
+		&gh.DownloadContentsOptions{
+			Method: gh.DownloadMethodBranchName,
+		},
+	)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedContents, contents)
+}


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Jun 23 13:50 UTC
This pull request adds unit tests for `repositories.go` file under `github` package in `codehost`. The tests cover `GetDefaultRepositoryBranch` and `DownloadContents` functions. The tests also include error scenarios to ensure proper handling.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 459c099</samp>

Add unit tests for GitHub codehost package. The tests cover the methods for getting the default branch and downloading file contents from a GitHub repository. The tests use a mock library to simulate the GitHub API responses.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require a code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 459c099</samp>

* Add unit tests for `GetDefaultRepositoryBranch` and `DownloadContents` methods of `GithubClient` struct ([link](https://github.com/reviewpad/reviewpad/pull/936/files?diff=unified&w=0#diff-308d7af0bf395d25bd5b5c261e8a9b45a154dc7710c8aea39058d09495990152R1-R238))
* Add license header and package imports to `repositories_test.go` file ([link](https://github.com/reviewpad/reviewpad/pull/936/files?diff=unified&w=0#diff-308d7af0bf395d25bd5b5c261e8a9b45a154dc7710c8aea39058d09495990152R1-R238))
