### PR TITLE
feat: exclude yarn.lock files from blame information

### DIFF
--- a/plugins/aladino/actions/assignCodeAuthorReviewers.go
+++ b/plugins/aladino/actions/assignCodeAuthorReviewers.go
@@ -147,7 +147,17 @@ func getAuthorsFromGitBlame(ctx context.Context, gitHubClient *github.GithubClie
 
 	changedFilesPath := []string{}
 
+	// we are excluding yarn.lock files
+	// to investigate if they are causing an issue with the git blame.
+	excludedFiles := map[string]bool{
+		"yarn.lock": true,
+	}
+
 	for _, patch := range pullRequest.Patch {
+		if excludedFiles[patch.Repr.GetFilename()] {
+			continue
+		}
+
 		changedFilesPath = append(changedFilesPath, patch.Repr.GetFilename())
 	}
 


### PR DESCRIPTION
## Description
the `yarn.lock` file seems to be causing some errors with github when trying to fetch git blame information, in this PR we are excluding the file to verify if it's the issue.
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jun 23 07:11 UTC
This pull request adds a feature that excludes yarn.lock files from being included in the blame information when fetching authors from git blame. This change was made to investigate if yarn.lock files are causing issues with git blame.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e835021</samp>

Exclude `yarn.lock` files from code author reviewers assignment. This improves the performance and accuracy of the feature that assigns reviewers based on the git blame of the changed files.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e835021</samp>

*  Exclude `yarn.lock` files from code author reviewers assignment ([link](https://github.com/reviewpad/reviewpad/pull/947/files?diff=unified&w=0#diff-acd9551bb4313dcc36ef244051ab652050f97e37e9a907c5bfbccc9f171a90d0L150-R160))
