### PR TITLE
fix: assign code author reviewers no changes

### DIFF
--- a/plugins/aladino/actions/assignCodeAuthorReviewers.go
+++ b/plugins/aladino/actions/assignCodeAuthorReviewers.go
@@ -51,6 +51,15 @@ func assignCodeAuthorReviewersCode(env aladino.Env, args []lang.Value) error {
 		return nil
 	}
 
+	// if a pull request has no changes for example when
+	// you edit a file in one commit but revert the changes in another
+	// we can end up in a situation where there are no changes in the pull request
+	// in those cases it's not possible to fetch the authors of the changed files
+	// so we just assign a random reviewer.
+	if len(pr.Patch) == 0 {
+		return assignRandomReviewerCode(env, nil)
+	}
+
 	// Fetch all users that have authored the changed files in the pull request.
 	authors, err := getAuthorsFromGitBlame(env.GetCtx(), gitHubClient, pr)
 	if err != nil {


### PR DESCRIPTION
## Description
When there are no changes in a pull request for example when you make a change in one commit and revert it in another the `$assignCodeAuthorReviewers` built-in will error because no git blame information can be fetched, this pull request updates the behaviour so that if there are no change a random reviewer is assigned.
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jun 23 06:39 UTC
This pull request includes a fix for assigning a random reviewer if there are no changes in a pull request and a test case for this scenario.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at acc3dc7</samp>

Add logic and test case for assigning reviewers to pull requests with no changes. Handle the edge case in `assignCodeAuthorReviewers.go` and verify the behavior in `assignCodeAuthorReviewers_test.go`.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at acc3dc7</samp>

* Add a check for empty pull request patches and assign a random reviewer in that case ([link](https://github.com/reviewpad/reviewpad/pull/946/files?diff=unified&w=0#diff-acd9551bb4313dcc36ef244051ab652050f97e37e9a907c5bfbccc9f171a90d0R54-R62))
* Add a test case for the previous change ([link](https://github.com/reviewpad/reviewpad/pull/946/files?diff=unified&w=0#diff-8f5d7fdfe397b07cf1e0dcb28bcc32b74f82d5d187f7644ad193ac905b7c9c2aR1391-R1421))
