### PR TITLE
fix: set group to an empty list if it can't be processed

### DIFF
--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -62,6 +62,7 @@ func (i *Interpreter) ProcessGroup(groupName string, kind engine.GroupKind, type
 		var unsupportedKindError *UnsupportedKindError
 		if errors.As(err, &unsupportedKindError) {
 			i.Env.GetLogger().Warningln(fmt.Sprintf("built-in %s is being executed on %s, however it is only supported on %s", unsupportedKindError.BuiltIn, unsupportedKindError.Kind, unsupportedKindError.SupportedOn()))
+			i.Env.GetRegisterMap()[groupName] = lang.BuildArrayValue([]lang.Value{})
 			return nil
 		}
 


### PR DESCRIPTION
## Description
Set's group to an empty list if it can't be processed because of an invalid kind.
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Jun 23 10:21 UTC
This pull request fixes an issue where the group list cannot be processed, by setting the group to an empty list if it cannot be processed.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00a891e</samp>

Fix a bug in the aladino interpreter that causes a nil pointer exception when using group expressions. Initialize the register map for a group name with an empty array value in `lang/aladino/interpreter.go`.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00a891e</samp>

* Fix a bug in the aladino interpreter related to group expressions ([link](https://github.com/reviewpad/reviewpad/pull/952/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becR65))
