### PR TITLE
fix: don't fail processing groups on unsupported kind

### DIFF
--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"errors"
 	"github.com/reviewpad/go-lib/entities"
 	"github.com/reviewpad/reviewpad/v4/codehost"
 	gh "github.com/reviewpad/reviewpad/v4/codehost/github"
@@ -58,6 +59,12 @@ func (i *Interpreter) ProcessGroup(groupName string, kind engine.GroupKind, type
 
 	value, err := evalGroup(i.Env, exprAST)
 	if err != nil {
+		var unsupportedKindError *UnsupportedKindError
+		if errors.As(err, &unsupportedKindError) {
+			i.Env.GetLogger().Warningln(fmt.Sprintf("built-in %s is being executed on %s, however it is only supported on %s", unsupportedKindError.BuiltIn, unsupportedKindError.Kind, unsupportedKindError.SupportedOn()))
+			return nil
+		}
+
 		return fmt.Errorf("ProcessGroup:evalGroup %v", err)
 	}
 


### PR DESCRIPTION
## Description
Fixes an a problem with processing groups when a built-in that doesn't support the kind(pull request / issue) is used in the groups spec.

Closes #950 

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Jun 23 09:56 UTC
This pull request fixes an issue where groups fail to process on unsupported kind and provides an error message with the details.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4062ae0</samp>

Improved error handling and reporting for Aladino language by introducing a custom error type and logging it in the interpreter. Affected files are `lang/aladino/eval.go` and `lang/aladino/interpreter.go`.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4062ae0</samp>

*  Import packages and define custom error type for unsupported entity kinds in built-in functions ([link](https://github.com/reviewpad/reviewpad/pull/951/files?diff=unified&w=0#diff-9dc9ed0b34b134c31282298a5a9a1846b3953a2b8b6dc4b324c764803aec1f59L9-R33))
*  Return custom error type instead of generic error when executing built-in functions on unsupported entity kinds in `Eval` function ([link](https://github.com/reviewpad/reviewpad/pull/951/files?diff=unified&w=0#diff-9dc9ed0b34b134c31282298a5a9a1846b3953a2b8b6dc4b324c764803aec1f59L118-R143))
*  Import `errors` package and handle custom error type by logging a warning and returning nil in `ProcessGroup` function ([link](https://github.com/reviewpad/reviewpad/pull/951/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becR12), [link](https://github.com/reviewpad/reviewpad/pull/951/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becR62-R67))
