### PR TITLE
fix: consider variables in transformer functions

### DIFF
--- a/engine/transform_internal_test.go
+++ b/engine/transform_internal_test.go
@@ -23,9 +23,17 @@ func TestTransformAladinoExpression(t *testing.T) {
 			arg:     "$merge()",
 			wantVal: "$merge(\"merge\")",
 		},
+		"merge with variable": {
+			arg:     "$merge($mergeMethod)",
+			wantVal: "$merge($mergeMethod)",
+		},
 		"size": {
 			arg:     "$size()",
 			wantVal: "$size([])",
+		},
+		"size with variable": {
+			arg:     "$size($files)",
+			wantVal: "$size($files)",
 		},
 		"issueCountBy simple": {
 			arg:     "$issueCountBy(\"john\", \"open\") > 0",
@@ -34,6 +42,18 @@ func TestTransformAladinoExpression(t *testing.T) {
 		"issueCountBy": {
 			arg:     "$issueCountBy(\"john\", \"open\") > 0 && true && $issueCountBy(\"dev\") > 0",
 			wantVal: "$issueCountBy(\"john\", \"open\") > 0 && true && $issueCountBy(\"dev\", \"all\") > 0",
+		},
+		"issueCountBy with one variable": {
+			arg:     `$issueCountBy($teamMember)`,
+			wantVal: `$issueCountBy($teamMember, "all")`,
+		},
+		"issueCountBy with two variables": {
+			arg:     `$issueCountBy($teamMember, $state)`,
+			wantVal: `$issueCountBy($teamMember, $state)`,
+		},
+		"issueCountBy with last one variable": {
+			arg:     `$issueCountBy($author(), $state)`,
+			wantVal: `$issueCountBy($author(), $state)`,
 		},
 		"pullRequestCountBy simple": {
 			arg:     "$pullRequestCountBy(\"john\") > 0",
@@ -71,6 +91,18 @@ func TestTransformAladinoExpression(t *testing.T) {
 			arg:     `$pullRequestCountBy($author(), "")`,
 			wantVal: `$pullRequestCountBy($author(), "all")`,
 		},
+		"pullRequestCountBy with one variable": {
+			arg:     `$pullRequestCountBy($teamMember)`,
+			wantVal: `$pullRequestCountBy($teamMember, "all")`,
+		},
+		"pullRequestCountBy with two variables": {
+			arg:     `$pullRequestCountBy($teamMember, $state)`,
+			wantVal: `$pullRequestCountBy($teamMember, $state)`,
+		},
+		"pullRequestCountBy with last one variable": {
+			arg:     `$pullRequestCountBy($author(), $state)`,
+			wantVal: `$pullRequestCountBy($author(), $state)`,
+		},
 		"close": {
 			arg:     "$close()",
 			wantVal: `$close("", "completed")`,
@@ -95,25 +127,57 @@ func TestTransformAladinoExpression(t *testing.T) {
 			arg:     `$close("", "not_planned")`,
 			wantVal: `$close("", "not_planned")`,
 		},
-		"multiple $haveAllChecksRunCompleted with one empty": {
-			arg:     `$haveAllChecksRunCompleted() && true && $haveAllChecksRunCompleted(["build"])`,
-			wantVal: `$haveAllChecksRunCompleted([], "", []) && true && $haveAllChecksRunCompleted(["build"], "", [])`,
+		"close with one variable": {
+			arg:     "$close($closeComment)",
+			wantVal: `$close($closeComment, "completed")`,
 		},
-		"one $haveAllChecksRunCompleted with arg provided": {
+		"close with two variable": {
+			arg:     "$close($closeComment, $closeState)",
+			wantVal: `$close($closeComment, $closeState)`,
+		},
+		"close with last one variable": {
+			arg:     `$close("closing as completed", $closeState)`,
+			wantVal: `$close("closing as completed", $closeState)`,
+		},
+		"$haveAllChecksRunCompleted with arg provided": {
 			arg:     `$haveAllChecksRunCompleted(["build", "test"], "", [])`,
 			wantVal: `$haveAllChecksRunCompleted(["build", "test"], "", [])`,
 		},
-		"one $haveAllChecksRunCompleted with no arg provided": {
+		"$haveAllChecksRunCompleted with no arg provided": {
 			arg:     `$haveAllChecksRunCompleted()`,
 			wantVal: `$haveAllChecksRunCompleted([], "", [])`,
 		},
-		"one $haveAllChecksRunCompleted with no empty arg provided": {
+		"$haveAllChecksRunCompleted with no empty arg provided": {
 			arg:     `$haveAllChecksRunCompleted(["build", "test"], "success", ["skipped"])`,
 			wantVal: `$haveAllChecksRunCompleted(["build", "test"], "success", ["skipped"])`,
 		},
-		"one $haveAllChecksRunCompleted with two args provided": {
+		"$haveAllChecksRunCompleted with two args provided": {
 			arg:     `$haveAllChecksRunCompleted(["build"], "completed")`,
 			wantVal: `$haveAllChecksRunCompleted(["build"], "completed", [])`,
+		},
+		"$haveAllChecksRunCompleted with one variable": {
+			arg:     `$haveAllChecksRunCompleted($checks)`,
+			wantVal: `$haveAllChecksRunCompleted($checks, "", [])`,
+		},
+		"$haveAllChecksRunCompleted with two variables": {
+			arg:     `$haveAllChecksRunCompleted($checks, $conclusion)`,
+			wantVal: `$haveAllChecksRunCompleted($checks, $conclusion, [])`,
+		},
+		"$haveAllChecksRunCompleted with three variables": {
+			arg:     `$haveAllChecksRunCompleted($checks, $conclusion, $ignoredConclusions)`,
+			wantVal: `$haveAllChecksRunCompleted($checks, $conclusion, $ignoredConclusions)`,
+		},
+		"$haveAnyChecksRunCompleted with first variable": {
+			arg:     `$haveAnyChecksRunCompleted($checks, "success", ["skipped"])`,
+			wantVal: `$haveAnyChecksRunCompleted($checks, "success", ["skipped"])`,
+		},
+		"$haveAnyChecksRunCompleted with second variable": {
+			arg:     `$haveAnyChecksRunCompleted(["build", "test"], $conclusion, ["skipped"])`,
+			wantVal: `$haveAnyChecksRunCompleted(["build", "test"], $conclusion, ["skipped"])`,
+		},
+		"$haveAnyChecksRunCompleted with third variable": {
+			arg:     `$haveAnyChecksRunCompleted(["build", "test"], "success", $ignoredConclusions)`,
+			wantVal: `$haveAnyChecksRunCompleted(["build", "test"], "success", $ignoredConclusions)`,
 		},
 		"join empty array with empty separator": {
 			arg:     `$join([])`,
@@ -163,6 +227,22 @@ func TestTransformAladinoExpression(t *testing.T) {
 			arg:     `$sprintf("hello: %s", [$join(["test", "test2"], " - ")])`,
 			wantVal: `$sprintf("hello: %s", [$join(["test", "test2"], " - ")])`,
 		},
+		"join with one variable": {
+			arg:     `$join($joinArray)`,
+			wantVal: `$join($joinArray, " ")`,
+		},
+		"join with two variables": {
+			arg:     `$join($joinArray, $joinSeparator)`,
+			wantVal: `$join($joinArray, $joinSeparator)`,
+		},
+		"join with first variable": {
+			arg:     `$join($joinArray, ", ")`,
+			wantVal: `$join($joinArray, ", ")`,
+		},
+		"join with last variable": {
+			arg:     `$join($assignees(), $joinSeparator)`,
+			wantVal: `$join($assignees(), $joinSeparator)`,
+		},
 		"approve": {
 			arg:     `$approve()`,
 			wantVal: `$approve("")`,
@@ -174,6 +254,10 @@ func TestTransformAladinoExpression(t *testing.T) {
 		"approve with empty comment": {
 			arg:     `$approve("")`,
 			wantVal: `$approve("")`,
+		},
+		"approve with variable": {
+			arg:     `$approve($approveComment)`,
+			wantVal: `$approve($approveComment)`,
 		},
 		"assign code author reviewer empty args": {
 			arg:     `$assignCodeAuthorReviewers()`,
@@ -199,6 +283,30 @@ func TestTransformAladinoExpression(t *testing.T) {
 			arg:     `$assignCodeAuthorReviewers(1, $team("reviewers"))`,
 			wantVal: `$assignCodeAuthorReviewers(1, $team("reviewers"), 0)`,
 		},
+		"assign code author reviewer with one variable": {
+			arg:     `$assignCodeAuthorReviewers($assignCodeAuthorReviewersTotal)`,
+			wantVal: `$assignCodeAuthorReviewers($assignCodeAuthorReviewersTotal, [], 0)`,
+		},
+		"assign code author reviewer with two variables": {
+			arg:     `$assignCodeAuthorReviewers($assignCodeAuthorReviewersTotal, $excludedReviewers)`,
+			wantVal: `$assignCodeAuthorReviewers($assignCodeAuthorReviewersTotal, $excludedReviewers, 0)`,
+		},
+		"assign code author reviewer with three variables": {
+			arg:     `$assignCodeAuthorReviewers($assignCodeAuthorReviewersTotal, $excludedReviewers, $maxReviews)`,
+			wantVal: `$assignCodeAuthorReviewers($assignCodeAuthorReviewersTotal, $excludedReviewers, $maxReviews)`,
+		},
+		"assign code author reviewer with first variable": {
+			arg:     `$assignCodeAuthorReviewers($assignCodeAuthorReviewersTotal, [], 0)`,
+			wantVal: `$assignCodeAuthorReviewers($assignCodeAuthorReviewersTotal, [], 0)`,
+		},
+		"assign code author reviewer with middle variable": {
+			arg:     `$assignCodeAuthorReviewers(1, $excludedReviewers, 1)`,
+			wantVal: `$assignCodeAuthorReviewers(1, $excludedReviewers, 1)`,
+		},
+		"assign code author reviewer with last variable": {
+			arg:     `$assignCodeAuthorReviewers(1, ["john", "jane"], $maxReviews)`,
+			wantVal: `$assignCodeAuthorReviewers(1, ["john", "jane"], $maxReviews)`,
+		},
 		"has any check run completed with no args": {
 			arg:     `$hasAnyCheckRunCompleted()`,
 			wantVal: `$hasAnyCheckRunCompleted([], [])`,
@@ -214,6 +322,22 @@ func TestTransformAladinoExpression(t *testing.T) {
 		"has any check run completed with group args": {
 			arg:     `$hasAnyCheckRunCompleted($group("ignored"), $group("conclusions"))`,
 			wantVal: `$hasAnyCheckRunCompleted($group("ignored"), $group("conclusions"))`,
+		},
+		"has any check run completed with first variable": {
+			arg:     `$hasAnyCheckRunCompleted($ignoredChecks, [])`,
+			wantVal: `$hasAnyCheckRunCompleted($ignoredChecks, [])`,
+		},
+		"has any check run completed with last variable": {
+			arg:     `$hasAnyCheckRunCompleted([], $conclusionChecks)`,
+			wantVal: `$hasAnyCheckRunCompleted([], $conclusionChecks)`,
+		},
+		"has any check run completed with all variables": {
+			arg:     `$hasAnyCheckRunCompleted($ignoredChecks, $conclusionChecks)`,
+			wantVal: `$hasAnyCheckRunCompleted($ignoredChecks, $conclusionChecks)`,
+		},
+		"has any check run completed with one nested function call and one variable": {
+			arg:     `$hasAnyCheckRunCompleted($group("checks), $conclusionChecks)`,
+			wantVal: `$hasAnyCheckRunCompleted($group("checks), $conclusionChecks)`,
 		},
 		"assign assignee with users list provided": {
 			arg:     `$assignAssignees(["john", "mary"])`,
@@ -239,6 +363,22 @@ func TestTransformAladinoExpression(t *testing.T) {
 			arg:     `$assignAssignees($team("test"), 1)`,
 			wantVal: `$assignAssignees($team("test"), 1)`,
 		},
+		"assign assignee with one variable": {
+			arg:     `$assignAssignees($assignAssigneesUsers, 5)`,
+			wantVal: `$assignAssignees($assignAssigneesUsers, 5)`,
+		},
+		"assign asignees with two variables": {
+			arg:     `$assignAssignees($assignAssigneesUsers, $assignAssigneesTotal)`,
+			wantVal: `$assignAssignees($assignAssigneesUsers, $assignAssigneesTotal)`,
+		},
+		"assign asignees with last variable": {
+			arg:     `$assignAssignees($team("test"), $assignAssigneesTotal)`,
+			wantVal: `$assignAssignees($team("test"), $assignAssigneesTotal)`,
+		},
+		"assign asignees with first argument array and second variable": {
+			arg:     `$assignAssignees(["john", "jane"], $assignAssigneesTotal)`,
+			wantVal: `$assignAssignees(["john", "jane"], $assignAssigneesTotal)`,
+		},
 		"hasCodeWithoutSemanticChanges with no argument": {
 			arg:     `$hasCodeWithoutSemanticChanges()`,
 			wantVal: `$hasCodeWithoutSemanticChanges([])`,
@@ -251,9 +391,45 @@ func TestTransformAladinoExpression(t *testing.T) {
 			arg:     `$hasCodeWithoutSemanticChanges(["*.md", "*.txt"])`,
 			wantVal: `$hasCodeWithoutSemanticChanges(["*.md", "*.txt"])`,
 		},
+		"hasCodeWithoutSemanticChanges with variable": {
+			arg:     `$hasCodeWithoutSemanticChanges($hasCodeWithoutSemanticChangesPaths)`,
+			wantVal: `$hasCodeWithoutSemanticChanges($hasCodeWithoutSemanticChangesPaths)`,
+		},
 		"summarize alias": {
 			arg:     `$summarize()`,
 			wantVal: `$robinSummarize("default", "openai-gpt-4")`,
+		},
+		"assignReviewer with one variable": {
+			arg:     `$assignReviewer($reviewers)`,
+			wantVal: `$assignReviewer($reviewers, 99, "reviewpad")`,
+		},
+		"assignReviewer with two variables": {
+			arg:     `$assignReviewer($reviewers, $maxReviewers)`,
+			wantVal: `$assignReviewer($reviewers, $maxReviewers, "reviewpad")`,
+		},
+		"assignReviewer with three variables": {
+			arg:     `$assignReviewer($reviewers, $maxReviewers, $strategy)`,
+			wantVal: `$assignReviewer($reviewers, $maxReviewers, $strategy)`,
+		},
+		"assignReviewer with one literal": {
+			arg:     `$assignReviewer(["john"])`,
+			wantVal: `$assignReviewer(["john"], 99, "reviewpad")`,
+		},
+		"assignReviewer with two literals": {
+			arg:     `$assignReviewer(["john"], 1)`,
+			wantVal: `$assignReviewer(["john"], 1, "reviewpad")`,
+		},
+		"assignReviewer with three literals": {
+			arg:     `$assignReviewer(["john"], 1, "reviewpad")`,
+			wantVal: `$assignReviewer(["john"], 1, "reviewpad")`,
+		},
+		"assignReviewer with one literal and one variable": {
+			arg:     `$assignReviewer(["john", "jane"], $maxReviewers)`,
+			wantVal: `$assignReviewer(["john", "jane"], $maxReviewers, "reviewpad")`,
+		},
+		"assignReviewer with one literal and two variables": {
+			arg:     `$assignReviewer(["john", "jane"], $maxReviewers, $strategy)`,
+			wantVal: `$assignReviewer(["john", "jane"], $maxReviewers, $strategy)`,
 		},
 		// TODO: test addDefaultTotalRequestedReviewers
 	}


### PR DESCRIPTION
## Description
Considers variables when providing defaults to built-ins with regular expressions.
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Jun 23 12:48 UTC
This pull request updates the addDefaultsToRequestedReviewers() function in the engine/transform.go file to allow for optional arguments for total required reviewers and policy. Additionally, a regular expression used to match the input has been updated, and several other functions have been updated to handle optional arguments.
<!-- reviewpad:summarize:end --> 

copilot:summary

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

copilot:walkthrough
