### PR TITLE
feat: add pr/issue to project if it doesnt exist on project with `$setProjectField`

### DIFF
--- a/codehost/github/projects.go
+++ b/codehost/github/projects.go
@@ -125,11 +125,6 @@ type GetIssueProjectItemsQuery struct {
 	} `graphql:"repository(owner: $owner, name: $name)"`
 }
 
-type GQLProjectColumn struct {
-	ID   string
-	Name string
-}
-
 func (c *GithubClient) GetProjectV2ByName(ctx context.Context, owner, repo, name string) (*ProjectV2, error) {
 	// Warning: we've faced trouble before with the Github GraphQL API, we'll update this later when we find a better alternative.
 	// We request the first 50 projects since GitHub can return several projects  with a partially matching name.

--- a/codehost/github/projects.go
+++ b/codehost/github/projects.go
@@ -125,6 +125,25 @@ type GetIssueProjectItemsQuery struct {
 	} `graphql:"repository(owner: $owner, name: $name)"`
 }
 
+type GetProjectColumnsQuery struct {
+	Repository struct {
+		Project struct {
+			Columns struct {
+				PageInfo PageInfo
+				Nodes    []struct {
+					ID   string
+					Name string
+				}
+			} `graphql:"columns(first: 100, after: $afterCursor)"`
+		} `graphql:"project(number: $number)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+type GQLProjectColumn struct {
+	ID   string
+	Name string
+}
+
 func (c *GithubClient) GetProjectV2ByName(ctx context.Context, owner, repo, name string) (*ProjectV2, error) {
 	// Warning: we've faced trouble before with the Github GraphQL API, we'll update this later when we find a better alternative.
 	// We request the first 50 projects since GitHub can return several projects  with a partially matching name.
@@ -282,4 +301,35 @@ func (c *GithubClient) DeleteProjectV2Item(ctx context.Context, projectID, itemI
 	}
 
 	return c.clientGQL.Mutate(ctx, &deleteProjectV2ItemMutation, deleteProjectV2ItemMutationInput, nil)
+}
+
+func (c *GithubClient) GetProjectColumns(ctx context.Context, owner, repo string, projectNumber uint64) ([]GQLProjectColumn, error) {
+	var getProjectColumnsQuery GetProjectColumnsQuery
+	varGQLGetProjectColumnsQuery := map[string]interface{}{
+		"owner":       githubv4.String(owner),
+		"name":        githubv4.String(repo),
+		"number":      githubv4.Int(projectNumber),
+		"afterCursor": githubv4.String(""),
+	}
+
+	var columns []GQLProjectColumn
+	for {
+		if err := c.clientGQL.Query(ctx, &getProjectColumnsQuery, varGQLGetProjectColumnsQuery); err != nil {
+			return nil, err
+		}
+
+		// Since a single issue can be associated with multiple projects, we need to find the project item ID
+		// that matches the project ID we're looking for.
+		for _, node := range getProjectColumnsQuery.Repository.Project.Columns.Nodes {
+			columns = append(columns, GQLProjectColumn{ID: node.ID, Name: node.Name})
+		}
+
+		if !getProjectColumnsQuery.Repository.Project.Columns.PageInfo.HasNextPage {
+			break
+		}
+
+		varGQLGetProjectColumnsQuery["afterCursor"] = githubv4.String(getProjectColumnsQuery.Repository.Project.Columns.PageInfo.EndCursor)
+	}
+
+	return columns, nil
 }

--- a/codehost/github/target/common_target.go
+++ b/codehost/github/target/common_target.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/google/go-github/v52/github"
 	"github.com/reviewpad/go-lib/entities"
@@ -227,66 +226,4 @@ func (t *CommonTarget) setProjectV2Field(projectID, projectItemID string, fieldD
 	}
 
 	return t.githubClient.GetClientGraphQL().Mutate(ctx, &updateProjectV2ItemFieldValueMutation, updateInput, nil)
-}
-
-func (t *CommonTarget) SetProjectField(projectTitle, fieldName, fieldValue string) error {
-	ctx := t.ctx
-	targetEntity := t.targetEntity
-	owner := targetEntity.Owner
-	repo := targetEntity.Repo
-	number := targetEntity.Number
-
-	var err error
-	var projectItems []gh.GQLProjectV2Item
-
-	totalRequestTries := 2
-
-	if targetEntity.Kind == entities.PullRequest {
-		projectItems, err = t.githubClient.GetLinkedProjectsForPullRequest(ctx, owner, repo, number, totalRequestTries)
-	} else {
-		projectItems, err = t.githubClient.GetLinkedProjectsForIssue(ctx, owner, repo, number, totalRequestTries)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	var projectItemID string
-	var projectID string
-	var projectNumber uint64
-	foundProject := false
-
-	for _, projectItem := range projectItems {
-		if projectItem.Project.Title == projectTitle {
-			projectItemID = projectItem.ID
-			projectNumber = projectItem.Project.Number
-			projectID = projectItem.Project.ID
-			foundProject = true
-			break
-		}
-	}
-
-	if !foundProject {
-		return gh.ErrProjectNotFound
-	}
-
-	fields, err := t.githubClient.GetProjectFieldsByProjectNumber(ctx, owner, repo, projectNumber, totalRequestTries)
-	if err != nil {
-		return err
-	}
-
-	for _, field := range fields {
-		switch field.TypeName {
-		case "ProjectV2Field":
-			if strings.EqualFold(field.FieldDetails.Name, fieldName) {
-				return t.setProjectV2Field(projectID, projectItemID, field.FieldDetails, fieldValue)
-			}
-		case "ProjectV2SingleSelectField":
-			if strings.EqualFold(field.SingleSelectFieldDetails.Name, fieldName) {
-				return t.setProjectSingleSelectField(projectID, projectItemID, field.SingleSelectFieldDetails, fieldValue)
-			}
-		}
-	}
-
-	return gh.ErrProjectHasNoSuchField
 }

--- a/codehost/github/target/issue_target.go
+++ b/codehost/github/target/issue_target.go
@@ -208,3 +208,18 @@ func (target *IssueTarget) GetProjectV2ItemID(projectID string) (string, error) 
 
 	return target.githubClient.GetIssueProjectV2ItemID(ctx, owner, repo, projectID, targetEntity.Number)
 }
+
+func (t *IssueTarget) IsInProject(projectTitle string) (bool, error) {
+	projectItems, err := t.GetLinkedProjects()
+	if err != nil {
+		return false, err
+	}
+
+	for _, projectItem := range projectItems {
+		if projectItem.Project.Title == projectTitle {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/codehost/github/target/issue_target.go
+++ b/codehost/github/target/issue_target.go
@@ -245,3 +245,56 @@ func (t *IssueTarget) AddToProject(projectID string) (string, error) {
 
 	return addProjectV2ItemByIdMutation.AddProjectV2ItemById.Item.Id, nil
 }
+
+func (t *IssueTarget) SetProjectField(projectTitle, fieldName, fieldValue string) error {
+	ctx := t.ctx
+	targetEntity := t.targetEntity
+	owner := targetEntity.Owner
+	repo := targetEntity.Repo
+
+	totalRequestTries := 2
+
+	projectItems, err := t.GetLinkedProjects()
+	if err != nil {
+		return err
+	}
+
+	var projectItemID string
+	var projectID string
+	var projectNumber uint64
+	foundProject := false
+
+	for _, projectItem := range projectItems {
+		if projectItem.Project.Title == projectTitle {
+			projectItemID = projectItem.ID
+			projectNumber = projectItem.Project.Number
+			projectID = projectItem.Project.ID
+			foundProject = true
+			break
+		}
+	}
+
+	if !foundProject {
+		return gh.ErrProjectNotFound
+	}
+
+	fields, err := t.githubClient.GetProjectFieldsByProjectNumber(ctx, owner, repo, projectNumber, totalRequestTries)
+	if err != nil {
+		return err
+	}
+
+	for _, field := range fields {
+		switch field.TypeName {
+		case "ProjectV2Field":
+			if strings.EqualFold(field.FieldDetails.Name, fieldName) {
+				return t.setProjectV2Field(projectID, projectItemID, field.FieldDetails, fieldValue)
+			}
+		case "ProjectV2SingleSelectField":
+			if strings.EqualFold(field.SingleSelectFieldDetails.Name, fieldName) {
+				return t.setProjectSingleSelectField(projectID, projectItemID, field.SingleSelectFieldDetails, fieldValue)
+			}
+		}
+	}
+
+	return gh.ErrProjectHasNoSuchField
+}

--- a/codehost/github/target/issue_target.go
+++ b/codehost/github/target/issue_target.go
@@ -223,3 +223,25 @@ func (t *IssueTarget) IsInProject(projectTitle string) (bool, error) {
 
 	return false, nil
 }
+
+func (t *IssueTarget) AddToProject(projectID string) (string, error) {
+	var addProjectV2ItemByIdMutation struct {
+		AddProjectV2ItemById struct {
+			Item struct {
+				Id string
+			}
+		} `graphql:"addProjectV2ItemById(input: $input)"`
+	}
+
+	input := gh.AddProjectV2ItemByIdInput{
+		ProjectID: projectID,
+		ContentID: t.issue.GetNodeID(),
+	}
+
+	err := t.githubClient.GetClientGraphQL().Mutate(t.ctx, &addProjectV2ItemByIdMutation, input, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return addProjectV2ItemByIdMutation.AddProjectV2ItemById.Item.Id, nil
+}

--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -566,3 +566,25 @@ func (t *PullRequestTarget) IsInProject(projectTitle string) (bool, error) {
 
 	return false, nil
 }
+
+func (t *PullRequestTarget) AddToProject(projectID string) (string, error) {
+	var addProjectV2ItemByIdMutation struct {
+		AddProjectV2ItemById struct {
+			Item struct {
+				Id string
+			}
+		} `graphql:"addProjectV2ItemById(input: $input)"`
+	}
+
+	input := gh.AddProjectV2ItemByIdInput{
+		ProjectID: projectID,
+		ContentID: t.PullRequest.GetId(),
+	}
+
+	err := t.githubClient.GetClientGraphQL().Mutate(t.ctx, &addProjectV2ItemByIdMutation, input, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return addProjectV2ItemByIdMutation.AddProjectV2ItemById.Item.Id, nil
+}

--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -551,3 +551,18 @@ func (target *PullRequestTarget) GetLatestApprovedReviews() ([]string, error) {
 
 	return approvedBy, nil
 }
+
+func (t *PullRequestTarget) IsInProject(projectTitle string) (bool, error) {
+	projectItems, err := t.GetLinkedProjects()
+	if err != nil {
+		return false, err
+	}
+
+	for _, projectItem := range projectItems {
+		if projectItem.Project.Title == projectTitle {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/codehost/target.go
+++ b/codehost/target.go
@@ -44,6 +44,7 @@ type Target interface {
 	JSON() (string, error)
 	GetProjectV2ItemID(projectID string) (string, error)
 	IsInProject(projectTitle string) (bool, error)
+	AddToProject(projectID string) (string, error)
 }
 
 type User struct {

--- a/codehost/target.go
+++ b/codehost/target.go
@@ -40,9 +40,10 @@ type Target interface {
 	GetTitle() string
 	IsLinkedToProject(title string) (bool, error)
 	RemoveLabel(labelName string) error
-	SetProjectField(projectItems []gh.GQLProjectV2Item, projectTitle, fieldName, fieldValue string) error
+	SetProjectField(projectTitle, fieldName, fieldValue string) error
 	JSON() (string, error)
 	GetProjectV2ItemID(projectID string) (string, error)
+	IsInProject(projectTitle string) (bool, error)
 }
 
 type User struct {

--- a/plugins/aladino/actions/addToProject_test.go
+++ b/plugins/aladino/actions/addToProject_test.go
@@ -155,22 +155,6 @@ func TestAddToProject(t *testing.T) {
 			expectedError:         io.EOF,
 		},
 		{
-			name:                  "when project has no status field",
-			getProjectQuery:       mockedGetProjectQuery,
-			getProjectQueryBody:   `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1, "title": "reviewpad"}]}}}}`,
-			getProjectFieldsQuery: mockedGetProjectFieldsQuery,
-			getProjectFieldsBody:  `{"data": {"repository":{"projectV2": {"fields": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": []}}}}}`,
-			expectedError:         gh.ErrProjectHasNoStatusField,
-		},
-		{
-			name:                  "when project status option is not found",
-			getProjectQuery:       mockedGetProjectQuery,
-			getProjectQueryBody:   `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1, "title": "reviewpad"}]}}}}`,
-			getProjectFieldsQuery: mockedGetProjectFieldsQuery,
-			getProjectFieldsBody:  `{"data": {"repository":{"projectV2": {"fields": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [{"id": "1", "name": "status", "options": []}]}}}}}`,
-			expectedError:         gh.ErrProjectStatusNotFound,
-		},
-		{
 			name:                         "add project item error",
 			getProjectQuery:              mockedGetProjectQuery,
 			getProjectQueryBody:          `{"data": {"repository":{"projectsV2":{"nodes":[{"id": "1", "number": 1, "title": "reviewpad"}]}}}}`,

--- a/plugins/aladino/actions/setProjectField.go
+++ b/plugins/aladino/actions/setProjectField.go
@@ -25,7 +25,6 @@ func setProjectField(e aladino.Env, args []lang.Value) error {
 	target := e.GetTarget()
 
 	var foundProject bool
-	var projectNumber uint64
 
 	projectItems, err := target.GetLinkedProjects()
 	if err != nil {
@@ -34,19 +33,13 @@ func setProjectField(e aladino.Env, args []lang.Value) error {
 
 	for _, projectItem := range projectItems {
 		if projectItem.Project.Title == projectTitle {
-			projectNumber = projectItem.Project.Number
 			foundProject = true
 			break
 		}
 	}
 
 	if !foundProject {
-		projectColumns, err := e.GetGithubClient().GetProjectColumns(e.GetCtx(), target.GetTargetEntity().Owner, target.GetTargetEntity().Repo, projectNumber)
-		if err != nil {
-			return err
-		}
-
-		err = addToProjectCode(e, []lang.Value{args[0], &lang.StringValue{Val: projectColumns[0].Name}})
+		err = addToProjectCode(e, []lang.Value{args[0], &lang.StringValue{Val: ""}})
 		if err != nil {
 			return err
 		}

--- a/plugins/aladino/actions/setProjectField.go
+++ b/plugins/aladino/actions/setProjectField.go
@@ -6,7 +6,6 @@ package plugins_aladino_actions
 
 import (
 	"github.com/reviewpad/go-lib/entities"
-	gh "github.com/reviewpad/reviewpad/v4/codehost/github"
 	"github.com/reviewpad/reviewpad/v4/lang"
 	"github.com/reviewpad/reviewpad/v4/lang/aladino"
 )
@@ -25,28 +24,17 @@ func setProjectField(e aladino.Env, args []lang.Value) error {
 	fieldValue := args[2].(*lang.StringValue).Val
 	target := e.GetTarget()
 
-	foundProject := true
-
-	_, err := e.GetGithubClient().GetProjectV2ByName(e.GetCtx(), target.GetTargetEntity().Owner, target.GetTargetEntity().Repo, projectTitle)
+	isInProject, err := target.IsInProject(projectTitle)
 	if err != nil {
-		if err == gh.ErrProjectNotFound {
-			foundProject = false
-		} else {
-			return err
-		}
+		return err
 	}
 
-	if !foundProject {
+	if !isInProject {
 		err = addToProjectCode(e, []lang.Value{args[0], &lang.StringValue{Val: ""}})
 		if err != nil {
 			return err
 		}
 	}
 
-	projectItems, err := target.GetLinkedProjects()
-	if err != nil {
-		return err
-	}
-
-	return target.SetProjectField(projectItems, projectTitle, fieldName, fieldValue)
+	return target.SetProjectField(projectTitle, fieldName, fieldValue)
 }

--- a/plugins/aladino/actions/setProjectField_test.go
+++ b/plugins/aladino/actions/setProjectField_test.go
@@ -660,7 +660,7 @@ func getMockedProjectFieldsByProjectNumberGraphQLQuery(mockedPRRepoName, mockedP
 }
 
 func getMockedUpdateProjectV2ItemFieldValueMutation() string {
-	return fmt.Sprintf(`{
+	return `{
 		"query": "mutation($input: UpdateProjectV2ItemFieldValueInput!) {
 			updateProjectV2ItemFieldValue(input: $input) {
 				clientMutationId
@@ -676,5 +676,5 @@ func getMockedUpdateProjectV2ItemFieldValueMutation() string {
 				"fieldId":"test"
 			}
 		}
-	}`)
+	}`
 }

--- a/plugins/aladino/actions/setProjectField_test.go
+++ b/plugins/aladino/actions/setProjectField_test.go
@@ -1,0 +1,680 @@
+// Copyright (C) 2023 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_actions_test
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v4/plugins/aladino"
+	"github.com/reviewpad/reviewpad/v4/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var setProjectField = plugins_aladino.PluginBuiltIns().Actions["setProjectField"].Code
+
+func TestSetProjectField_WhenGetLinkedProjectsRequestFails(t *testing.T) {
+	failMessageForPullRequest := "GetLinkedProjectsForPullRequestRequestFail"
+	failMessageForIssue := "GetLinkedProjectsForIssueRequestFail"
+
+	mockedPRRepoName := aladino.DefaultMockPrRepoName
+	mockedPRNum := aladino.DefaultMockPrNum
+	mockedPROwner := aladino.DefaultMockPrOwner
+
+	mockedGetLinkedProjectsForPullRequestGraphQLQuery := getMockedGetLinkedProjectsForPullRequestGraphQLQuery(mockedPRNum, mockedPRRepoName, mockedPROwner)
+
+	mockedGetLinkedProjectsForIssueGraphQLQuery := getMockedGetLinkedProjectsForIssueGraphQLQuery(mockedPRNum, mockedPRRepoName, mockedPROwner)
+
+	tests := map[string]struct {
+		mockedEnv aladino.Env
+		wantErr   string
+	}{
+		"when get linked projects for pull request fails": {
+			mockedEnv: aladino.MockDefaultEnvWithTargetEntity(
+				t,
+				nil,
+				func(w http.ResponseWriter, req *http.Request) {
+					query := utils.MinifyQuery(utils.MustRead(req.Body))
+					switch query {
+					case utils.MinifyQuery(mockedGetLinkedProjectsForPullRequestGraphQLQuery):
+						http.Error(w, failMessageForPullRequest, http.StatusNotFound)
+					}
+				},
+				aladino.MockBuiltIns(),
+				nil,
+				&entities.TargetEntity{
+					Owner:  aladino.DefaultMockPrOwner,
+					Repo:   aladino.DefaultMockPrRepoName,
+					Number: aladino.DefaultMockPrNum,
+					Kind:   entities.PullRequest,
+				},
+			),
+			wantErr: fmt.Sprintf("non-200 OK status code: 404 Not Found body: \"%s\\n\"", failMessageForPullRequest),
+		},
+		"when get linked projects for issue fails": {
+			mockedEnv: aladino.MockDefaultEnvWithTargetEntity(
+				t,
+				nil,
+				func(w http.ResponseWriter, req *http.Request) {
+					query := utils.MinifyQuery(utils.MustRead(req.Body))
+					switch query {
+					case utils.MinifyQuery(mockedGetLinkedProjectsForIssueGraphQLQuery):
+						http.Error(w, failMessageForIssue, http.StatusNotFound)
+					}
+				},
+				aladino.MockBuiltIns(),
+				nil,
+				&entities.TargetEntity{
+					Owner:  aladino.DefaultMockPrOwner,
+					Repo:   aladino.DefaultMockPrRepoName,
+					Number: aladino.DefaultMockPrNum,
+					Kind:   entities.Issue,
+				},
+			),
+			wantErr: fmt.Sprintf("non-200 OK status code: 404 Not Found body: \"%s\\n\"", failMessageForIssue),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			args := []lang.Value{lang.BuildStringValue("reviewpad"), lang.BuildStringValue("size"), lang.BuildStringValue("50")}
+			gotErr := setProjectField(test.mockedEnv, args)
+
+			assert.EqualError(t, gotErr, test.wantErr)
+		})
+	}
+}
+
+func TestSetProjectField_WhenEntityIsInProject(t *testing.T) {
+	mockedPRRepoName := aladino.DefaultMockPrRepoName
+	mockedPRNum := aladino.DefaultMockPrNum
+	mockedPROwner := aladino.DefaultMockPrOwner
+
+	mockedGetLinkedProjectsForPullRequestGraphQLQuery := getMockedGetLinkedProjectsForPullRequestGraphQLQuery(mockedPRNum, mockedPRRepoName, mockedPROwner)
+
+	mockedGetLinkedProjectsForPullRequestGraphQLQueryBody := `{
+		"data": {
+				"repository": {
+				"pullRequest": {
+					"projectItems": {
+						"nodes": [
+							{
+								"id": "test",
+								"project": {
+									"id": "test",
+									"number": 1,
+									"title": "test"
+								}
+							}
+						]
+					}
+				}
+			}
+		}
+	}`
+
+	mockedGetLinkedProjectsForIssueGraphQLQuery := getMockedGetLinkedProjectsForIssueGraphQLQuery(mockedPRNum, mockedPRRepoName, mockedPROwner)
+
+	mockedGetLinkedProjectsForIssueGraphQLQueryBody := `{
+		"data": {
+				"repository": {
+				"issue": {
+					"projectItems": {
+						"nodes": [
+							{
+								"id": "test",
+								"project": {
+									"id": "test",
+									"number": 1,
+									"title": "test"
+								}
+							}
+						]
+					}
+				}
+			}
+		}
+	}`
+
+	mockedGetProjectFieldsByProjectNumberGraphQLQuery := getMockedProjectFieldsByProjectNumberGraphQLQuery(mockedPRRepoName, mockedPROwner)
+
+	mockedSetProjectSingleSelectFieldMutation := getMockedUpdateProjectV2ItemFieldValueMutation()
+
+	mockedGetProjectFieldsByProjectNumberGraphQLQueryBody := `{
+		"data": {
+			"repository": {
+				"projectV2": {
+					"fields": {
+						"nodes": [
+							{
+								"__typename": "ProjectV2SingleSelectField",
+								"id": "test",
+								"name": "size",
+								"options": [
+									{
+										"id": "test",
+										"name": "50"
+									}
+								]
+							}
+						]
+					}
+				}
+			}
+		}
+	}`
+
+	mockedSetProjectSingleSelectFieldMutationBody := `{
+		"data": {
+			"updateProjectV2ItemFieldValue": {
+				"clientMutationId": "test"
+			}
+		}
+	}`
+
+	tests := map[string]struct {
+		mockedEnv aladino.Env
+		wantErr   string
+	}{
+		"when pull request is already in the project": {
+			mockedEnv: aladino.MockDefaultEnvWithTargetEntity(
+				t,
+				nil,
+				func(w http.ResponseWriter, req *http.Request) {
+					query := utils.MinifyQuery(utils.MustRead(req.Body))
+					log.Printf("query: %s", query)
+					log.Printf("mockedSetProjectSingleSelectFieldMutation: %s", utils.MinifyQuery(mockedSetProjectSingleSelectFieldMutation))
+					switch query {
+					case utils.MinifyQuery(mockedGetLinkedProjectsForPullRequestGraphQLQuery):
+						utils.MustWrite(w, mockedGetLinkedProjectsForPullRequestGraphQLQueryBody)
+					case utils.MinifyQuery(mockedGetProjectFieldsByProjectNumberGraphQLQuery):
+						utils.MustWrite(w, mockedGetProjectFieldsByProjectNumberGraphQLQueryBody)
+					case utils.MinifyQuery(mockedSetProjectSingleSelectFieldMutation):
+						utils.MustWrite(w, mockedSetProjectSingleSelectFieldMutationBody)
+					}
+				},
+				aladino.MockBuiltIns(),
+				nil,
+				&entities.TargetEntity{
+					Owner:  aladino.DefaultMockPrOwner,
+					Repo:   aladino.DefaultMockPrRepoName,
+					Number: aladino.DefaultMockPrNum,
+					Kind:   entities.PullRequest,
+				},
+			),
+		},
+		"when issue is already in the project": {
+			mockedEnv: aladino.MockDefaultEnvWithTargetEntity(
+				t,
+				nil,
+				func(w http.ResponseWriter, req *http.Request) {
+					query := utils.MinifyQuery(utils.MustRead(req.Body))
+					switch query {
+					case utils.MinifyQuery(mockedGetLinkedProjectsForIssueGraphQLQuery):
+						utils.MustWrite(w, mockedGetLinkedProjectsForIssueGraphQLQueryBody)
+					case utils.MinifyQuery(mockedGetProjectFieldsByProjectNumberGraphQLQuery):
+						utils.MustWrite(w, mockedGetProjectFieldsByProjectNumberGraphQLQueryBody)
+					case utils.MinifyQuery(mockedSetProjectSingleSelectFieldMutation):
+						utils.MustWrite(w, mockedSetProjectSingleSelectFieldMutationBody)
+					}
+				},
+				aladino.MockBuiltIns(),
+				nil,
+				&entities.TargetEntity{
+					Owner:  aladino.DefaultMockPrOwner,
+					Repo:   aladino.DefaultMockPrRepoName,
+					Number: aladino.DefaultMockPrNum,
+					Kind:   entities.Issue,
+				},
+			),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			args := []lang.Value{lang.BuildStringValue("test"), lang.BuildStringValue("size"), lang.BuildStringValue("50")}
+			gotErr := setProjectField(test.mockedEnv, args)
+
+			assert.Nil(t, gotErr)
+		})
+	}
+}
+
+func TestSetProjectField_WhenSetProjectFieldFails(t *testing.T) {
+	mockedPRRepoName := aladino.DefaultMockPrRepoName
+	mockedPRNum := aladino.DefaultMockPrNum
+	mockedPROwner := aladino.DefaultMockPrOwner
+
+	mockedGetLinkedProjectsForPullRequestGraphQLQuery := getMockedGetLinkedProjectsForPullRequestGraphQLQuery(mockedPRNum, mockedPRRepoName, mockedPROwner)
+
+	mockedGetLinkedProjectsForPullRequestGraphQLQueryBody := `{
+		"data": {
+			"repository": {
+				"pullRequest": {
+					"projectItems": {
+						"nodes": [
+							{
+								"id": "test",
+								"project": {
+									"id": "test",
+									"number": 1,
+									"title": "test"
+								}
+							}
+						]
+					}
+				}
+			}
+		}
+	}`
+
+	mockedGetLinkedProjectsForIssueGraphQLQuery := getMockedGetLinkedProjectsForIssueGraphQLQuery(mockedPRNum, mockedPRRepoName, mockedPROwner)
+
+	mockedGetLinkedProjectsForIssueGraphQLQueryBody := `{
+		"data": {
+			"repository": {
+				"issue": {
+					"projectItems": {
+						"nodes": [
+							{
+								"id": "test",
+								"project": {
+									"id": "test",
+									"number": 1,
+									"title": "test"
+								}
+							}
+						]
+					}
+				}
+			}
+		}
+	}`
+
+	mockedGetProjectFieldsByProjectNumberGraphQLQuery := getMockedProjectFieldsByProjectNumberGraphQLQuery(mockedPRRepoName, mockedPROwner)
+
+	mockedGetProjectFieldsByProjectNumberGraphQLQueryBody := `{
+		"data": {
+			"repository": {
+				"projectV2": {
+					"fields": {
+						"nodes": [
+							{
+								"__typename": "ProjectV2SingleSelectField",
+								"id": "test",
+								"name": "size",
+								"options": [
+									{
+										"id": "test",
+										"name": "50"
+									}
+								]
+							}
+						]
+					}
+				}
+			}
+		}
+	}`
+
+	mockedSetProjectSingleSelectFieldMutation := getMockedUpdateProjectV2ItemFieldValueMutation()
+
+	tests := map[string]struct {
+		mockedEnv aladino.Env
+		wantErr   string
+	}{
+		"when set project field for pull request fails because the request to get the project fields by project number fails": {
+			mockedEnv: aladino.MockDefaultEnvWithTargetEntity(
+				t,
+				nil,
+				func(w http.ResponseWriter, req *http.Request) {
+					query := utils.MinifyQuery(utils.MustRead(req.Body))
+					switch query {
+					case utils.MinifyQuery(mockedGetLinkedProjectsForPullRequestGraphQLQuery):
+						utils.MustWrite(w, mockedGetLinkedProjectsForPullRequestGraphQLQueryBody)
+					case utils.MinifyQuery(mockedGetProjectFieldsByProjectNumberGraphQLQuery):
+						http.Error(w, "GetProjectFieldsByProjectNumberRequestFail", http.StatusNotFound)
+					}
+				},
+				aladino.MockBuiltIns(),
+				nil,
+				&entities.TargetEntity{
+					Owner:  aladino.DefaultMockPrOwner,
+					Repo:   aladino.DefaultMockPrRepoName,
+					Number: aladino.DefaultMockPrNum,
+					Kind:   entities.PullRequest,
+				},
+			),
+			wantErr: "non-200 OK status code: 404 Not Found body: \"GetProjectFieldsByProjectNumberRequestFail\\n\"",
+		},
+		"when set project field for pull request fails because the request to set the project single select field fails": {
+			mockedEnv: aladino.MockDefaultEnvWithTargetEntity(
+				t,
+				nil,
+				func(w http.ResponseWriter, req *http.Request) {
+					query := utils.MinifyQuery(utils.MustRead(req.Body))
+					switch query {
+					case utils.MinifyQuery(mockedGetLinkedProjectsForPullRequestGraphQLQuery):
+						utils.MustWrite(w, mockedGetLinkedProjectsForPullRequestGraphQLQueryBody)
+					case utils.MinifyQuery(mockedGetProjectFieldsByProjectNumberGraphQLQuery):
+						utils.MustWrite(w, mockedGetProjectFieldsByProjectNumberGraphQLQueryBody)
+					case utils.MinifyQuery(mockedSetProjectSingleSelectFieldMutation):
+						http.Error(w, "SetProjectSingleSelectFieldRequestFail", http.StatusNotFound)
+					}
+				},
+				aladino.MockBuiltIns(),
+				nil,
+				&entities.TargetEntity{
+					Owner:  aladino.DefaultMockPrOwner,
+					Repo:   aladino.DefaultMockPrRepoName,
+					Number: aladino.DefaultMockPrNum,
+					Kind:   entities.PullRequest,
+				},
+			),
+			wantErr: "non-200 OK status code: 404 Not Found body: \"SetProjectSingleSelectFieldRequestFail\\n\"",
+		},
+		"when set project field for issue fails because the request to get the project fields by project number fails": {
+			mockedEnv: aladino.MockDefaultEnvWithTargetEntity(
+				t,
+				nil,
+				func(w http.ResponseWriter, req *http.Request) {
+					query := utils.MinifyQuery(utils.MustRead(req.Body))
+					switch query {
+					case utils.MinifyQuery(mockedGetLinkedProjectsForIssueGraphQLQuery):
+						utils.MustWrite(w, mockedGetLinkedProjectsForIssueGraphQLQueryBody)
+					case utils.MinifyQuery(mockedGetProjectFieldsByProjectNumberGraphQLQuery):
+						http.Error(w, "GetProjectFieldsByProjectNumberRequestFail", http.StatusNotFound)
+					}
+				},
+				aladino.MockBuiltIns(),
+				nil,
+				&entities.TargetEntity{
+					Owner:  aladino.DefaultMockPrOwner,
+					Repo:   aladino.DefaultMockPrRepoName,
+					Number: aladino.DefaultMockPrNum,
+					Kind:   entities.Issue,
+				},
+			),
+			wantErr: "non-200 OK status code: 404 Not Found body: \"GetProjectFieldsByProjectNumberRequestFail\\n\"",
+		},
+		"when set project field for issue fails because the request to set the project single select field fails": {
+			mockedEnv: aladino.MockDefaultEnvWithTargetEntity(
+				t,
+				nil,
+				func(w http.ResponseWriter, req *http.Request) {
+					query := utils.MinifyQuery(utils.MustRead(req.Body))
+					switch query {
+					case utils.MinifyQuery(mockedGetLinkedProjectsForIssueGraphQLQuery):
+						utils.MustWrite(w, mockedGetLinkedProjectsForIssueGraphQLQueryBody)
+					case utils.MinifyQuery(mockedGetProjectFieldsByProjectNumberGraphQLQuery):
+						utils.MustWrite(w, mockedGetProjectFieldsByProjectNumberGraphQLQueryBody)
+					case utils.MinifyQuery(mockedSetProjectSingleSelectFieldMutation):
+						http.Error(w, "SetProjectSingleSelectFieldRequestFail", http.StatusNotFound)
+					}
+				},
+				aladino.MockBuiltIns(),
+				nil,
+				&entities.TargetEntity{
+					Owner:  aladino.DefaultMockPrOwner,
+					Repo:   aladino.DefaultMockPrRepoName,
+					Number: aladino.DefaultMockPrNum,
+					Kind:   entities.Issue,
+				},
+			),
+			wantErr: "non-200 OK status code: 404 Not Found body: \"SetProjectSingleSelectFieldRequestFail\\n\"",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			args := []lang.Value{lang.BuildStringValue("test"), lang.BuildStringValue("size"), lang.BuildStringValue("50")}
+			gotErr := setProjectField(test.mockedEnv, args)
+
+			assert.EqualError(t, gotErr, test.wantErr)
+		})
+	}
+}
+
+func TestSetProjectField_WhenEntityIsNotInProjectAndAddToProjectFails(t *testing.T) {
+	mockedPRRepoName := aladino.DefaultMockPrRepoName
+	mockedPRNum := aladino.DefaultMockPrNum
+	mockedPROwner := aladino.DefaultMockPrOwner
+
+	mockedGetLinkedProjectsForPullRequestGraphQLQuery := getMockedGetLinkedProjectsForPullRequestGraphQLQuery(mockedPRNum, mockedPRRepoName, mockedPROwner)
+
+	mockedGetLinkedProjectsForPullRequestGraphQLQueryBody := `{
+		"data": {
+				"repository": {
+				"pullRequest": {
+					"projectItems": {
+						"nodes": []
+					}
+				}
+			}
+		}
+	}`
+
+	mockedGetLinkedProjectsForIssueGraphQLQuery := getMockedGetLinkedProjectsForIssueGraphQLQuery(mockedPRNum, mockedPRRepoName, mockedPROwner)
+
+	mockedGetLinkedProjectsForIssueGraphQLQueryBody := `{
+		"data": {
+				"repository": {
+				"issue": {
+					"projectItems": {
+						"nodes": []
+					}
+				}
+			}
+		}
+	}`
+
+	mockedGetProjectQuery := `{
+        "query":"query($name: String! $repositoryName: String! $repositoryOwner: String!) {
+            repository(owner: $repositoryOwner, name: $repositoryName) {
+                projectsV2(query: $name, first: 50, orderBy: {field: TITLE, direction: ASC}) {
+                    nodes{
+                        id,
+                        number,
+                        title
+                    }
+                }
+            }
+        }",
+        "variables":{
+            "name":"test",
+            "repositoryName":"default-mock-repo",
+            "repositoryOwner":"foobar"
+            }
+        }`
+
+	tests := map[string]struct {
+		mockedEnv aladino.Env
+		wantErr   string
+	}{
+		"when pull request is already in the project": {
+			mockedEnv: aladino.MockDefaultEnvWithTargetEntity(
+				t,
+				nil,
+				func(w http.ResponseWriter, req *http.Request) {
+					query := utils.MinifyQuery(utils.MustRead(req.Body))
+					switch query {
+					case utils.MinifyQuery(mockedGetLinkedProjectsForPullRequestGraphQLQuery):
+						utils.MustWrite(w, mockedGetLinkedProjectsForPullRequestGraphQLQueryBody)
+					case utils.MinifyQuery(mockedGetProjectQuery):
+						http.Error(w, "GetProjectV2ByName", http.StatusNotFound)
+					}
+				},
+				aladino.MockBuiltIns(),
+				nil,
+				&entities.TargetEntity{
+					Owner:  aladino.DefaultMockPrOwner,
+					Repo:   aladino.DefaultMockPrRepoName,
+					Number: aladino.DefaultMockPrNum,
+					Kind:   entities.PullRequest,
+				},
+			),
+			wantErr: "non-200 OK status code: 404 Not Found body: \"GetProjectV2ByName\\n\"",
+		},
+		"when issue is already in the project": {
+			mockedEnv: aladino.MockDefaultEnvWithTargetEntity(
+				t,
+				nil,
+				func(w http.ResponseWriter, req *http.Request) {
+					query := utils.MinifyQuery(utils.MustRead(req.Body))
+					switch query {
+					case utils.MinifyQuery(mockedGetLinkedProjectsForIssueGraphQLQuery):
+						utils.MustWrite(w, mockedGetLinkedProjectsForIssueGraphQLQueryBody)
+					case utils.MinifyQuery(mockedGetProjectQuery):
+						http.Error(w, "GetProjectV2ByName", http.StatusNotFound)
+					}
+				},
+				aladino.MockBuiltIns(),
+				nil,
+				&entities.TargetEntity{
+					Owner:  aladino.DefaultMockPrOwner,
+					Repo:   aladino.DefaultMockPrRepoName,
+					Number: aladino.DefaultMockPrNum,
+					Kind:   entities.Issue,
+				},
+			),
+			wantErr: "non-200 OK status code: 404 Not Found body: \"GetProjectV2ByName\\n\"",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			args := []lang.Value{lang.BuildStringValue("test"), lang.BuildStringValue("size"), lang.BuildStringValue("50")}
+			gotErr := setProjectField(test.mockedEnv, args)
+
+			assert.EqualError(t, gotErr, test.wantErr)
+		})
+	}
+}
+
+func getMockedGetLinkedProjectsForIssueGraphQLQuery(mockedPRNum int, mockedPRRepoName, mockedPROwner string) string {
+	return fmt.Sprintf(`{
+		"query": "query($issueNumber:Int!$projectItemsCursor:String!$repositoryName:String!$repositoryOwner:String!) {
+			repository(owner: $repositoryOwner, name: $repositoryName) {
+				issue(number: $issueNumber) {
+					projectItems(first: 10, after: $projectItemsCursor) {
+						nodes {
+							id,
+							project {
+								id,
+								number,
+								title
+							}
+						},
+						pageInfo {
+							endCursor,
+							hasNextPage
+						}
+					}
+				}
+			}
+		}",
+		"variables": {
+			"issueNumber": %d,
+			"projectItemsCursor": "",
+			"repositoryName": "%s",
+			"repositoryOwner": "%s"
+		}
+	}`, mockedPRNum, mockedPRRepoName, mockedPROwner)
+}
+
+func getMockedGetLinkedProjectsForPullRequestGraphQLQuery(mockedPRNum int, mockedPRRepoName, mockedPROwner string) string {
+	return fmt.Sprintf(`{
+		"query": "query($issueNumber:Int!$projectItemsCursor:String!$repositoryName:String!$repositoryOwner:String!) {
+			repository(owner: $repositoryOwner, name: $repositoryName) {
+				pullRequest(number: $issueNumber) {
+					projectItems(first: 10, after: $projectItemsCursor) {
+						nodes {
+							id,
+							project {
+								id,
+								number,
+								title
+							}
+						},
+						pageInfo {
+							endCursor,
+							hasNextPage
+						}
+					}
+				}
+			}
+		}",
+		"variables": {
+			"issueNumber": %d,
+			"projectItemsCursor": "",
+			"repositoryName": "%s",
+			"repositoryOwner": "%s"
+		}
+	}`, mockedPRNum, mockedPRRepoName, mockedPROwner)
+}
+
+func getMockedProjectFieldsByProjectNumberGraphQLQuery(mockedPRRepoName, mockedPROwner string) string {
+	return fmt.Sprintf(`{
+		"query": "query($afterCursor:String!$projectNumber:Int!$repositoryName:String!$repositoryOwner:String!) {
+			repository(owner: $repositoryOwner, name: $repositoryName) {
+				projectV2(number: $projectNumber) {
+					fields(first: 50, after: $afterCursor, orderBy: {field: NAME, direction: ASC}) {
+						pageInfo {
+							hasNextPage,
+							endCursor
+						},
+						nodes {
+							__typename,
+							...on ProjectV2SingleSelectField {
+								id,
+								name,
+								options {
+									id,
+									name
+								}
+							},
+							...on ProjectV2Field {
+								id,
+								name,
+								dataType
+							}
+						}
+					}
+				}
+			}
+		}",
+		"variables": {
+			"afterCursor": "",
+			"projectNumber": 1,
+			"repositoryName": "%s",
+			"repositoryOwner": "%s"
+		}
+	}`, mockedPRRepoName, mockedPROwner)
+}
+
+func getMockedUpdateProjectV2ItemFieldValueMutation() string {
+	return fmt.Sprintf(`{
+		"query": "mutation($input: UpdateProjectV2ItemFieldValueInput!) {
+			updateProjectV2ItemFieldValue(input: $input) {
+				clientMutationId
+			}
+		}",
+		"variables": {
+			"input": {
+				"itemId": "test",
+				"value": {
+					"singleSelectOptionId":"test"
+				},
+				"projectId":"test",
+				"fieldId":"test"
+			}
+		}
+	}`)
+}


### PR DESCRIPTION
## Description

Closes #782.
Closes #580.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jun 23 16:53 UTC
This pull request contains changes to multiple files related to project and issue management. Import of "strings" and the `SetProjectField` function were removed from one file, and new functions were added to two different structs across two other files. Changes to the `Target` interface were made in one file, and the function signatures were updated in another file as well. One file saw updates made to the `addToProjectCode` function. Overall, these changes seem to be aimed at improving how projects and issues are managed within the codebase.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a18f3d1</samp>

Added project integration for GitHub issues and pull requests. Refactored and improved the code for setting project fields and adding project items. Updated the target interface and the tests accordingly.

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a18f3d1</samp>

*  Remove unused `strings` package from `common_target.go` ([link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-7247ed9ca0aee28e6df945bad537947127c667f549506a56b77d37f51d58cf8fL10))
*  Move `SetProjectField` method from `CommonTarget` to `IssueTarget` and `PullRequestTarget` ([link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-7247ed9ca0aee28e6df945bad537947127c667f549506a56b77d37f51d58cf8fL231-L277), [link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-6bd999999b8d8837f984adfa57938368828a6cdb0bf836d11d600ceedb9a1282R211-R300), [link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-941cc2c2b19ac7ec6160457e465d3089df7aa23e19248596ec71396396dc7c54R555-R644))
*  Add `IsInProject` and `AddToProject` methods to `IssueTarget` and `PullRequestTarget` using GitHub GraphQL API ([link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-6bd999999b8d8837f984adfa57938368828a6cdb0bf836d11d600ceedb9a1282R211-R300), [link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-941cc2c2b19ac7ec6160457e465d3089df7aa23e19248596ec71396396dc7c54R555-R644))
*  Update `Target` interface to reflect new methods and remove `projectItems` parameter ([link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-2b858d8965a0d0b78d379596ea7cd062de20b260e230595c2623d3ca41e53553L43-R47))
*  Simplify `addToProjectCode` function by calling `AddToProject` method on target and storing project item ID ([link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-eaa44e173381b2f35ed2011999303f0063ea6cbf5e50acf4bccff740cf177050R39-R49), [link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-eaa44e173381b2f35ed2011999303f0063ea6cbf5e50acf4bccff740cf177050L70-L88), [link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-eaa44e173381b2f35ed2011999303f0063ea6cbf5e50acf4bccff740cf177050L97-R89))
*  Enhance `setProjectField` function by checking and adding target to project if needed ([link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-c048bb4a533ddcf4544de20fcaaf0017a218c8c8fb189aad0dfcbfd5568eb23eL27-R39))
*  Remove obsolete test cases for `addToProjectCode` function ([link](https://github.com/reviewpad/reviewpad/pull/943/files?diff=unified&w=0#diff-00c45df6d7ce76668a7497c6078c34d58fcbc8a69885a267ab01386f377d3936L158-L173))
