### PR TITLE
fix: filter reviews by code authors eligible to receive review requests

### DIFF
--- a/plugins/aladino/actions/assignCodeAuthorReviewers_test.go
+++ b/plugins/aladino/actions/assignCodeAuthorReviewers_test.go
@@ -100,11 +100,80 @@ func TestAssignCodeAuthorReviewerCode(t *testing.T) {
 							Body:  github.String("body"),
 							State: github.String("APPROVED"),
 							User: &github.User{
-								Login: github.String("test"),
+								Login: github.String("reviewpad[bot]"),
 							},
 						},
 					},
 				),
+			},
+			graphQLHandler: func(w http.ResponseWriter, r *http.Request) {
+				graphQLQuery := utils.MustRead(r.Body)
+				if utils.MinifyQuery(getOpenPullRequestsAsReviewerQuery) == utils.MinifyQuery(graphQLQuery) {
+					utils.MustWrite(w, `{
+						"data": {
+							"repository": {
+								"pullRequests": {
+									"nodes": []
+								}
+							}
+						}
+					}`)
+					return
+				}
+
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"object": {
+								"blame0": {
+									"ranges": [
+										{
+											"startingLine": 1,
+											"endingLine": 10,
+											"commit": {
+												"author": {
+													"user": {
+														"login": "reviewpad[bot]"
+													}
+												}
+											}
+										}
+									]
+								},
+								"blame1": {
+									"ranges": [
+										{
+											"startingLine": 1,
+											"endingLine": 5,
+											"commit": {
+												"author": {
+													"user": {
+														"login": "reviewpad[bot]"
+													}
+												}
+											}
+										}
+									]
+								},
+								"blame3": {
+									"ranges": [
+										{
+											"startingLine": 1,
+											"endingLine": 10,
+											"commit": {
+												"author": {
+													"user": {
+														"login": "reviewpad[bot]"
+													}
+												}
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
 			},
 			mockedFileList: aladino.GetDefaultPullRequestFileList(),
 		},


### PR DESCRIPTION
## Description

Closes #938.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Jun 23 15:28 UTC
This pull request adds a fix to filter reviews by code authors that are eligible to receive review requests. It also includes an update to the unit tests.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98845ba</samp>

This pull request enhances the aladino plugin to exclude the reviewpad bot and other specified users from being assigned as code author reviewers. It also adds more test coverage and refactors some code for better performance and readability. The main changes are in `plugins/aladino/actions/assignCodeAuthorReviewers.go` and `plugins/aladino/actions/assignCodeAuthorReviewers_test.go`.

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before the merge

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 98845ba</samp>

* Move the call to `getAuthorsFromGitBlame` before filtering the reviews to avoid unnecessary API calls ([link](https://github.com/reviewpad/reviewpad/pull/939/files?diff=unified&w=0#diff-acd9551bb4313dcc36ef244051ab652050f97e37e9a907c5bfbccc9f171a90d0L54-R60))
* Filter out the reviews submitted by the users to exclude from review requests, such as the reviewpad bot, using the `filterReviewsByNonExcludedCodeAuthors` function ([link](https://github.com/reviewpad/reviewpad/pull/939/files?diff=unified&w=0#diff-acd9551bb4313dcc36ef244051ab652050f97e37e9a907c5bfbccc9f171a90d0L62-R68), [link](https://github.com/reviewpad/reviewpad/pull/939/files?diff=unified&w=0#diff-acd9551bb4313dcc36ef244051ab652050f97e37e9a907c5bfbccc9f171a90d0R223-R233))
* Remove the redundant call to `getAuthorsFromGitBlame` after filtering the reviews ([link](https://github.com/reviewpad/reviewpad/pull/939/files?diff=unified&w=0#diff-acd9551bb4313dcc36ef244051ab652050f97e37e9a907c5bfbccc9f171a90d0L82-L87))
* Update the test case for `assignCodeAuthorReviewersCode` to use the reviewpad bot as the pull request author and reviewer, and mock the GraphQL handler to return the blame information ([link](https://github.com/reviewpad/reviewpad/pull/939/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aL103-R103), [link](https://github.com/reviewpad/reviewpad/pull/939/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR109-R177))
