### PR TITLE
feat: add create issue builtin

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -9,10 +9,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"regexp"
 
 	"github.com/google/uuid"
+	"github.com/hasura/go-graphql-client"
 	"github.com/reviewpad/api/go/clients"
 	"github.com/reviewpad/go-lib/entities"
 	log "github.com/reviewpad/go-lib/logrus"
@@ -71,6 +73,14 @@ func init() {
 	if endpoint := os.Getenv("INPUT_ROBIN_SERVICE"); endpoint == "" {
 		panic("INPUT_ROBIN_SERVICE env var is required")
 	}
+
+	if endpoint := os.Getenv("INPUT_NEXUS_GRAPH_SERVICE"); endpoint == "" {
+		panic("INPUT_NEXUS_GRAPH_SERVICE env var is required")
+	}
+
+	if endpoint := os.Getenv("INPUT_NEXUS_GRAPH_TOKEN"); endpoint == "" {
+		panic("INPUT_NEXUS_GRAPH_TOKEN env var is required")
+	}
 }
 
 func run() error {
@@ -113,6 +123,11 @@ func run() error {
 		log.Errorf("error creating new collector: %v", err)
 	}
 
+	nexusClient := graphql.NewClient(os.Getenv("INPUT_NEXUS_GRAPH_SERVICE"), http.DefaultClient)
+	nexusClient = nexusClient.WithRequestModifier(func(req *http.Request) {
+		req.Header.Set("x-hasura-admin-secret", os.Getenv("INPUT_NEXUS_GRAPH_TOKEN"))
+	})
+
 	rawReviewpadFile, err := os.ReadFile(reviewpadFilePath)
 	if err != nil {
 		return fmt.Errorf("error reading reviewpad file. Details: %v", err.Error())
@@ -152,7 +167,20 @@ func run() error {
 
 	for _, targetEntity := range targetEntities {
 		log.Infof("Processing entity %s/%s#%d", targetEntity.Owner, targetEntity.Repo, targetEntity.Number)
-		_, _, _, err = reviewpad.Run(ctxReq, log, gitHubClient, codeHostClient, collectorClient, targetEntity, eventDetails, reviewpadFile, nil, dryRun, safeModeRun)
+		_, _, _, err = reviewpad.Run(
+			ctxReq,
+			log,
+			gitHubClient,
+			codeHostClient,
+			nexusClient,
+			collectorClient,
+			targetEntity,
+			eventDetails,
+			reviewpadFile,
+			nil,
+			dryRun,
+			safeModeRun,
+		)
 		if err != nil {
 			return fmt.Errorf("error running reviewpad team edition. Details %v", err.Error())
 		}

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -435,11 +435,13 @@ func TestExecConfigurationFile(t *testing.T) {
 				dryRun,
 				mockedClient,
 				codehostClient,
+				nil,
 				engine.DefaultMockCollector,
 				engine.DefaultMockTargetEntity,
 				engine.DefaultMockEventPayload,
 				builtIns,
 				nil,
+				"",
 			)
 			if err != nil {
 				assert.FailNow(t, fmt.Sprintf("mockAladinoInterpreter: %v", err))
@@ -710,11 +712,13 @@ func mockAladinoInterpreter(githubClient *gh.GithubClient, codehostClient *codeh
 		dryRun,
 		githubClient,
 		codehostClient,
+		nil,
 		engine.DefaultMockCollector,
 		engine.DefaultMockTargetEntity,
 		engine.DefaultMockEventPayload,
 		aladino.MockBuiltIns(),
 		nil,
+		"",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("aladino NewInterpreter returned unexpected error: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/ohler55/ojg v1.18.5
 	github.com/reviewpad/api/go v0.0.0-20230519182648-a6db32ab3994
 	github.com/reviewpad/go-conventionalcommits v0.10.0
-	github.com/reviewpad/go-lib v0.0.0-20230523100931-3276b99f2619
+	github.com/reviewpad/go-lib v0.0.0-20230629080833-7f90e3730f59
 	github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9
 	github.com/sirupsen/logrus v1.9.2
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/reviewpad/api/go v0.0.0-20230519182648-a6db32ab3994 h1:K4cZ5YyHkXZU9g
 github.com/reviewpad/api/go v0.0.0-20230519182648-a6db32ab3994/go.mod h1:Ip1ZnFEOM9DSgAkjjKxBOV7LTIzj5MxKHirgaDRzGb0=
 github.com/reviewpad/go-conventionalcommits v0.10.0 h1:49Fv1q5vougqA7g5mpFZ+W5sQs9kJ5F5zH7kCEwZ+w8=
 github.com/reviewpad/go-conventionalcommits v0.10.0/go.mod h1:NWUK2G+V+KrhmHW2fBAWGEgZFW8jUXqqBkm9mYJJNi4=
-github.com/reviewpad/go-lib v0.0.0-20230523100931-3276b99f2619 h1:TwttNjQ5548Q+ASYu6prIO4CNt2S9LQFZFfmO5794ds=
-github.com/reviewpad/go-lib v0.0.0-20230523100931-3276b99f2619/go.mod h1:9pk6N6eG81GlBCL23LaMTMsrISEBL5VRIWknSQ3ZFOs=
+github.com/reviewpad/go-lib v0.0.0-20230629080833-7f90e3730f59 h1:do+q7XeVIxppOXmEUDHWJQGZtvGvP4Ii/DLIfMWIens=
+github.com/reviewpad/go-lib v0.0.0-20230629080833-7f90e3730f59/go.mod h1:9pk6N6eG81GlBCL23LaMTMsrISEBL5VRIWknSQ3ZFOs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/handler/processors.go
+++ b/handler/processors.go
@@ -67,12 +67,14 @@ func processCronEvent(log *logrus.Entry, token string, e *ActionEvent) ([]*entit
 			kind = entities.PullRequest
 		}
 		targets = append(targets, &entities.TargetEntity{
-			Kind:        kind,
-			Number:      *issue.Number,
-			Owner:       owner,
-			Repo:        repo,
-			AccountType: repository.GetOwner().GetType(),
-			Visibility:  repository.GetVisibility(),
+			Kind:           kind,
+			Number:         *issue.Number,
+			Owner:          owner,
+			Repo:           repo,
+			AccountType:    repository.GetOwner().GetType(),
+			Visibility:     repository.GetVisibility(),
+			OrganizationId: repository.GetOwner().GetNodeID(),
+			NodeId:         issue.GetNodeID(),
 		})
 	}
 
@@ -89,12 +91,14 @@ func processIssuesEvent(log *logrus.Entry, e *github.IssuesEvent) ([]*entities.T
 
 	return []*entities.TargetEntity{
 			{
-				Kind:        entities.Issue,
-				Number:      *e.Issue.Number,
-				Owner:       *e.Repo.Owner.Login,
-				Repo:        *e.Repo.Name,
-				AccountType: e.GetRepo().GetOwner().GetType(),
-				Visibility:  e.GetRepo().GetVisibility(),
+				Kind:           entities.Issue,
+				Number:         *e.Issue.Number,
+				Owner:          *e.Repo.Owner.Login,
+				Repo:           *e.Repo.Name,
+				AccountType:    e.GetRepo().GetOwner().GetType(),
+				Visibility:     e.GetRepo().GetVisibility(),
+				OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+				NodeId:         e.GetIssue().GetNodeID(),
 			},
 		}, &entities.EventDetails{
 			EventName:   "issues",
@@ -114,12 +118,14 @@ func processIssueCommentEvent(log *logrus.Entry, e *github.IssueCommentEvent) ([
 
 	return []*entities.TargetEntity{
 			{
-				Kind:        kind,
-				Number:      *e.Issue.Number,
-				Owner:       *e.Repo.Owner.Login,
-				Repo:        *e.Repo.Name,
-				AccountType: e.GetRepo().GetOwner().GetType(),
-				Visibility:  e.GetRepo().GetVisibility(),
+				Kind:           kind,
+				Number:         *e.Issue.Number,
+				Owner:          *e.Repo.Owner.Login,
+				Repo:           *e.Repo.Name,
+				AccountType:    e.GetRepo().GetOwner().GetType(),
+				Visibility:     e.GetRepo().GetVisibility(),
+				OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+				NodeId:         e.GetIssue().GetNodeID(),
 			},
 		}, &entities.EventDetails{
 			EventName:   "issue_comment",
@@ -134,12 +140,14 @@ func processDiscussionEvent(log *logrus.Entry, e *github.DiscussionEvent) ([]*en
 
 	return []*entities.TargetEntity{
 			{
-				Kind:        entities.Discussion,
-				Number:      *e.Discussion.Number,
-				Owner:       *e.Repo.Owner.Login,
-				Repo:        *e.Repo.Name,
-				AccountType: e.GetRepo().GetOwner().GetType(),
-				Visibility:  e.GetRepo().GetVisibility(),
+				Kind:           entities.Discussion,
+				Number:         *e.Discussion.Number,
+				Owner:          *e.Repo.Owner.Login,
+				Repo:           *e.Repo.Name,
+				AccountType:    e.GetRepo().GetOwner().GetType(),
+				Visibility:     e.GetRepo().GetVisibility(),
+				OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+				NodeId:         e.GetDiscussion().GetNodeID(),
 			},
 		}, &entities.EventDetails{
 			EventName:   "discussion",
@@ -154,12 +162,14 @@ func processDiscussionCommentEvent(log *logrus.Entry, e *github.DiscussionCommen
 
 	return []*entities.TargetEntity{
 			{
-				Kind:        entities.Discussion,
-				Number:      *e.Discussion.Number,
-				Owner:       *e.Repo.Owner.Login,
-				Repo:        *e.Repo.Name,
-				AccountType: e.GetRepo().GetOwner().GetType(),
-				Visibility:  e.GetRepo().GetVisibility(),
+				Kind:           entities.Discussion,
+				Number:         *e.Discussion.Number,
+				Owner:          *e.Repo.Owner.Login,
+				Repo:           *e.Repo.Name,
+				AccountType:    e.GetRepo().GetOwner().GetType(),
+				Visibility:     e.GetRepo().GetVisibility(),
+				OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+				NodeId:         e.GetDiscussion().GetNodeID(),
 			},
 		}, &entities.EventDetails{
 			EventName:   "discussion_comment",
@@ -174,12 +184,14 @@ func processPullRequestEvent(log *logrus.Entry, e *github.PullRequestEvent) ([]*
 
 	return []*entities.TargetEntity{
 			{
-				Kind:        entities.PullRequest,
-				Number:      *e.PullRequest.Number,
-				Owner:       *e.Repo.Owner.Login,
-				Repo:        *e.Repo.Name,
-				AccountType: e.GetRepo().GetOwner().GetType(),
-				Visibility:  e.GetRepo().GetVisibility(),
+				Kind:           entities.PullRequest,
+				Number:         *e.PullRequest.Number,
+				Owner:          *e.Repo.Owner.Login,
+				Repo:           *e.Repo.Name,
+				AccountType:    e.GetRepo().GetOwner().GetType(),
+				Visibility:     e.GetRepo().GetVisibility(),
+				OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+				NodeId:         e.GetPullRequest().GetNodeID(),
 			},
 		}, &entities.EventDetails{
 			EventName:   "pull_request",
@@ -194,12 +206,14 @@ func processPullRequestReviewEvent(log *logrus.Entry, e *github.PullRequestRevie
 
 	return []*entities.TargetEntity{
 			{
-				Kind:        entities.PullRequest,
-				Number:      *e.PullRequest.Number,
-				Owner:       *e.Repo.Owner.Login,
-				Repo:        *e.Repo.Name,
-				AccountType: e.GetRepo().GetOwner().GetType(),
-				Visibility:  e.GetRepo().GetVisibility(),
+				Kind:           entities.PullRequest,
+				Number:         *e.PullRequest.Number,
+				Owner:          *e.Repo.Owner.Login,
+				Repo:           *e.Repo.Name,
+				AccountType:    e.GetRepo().GetOwner().GetType(),
+				Visibility:     e.GetRepo().GetVisibility(),
+				OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+				NodeId:         e.GetPullRequest().GetNodeID(),
 			},
 		}, &entities.EventDetails{
 			EventName:   "pull_request_review",
@@ -214,12 +228,14 @@ func processPullRequestReviewCommentEvent(log *logrus.Entry, e *github.PullReque
 
 	return []*entities.TargetEntity{
 			{
-				Kind:        entities.PullRequest,
-				Number:      *e.PullRequest.Number,
-				Owner:       *e.Repo.Owner.Login,
-				Repo:        *e.Repo.Name,
-				AccountType: e.GetRepo().GetOwner().GetType(),
-				Visibility:  e.GetRepo().GetVisibility(),
+				Kind:           entities.PullRequest,
+				Number:         *e.PullRequest.Number,
+				Owner:          *e.Repo.Owner.Login,
+				Repo:           *e.Repo.Name,
+				AccountType:    e.GetRepo().GetOwner().GetType(),
+				Visibility:     e.GetRepo().GetVisibility(),
+				OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+				NodeId:         e.GetPullRequest().GetNodeID(),
 			},
 		}, &entities.EventDetails{
 			EventName:   "pull_request_review_comment",
@@ -234,12 +250,14 @@ func processPullRequestTargetEvent(log *logrus.Entry, e *github.PullRequestTarge
 
 	return []*entities.TargetEntity{
 			{
-				Kind:        entities.PullRequest,
-				Number:      *e.PullRequest.Number,
-				Owner:       *e.Repo.Owner.Login,
-				Repo:        *e.Repo.Name,
-				AccountType: e.GetRepo().GetOwner().GetType(),
-				Visibility:  e.GetRepo().GetVisibility(),
+				Kind:           entities.PullRequest,
+				Number:         *e.PullRequest.Number,
+				Owner:          *e.Repo.Owner.Login,
+				Repo:           *e.Repo.Name,
+				AccountType:    e.GetRepo().GetOwner().GetType(),
+				Visibility:     e.GetRepo().GetVisibility(),
+				OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+				NodeId:         e.GetPullRequest().GetNodeID(),
 			},
 		}, &entities.EventDetails{
 			EventName:   "pull_request_target",
@@ -273,12 +291,14 @@ func processStatusEvent(log *logrus.Entry, token string, e *github.StatusEvent) 
 			log.Infof("found pull request %v", *pr.Number)
 			return []*entities.TargetEntity{
 				{
-					Kind:        entities.PullRequest,
-					Number:      *pr.Number,
-					Owner:       *pr.Base.Repo.Owner.Login,
-					Repo:        *pr.Base.Repo.Name,
-					AccountType: pr.GetBase().GetRepo().GetOwner().GetType(),
-					Visibility:  pr.GetBase().GetRepo().GetVisibility(),
+					Kind:           entities.PullRequest,
+					Number:         *pr.Number,
+					Owner:          *pr.Base.Repo.Owner.Login,
+					Repo:           *pr.Base.Repo.Name,
+					AccountType:    pr.GetBase().GetRepo().GetOwner().GetType(),
+					Visibility:     pr.GetBase().GetRepo().GetVisibility(),
+					OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+					NodeId:         pr.GetNodeID(),
 				},
 			}, eventDetails, nil
 		}
@@ -314,12 +334,14 @@ func processWorkflowRunEvent(log *logrus.Entry, token string, e *github.Workflow
 			log.Infof("found pull request %v", *pr.Number)
 			return []*entities.TargetEntity{
 				{
-					Kind:        entities.PullRequest,
-					Number:      *pr.Number,
-					Owner:       *pr.Base.Repo.Owner.Login,
-					Repo:        *pr.Base.Repo.Name,
-					AccountType: pr.GetBase().GetRepo().GetOwner().GetType(),
-					Visibility:  pr.GetBase().GetRepo().GetVisibility(),
+					Kind:           entities.PullRequest,
+					Number:         *pr.Number,
+					Owner:          *pr.Base.Repo.Owner.Login,
+					Repo:           *pr.Base.Repo.Name,
+					AccountType:    pr.GetBase().GetRepo().GetOwner().GetType(),
+					Visibility:     pr.GetBase().GetRepo().GetVisibility(),
+					OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+					NodeId:         pr.GetNodeID(),
 				},
 			}, eventDetail, nil
 		}
@@ -354,12 +376,14 @@ func processPushEvent(log *logrus.Entry, token string, e *github.PushEvent) ([]*
 	for _, pr := range prs {
 		if fmt.Sprintf("refs/heads/%s", pr.GetHead().GetRef()) == e.GetRef() {
 			targets = append(targets, &entities.TargetEntity{
-				Kind:        entities.PullRequest,
-				Number:      *pr.Number,
-				Owner:       owner,
-				Repo:        repo,
-				AccountType: pr.GetBase().GetRepo().GetOwner().GetType(),
-				Visibility:  pr.GetBase().GetRepo().GetVisibility(),
+				Kind:           entities.PullRequest,
+				Number:         *pr.Number,
+				Owner:          owner,
+				Repo:           repo,
+				AccountType:    pr.GetBase().GetRepo().GetOwner().GetType(),
+				Visibility:     pr.GetBase().GetRepo().GetVisibility(),
+				OrganizationId: e.GetRepo().GetOwner().GetNodeID(),
+				NodeId:         pr.GetNodeID(),
 			})
 		}
 	}
@@ -451,12 +475,14 @@ func processCheckRunEvent(log *logrus.Entry, token string, event *github.CheckRu
 				log.Infof("found pull request %v", pr.GetNumber())
 				return []*entities.TargetEntity{
 					{
-						Kind:        entities.PullRequest,
-						Number:      pr.GetNumber(),
-						Owner:       event.GetRepo().GetOwner().GetLogin(),
-						Repo:        event.GetRepo().GetName(),
-						AccountType: pr.GetBase().GetRepo().GetOwner().GetType(),
-						Visibility:  pr.GetBase().GetRepo().GetVisibility(),
+						Kind:           entities.PullRequest,
+						Number:         pr.GetNumber(),
+						Owner:          event.GetRepo().GetOwner().GetLogin(),
+						Repo:           event.GetRepo().GetName(),
+						AccountType:    pr.GetBase().GetRepo().GetOwner().GetType(),
+						Visibility:     pr.GetBase().GetRepo().GetVisibility(),
+						OrganizationId: event.GetRepo().GetOwner().GetNodeID(),
+						NodeId:         pr.GetNodeID(),
 					},
 				}, eventDetails, nil
 			}
@@ -469,12 +495,14 @@ func processCheckRunEvent(log *logrus.Entry, token string, event *github.CheckRu
 
 	for _, pr := range event.CheckRun.PullRequests {
 		targetEntities = append(targetEntities, &entities.TargetEntity{
-			Kind:        entities.PullRequest,
-			Owner:       event.GetRepo().GetOwner().GetLogin(),
-			Repo:        event.GetRepo().GetName(),
-			Number:      pr.GetNumber(),
-			AccountType: event.GetRepo().GetOwner().GetType(),
-			Visibility:  event.GetRepo().GetVisibility(),
+			Kind:           entities.PullRequest,
+			Owner:          event.GetRepo().GetOwner().GetLogin(),
+			Repo:           event.GetRepo().GetName(),
+			Number:         pr.GetNumber(),
+			AccountType:    event.GetRepo().GetOwner().GetType(),
+			Visibility:     event.GetRepo().GetVisibility(),
+			OrganizationId: event.GetRepo().GetOwner().GetNodeID(),
+			NodeId:         pr.GetNodeID(),
 		})
 	}
 
@@ -513,12 +541,14 @@ func processCheckSuiteEvent(log *logrus.Entry, token string, event *github.Check
 				log.Infof("found pull request %v", pr.GetNumber())
 				return []*entities.TargetEntity{
 					{
-						Kind:        entities.PullRequest,
-						Number:      pr.GetNumber(),
-						Owner:       event.GetRepo().GetOwner().GetLogin(),
-						Repo:        event.GetRepo().GetName(),
-						AccountType: pr.GetBase().GetRepo().GetOwner().GetType(),
-						Visibility:  pr.GetBase().GetRepo().GetVisibility(),
+						Kind:           entities.PullRequest,
+						Number:         pr.GetNumber(),
+						Owner:          event.GetRepo().GetOwner().GetLogin(),
+						Repo:           event.GetRepo().GetName(),
+						AccountType:    pr.GetBase().GetRepo().GetOwner().GetType(),
+						Visibility:     pr.GetBase().GetRepo().GetVisibility(),
+						OrganizationId: event.GetRepo().GetOwner().GetNodeID(),
+						NodeId:         pr.GetNodeID(),
 					},
 				}, eventDetails, nil
 			}
@@ -530,12 +560,14 @@ func processCheckSuiteEvent(log *logrus.Entry, token string, event *github.Check
 	} else {
 		for _, pr := range event.CheckSuite.PullRequests {
 			targetEntities = append(targetEntities, &entities.TargetEntity{
-				Kind:        entities.PullRequest,
-				Owner:       event.GetRepo().GetOwner().GetLogin(),
-				Repo:        event.GetRepo().GetName(),
-				Number:      pr.GetNumber(),
-				AccountType: event.GetRepo().GetOwner().GetType(),
-				Visibility:  event.GetRepo().GetVisibility(),
+				Kind:           entities.PullRequest,
+				Owner:          event.GetRepo().GetOwner().GetLogin(),
+				Repo:           event.GetRepo().GetName(),
+				Number:         pr.GetNumber(),
+				AccountType:    event.GetRepo().GetOwner().GetType(),
+				Visibility:     event.GetRepo().GetVisibility(),
+				OrganizationId: event.GetRepo().GetOwner().GetNodeID(),
+				NodeId:         pr.GetNodeID(),
 			})
 		}
 	}
@@ -561,12 +593,14 @@ func processCheckSuiteEventForMergeQueue(log *logrus.Entry, token string, event 
 
 	return []*entities.TargetEntity{
 		{
-			Kind:        entities.PullRequest,
-			Number:      pr.GetNumber(),
-			Owner:       event.GetRepo().GetOwner().GetLogin(),
-			Repo:        event.GetRepo().GetName(),
-			AccountType: pr.GetBase().GetRepo().GetOwner().GetType(),
-			Visibility:  pr.GetBase().GetRepo().GetVisibility(),
+			Kind:           entities.PullRequest,
+			Number:         pr.GetNumber(),
+			Owner:          event.GetRepo().GetOwner().GetLogin(),
+			Repo:           event.GetRepo().GetName(),
+			AccountType:    pr.GetBase().GetRepo().GetOwner().GetType(),
+			Visibility:     pr.GetBase().GetRepo().GetVisibility(),
+			OrganizationId: event.GetRepo().GetOwner().GetNodeID(),
+			NodeId:         pr.GetNodeID(),
 		},
 	}, eventDetails, nil
 }

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -11,10 +11,13 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hasura/go-graphql-client"
 	pbe "github.com/reviewpad/api/go/entities"
 	"github.com/reviewpad/api/go/services"
 	"github.com/reviewpad/go-lib/entities"
@@ -31,6 +34,16 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 )
+
+type localRoundTripper struct {
+	handler http.Handler
+}
+
+func (l localRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	w := httptest.NewRecorder()
+	l.handler.ServeHTTP(w, req)
+	return w.Result(), nil
+}
 
 const (
 	// opening a pull request from this commit
@@ -327,10 +340,23 @@ func TestIntegration(t *testing.T) {
 				CodehostClient: codehostClient,
 			}
 
+			mux := http.NewServeMux()
+			mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{
+					"data": {
+						"insert_execution": {
+							"id": "id"
+						}
+					}
+				}`))
+			})
+			nexusClientGQL := graphql.NewClient("https://api.github.com/graphql", &http.Client{Transport: localRoundTripper{handler: mux}})
+
 			// execute the reviewpad files one by one and
 			// ensure there are no errors and exit statuses match
 			for i, file := range test.reviewpadFiles {
-				exitStatus, _, _, err := reviewpad.Run(ctxReq, logger, githubClient, codeHostClient, nil, collector, targetEntity, eventDetails, file, nil, false, false)
+				exitStatus, _, _, err := reviewpad.Run(ctxReq, logger, githubClient, codeHostClient, nexusClientGQL, collector, targetEntity, eventDetails, file, nil, false, false)
 				assert.Equal(test.wantErr, err)
 				assert.Equal(test.exitStatus[i], exitStatus)
 			}

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -330,7 +330,7 @@ func TestIntegration(t *testing.T) {
 			// execute the reviewpad files one by one and
 			// ensure there are no errors and exit statuses match
 			for i, file := range test.reviewpadFiles {
-				exitStatus, _, _, err := reviewpad.Run(ctxReq, logger, githubClient, codeHostClient, collector, targetEntity, eventDetails, file, nil, false, false)
+				exitStatus, _, _, err := reviewpad.Run(ctxReq, logger, githubClient, codeHostClient, nil, collector, targetEntity, eventDetails, file, nil, false, false)
 				assert.Equal(test.wantErr, err)
 				assert.Equal(test.exitStatus[i], exitStatus)
 			}

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/hasura/go-graphql-client"
 	"github.com/reviewpad/go-lib/entities"
 	"github.com/reviewpad/reviewpad/v4/codehost"
 	gh "github.com/reviewpad/reviewpad/v4/codehost/github"
@@ -36,6 +37,7 @@ type Env interface {
 	GetBuiltIns() *BuiltIns
 	GetBuiltInsReportedMessages() map[Severity][]string
 	GetGithubClient() *gh.GithubClient
+	GetNexusClient() *graphql.Client
 	GetCodeHostClient() *codehost.CodeHostClient
 	GetCollector() collector.Collector
 	GetCtx() context.Context
@@ -51,6 +53,7 @@ type Env interface {
 	GetCheckRunID() *int64
 	SetCheckRunConclusion(string)
 	GetCheckRunConclusion() string
+	GetExecutionID() string
 }
 
 type BaseEnv struct {
@@ -58,6 +61,7 @@ type BaseEnv struct {
 	BuiltInsReportedMessages map[Severity][]string
 	GithubClient             *gh.GithubClient
 	CodeHostClient           *codehost.CodeHostClient
+	NexusClient              *graphql.Client
 	Collector                collector.Collector
 	Ctx                      context.Context
 	DryRun                   bool
@@ -71,6 +75,7 @@ type BaseEnv struct {
 	ExecFatalErrorOccurred   error
 	CheckRunID               *int64
 	CheckRunConclusion       string
+	ExecutionID              string
 }
 
 func (e *BaseEnv) GetBuiltIns() *BuiltIns {
@@ -83,6 +88,10 @@ func (e *BaseEnv) GetBuiltInsReportedMessages() map[Severity][]string {
 
 func (e *BaseEnv) GetGithubClient() *gh.GithubClient {
 	return e.GithubClient
+}
+
+func (e *BaseEnv) GetNexusClient() *graphql.Client {
+	return e.NexusClient
 }
 
 func (e *BaseEnv) GetCollector() collector.Collector {
@@ -149,6 +158,10 @@ func (e *BaseEnv) GetCheckRunID() *int64 {
 	return e.CheckRunID
 }
 
+func (e *BaseEnv) GetExecutionID() string {
+	return e.ExecutionID
+}
+
 func NewTypeEnv(e Env) TypeEnv {
 	builtInsType := make(map[string]lang.Type)
 	for builtInName, builtInFunction := range e.GetBuiltIns().Functions {
@@ -172,11 +185,13 @@ func NewEvalEnv(
 	dryRun bool,
 	githubClient *gh.GithubClient,
 	codeHostClient *codehost.CodeHostClient,
+	nexusClient *graphql.Client,
 	collector collector.Collector,
 	targetEntity *entities.TargetEntity,
 	eventPayload interface{},
 	builtIns *BuiltIns,
 	checkRunID *int64,
+	executionID string,
 ) (Env, error) {
 	registerMap := RegisterMap(make(map[string]lang.Value))
 	report := &Report{Actions: make([]string, 0)}
@@ -188,6 +203,7 @@ func NewEvalEnv(
 		BuiltIns:                 builtIns,
 		BuiltInsReportedMessages: make(map[Severity][]string),
 		GithubClient:             githubClient,
+		NexusClient:              nexusClient,
 		Collector:                collector,
 		Ctx:                      ctx,
 		DryRun:                   dryRun,
@@ -199,6 +215,7 @@ func NewEvalEnv(
 		ExecWaitGroup:            &wg,
 		ExecMutex:                &mu,
 		CheckRunID:               checkRunID,
+		ExecutionID:              executionID,
 	}
 
 	switch targetEntity.Kind {

--- a/lang/aladino/env_test.go
+++ b/lang/aladino/env_test.go
@@ -52,11 +52,13 @@ func TestNewEvalEnv_WhenGetPullRequestFilesFails(t *testing.T) {
 		false,
 		nil,
 		codehostClient,
+		nil,
 		aladino.DefaultMockCollector,
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
 		nil,
+		"",
 	)
 
 	assert.Nil(t, env)
@@ -84,11 +86,13 @@ func TestNewEvalEnv_WhenNewFileFails(t *testing.T) {
 		false,
 		nil,
 		codehostClient,
+		nil,
 		aladino.DefaultMockCollector,
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
 		nil,
+		"",
 	)
 
 	assert.Nil(t, env)
@@ -117,11 +121,13 @@ func TestNewEvalEnv(t *testing.T) {
 		false,
 		mockedGithubClient,
 		mockedCodehostClient,
+		nil,
 		aladino.DefaultMockCollector,
 		aladino.DefaultMockTargetEntity,
 		nil,
 		aladino.MockBuiltIns(),
 		nil,
+		"",
 	)
 
 	mockedTarget, _ := target.NewPullRequestTarget(ctx, aladino.DefaultMockTargetEntity, mockedGithubClient, mockedCodehostClient, mockedCodeReview)
@@ -181,11 +187,13 @@ func TestNewEvalEnv_WhenGetPullRequestFails(t *testing.T) {
 		false,
 		nil,
 		codehostClient,
+		nil,
 		aladino.DefaultMockCollector,
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
 		nil,
+		"",
 	)
 
 	assert.Nil(t, env)

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"errors"
+
+	"github.com/hasura/go-graphql-client"
 	"github.com/reviewpad/go-lib/entities"
 	"github.com/reviewpad/reviewpad/v4/codehost"
 	gh "github.com/reviewpad/reviewpad/v4/codehost/github"
@@ -352,13 +354,28 @@ func NewInterpreter(
 	dryRun bool,
 	githubClient *gh.GithubClient,
 	codeHostClient *codehost.CodeHostClient,
+	nexusClient *graphql.Client,
 	collector collector.Collector,
 	targetEntity *entities.TargetEntity,
 	eventPayload interface{},
 	builtIns *BuiltIns,
 	checkRunID *int64,
+	executionID string,
 ) (engine.Interpreter, error) {
-	evalEnv, err := NewEvalEnv(ctx, logger, dryRun, githubClient, codeHostClient, collector, targetEntity, eventPayload, builtIns, checkRunID)
+	evalEnv, err := NewEvalEnv(
+		ctx,
+		logger,
+		dryRun,
+		githubClient,
+		codeHostClient,
+		nexusClient,
+		collector,
+		targetEntity,
+		eventPayload,
+		builtIns,
+		checkRunID,
+		executionID,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -772,10 +772,12 @@ func TestNewInterpreter_WhenNewEvalEnvFails(t *testing.T) {
 		nil,
 		codehostClient,
 		nil,
+		nil,
 		DefaultMockTargetEntity,
 		nil,
 		nil,
 		nil,
+		"",
 	)
 
 	assert.Nil(t, gotInterpreter)
@@ -795,11 +797,13 @@ func TestNewInterpreter(t *testing.T) {
 		mockedEnv.GetDryRun(),
 		mockedEnv.GetGithubClient(),
 		mockedEnv.GetCodeHostClient(),
+		mockedEnv.GetNexusClient(),
 		mockedEnv.GetCollector(),
 		DefaultMockTargetEntity,
 		mockedEnv.GetEventPayload(),
 		mockedEnv.GetBuiltIns(),
 		nil,
+		"",
 	)
 
 	assert.Nil(t, err)
@@ -1041,11 +1045,13 @@ func TestReportMetric(t *testing.T) {
 				env.GetDryRun(),
 				env.GetGithubClient(),
 				env.GetCodeHostClient(),
+				env.GetNexusClient(),
 				env.GetCollector(),
 				env.GetTarget().GetTargetEntity(),
 				nil,
 				nil,
 				nil,
+				"",
 			)
 
 			assert.Nil(t, err)

--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -152,11 +152,13 @@ func mockEnvWith(prOwner string, prRepoName string, prNum int, githubClient *gh.
 		false,
 		githubClient,
 		codehostClient,
+		nil,
 		DefaultMockCollector,
 		targetEntity,
 		eventPayload,
 		builtIns,
 		nil,
+		"",
 	)
 	if err != nil {
 		return nil, err

--- a/plugins/aladino/actions/createIssue.go
+++ b/plugins/aladino/actions/createIssue.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_actions
+
+import (
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+)
+
+func CreateIssue() *aladino.BuiltInAction {
+	return &aladino.BuiltInAction{
+		Type:           lang.BuildFunctionType([]lang.Type{lang.BuildStringType(), lang.BuildStringType()}, nil),
+		Code:           createIssueCode,
+		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest},
+	}
+}
+
+type InsertIssueInput struct {
+	Title          string `graphql:"title" json:"title"`
+	ResourceNodeId string `graphql:"resource_node_id" json:"resource_node_id"`
+	Results        string `graphql:"results" json:"results"`
+	ExecutionId    string `graphql:"execution_id" json:"execution_id"`
+}
+
+func (i InsertIssueInput) GetGraphQLType() string {
+	return "issues_insert_input"
+}
+
+type InsertIssueMutation struct {
+	Insert_issue struct {
+		Id string
+	} `graphql:"insert_issue(object: $object)"`
+}
+
+func createIssueCode(e aladino.Env, args []lang.Value) error {
+	t := e.GetTarget()
+	context := args[0].(*lang.StringValue).Val
+	description := args[1].(*lang.StringValue).Val
+	log := e.GetLogger().WithField("builtin", "createIssue")
+
+	executionId := e.GetExecutionID()
+	nodeId := t.GetTargetEntity().NodeId
+
+	insertInput := InsertIssueInput{
+		Title:          context,
+		ResourceNodeId: nodeId,
+		Results:        description,
+		ExecutionId:    executionId,
+	}
+
+	err := e.GetNexusClient().WithDebug(true).Mutate(e.GetCtx(), &InsertIssueMutation{}, map[string]interface{}{
+		"object": insertInput,
+	})
+
+	if err != nil {
+		log.WithError(err).Error("Failed to create issue")
+		return err
+	}
+
+	return nil
+}

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -153,6 +153,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"comment":                   actions.Comment(),
 			"commentOnce":               actions.CommentOnce(),
 			"commitLint":                actions.CommitLint(),
+			"createIssue":               actions.CreateIssue(),
 			"deleteHeadBranch":          actions.DeleteHeadBranch(),
 			"disableActions":            actions.DisableActions(),
 			"error":                     actions.ErrorMsg(),


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Jun 23 11:33 UTC
This pull request includes the following changes:

1. Additions to the `builtins.go` file in the `plugins/aladino` directory include a new function `createIssue` to the list of available actions.

2. The `go.mod` file shows an update to the `github.com/reviewpad/go-lib` dependency from version `v0.0.0-20230523100931-3276b99f2619` to `v0.0.0-20230629080833-7f90e3730f59`.

3. The `builtins.go` file has several changes, including added import statements, a new type, modification to a function parameter, and a new mutation.

4. The `env.go` file includes additions of import statements, a new method, a new field, implementation of a method, and modifications to a function.

5. The `exec_test.go` file has additions of new arguments to function calls.

6. The `createIssue.go` file has new additions, including a new function, new structs, and the implementation of an action.

7. The file diff includes various changes and additions, including import statements, structs, constants, and modifications in the `go.mod` and `go.sum` files.

8. The `run.go` file shows several changes, such as import statements, initialization checks, client initialization, and modifications to functions.

9. The `mocks.go` file has changes related to modifying arguments passed to a function call.

10. The `env_test.go` file involves additions of new parameters in multiple function calls.

11. The `lang/aladino/interpreter_internal_test.go` file includes additions of new parameters in multiple functions.

Please let me know if you need further assistance or clarification regarding these code changes.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b88d7a</samp>

Added Nexus service integration to the Reviewpad CLI and the Aladino language. The Nexus service is a GraphQL API that allows creating and managing issues and other entities related to code reviews. The CLI can now insert an execution in the Nexus service when running an Aladino script. The Aladino interpreter can use the Nexus client and the execution ID to perform GraphQL queries and mutations. The Aladino language also has a new built-in action `createIssue` that creates an issue in the Nexus service. The `TargetEntity` struct was updated to include the GraphQL node IDs for the relevant GitHub entities. The `go-lib` module was updated accordingly. The tests and mocks were updated to reflect the changes in the function signatures and parameters.

Paired with @zolamk 

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b88d7a</samp>

*  Import `github.com/hasura/go-graphql-client` package and check `INPUT_NEXUS_GRAPH_SERVICE` and `INPUT_NEXUS_GRAPH_TOKEN` environment variables in `cli/cmd/run.go` ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-90ee5300adc85797bd4537cc53f7b93a501cad3d1bd40d87d77a8520258e718bL12-R17),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-90ee5300adc85797bd4537cc53f7b93a501cad3d1bd40d87d77a8520258e718bR76-R83))
* Initialize `nexusClient` variable with `graphql.NewClient` function and `WithRequestModifier` method in `cli/cmd/run.go` ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-90ee5300adc85797bd4537cc53f7b93a501cad3d1bd40d87d77a8520258e718bR126-R130))
* Pass `nexusClient` variable as an argument to `reviewpad.Run` function in `cli/cmd/run.go` and `integration_test/integration_test.go` ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-90ee5300adc85797bd4537cc53f7b93a501cad3d1bd40d87d77a8520258e718bL155-R183),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d3eb09459cc01c739c3f4a145b3bb3aeac9d7dc01757173361ab4b557fe876bbL333-R333))
* Update `github.com/reviewpad/go-lib` module to the latest version in `go.mod` ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L24-R24))
* Add `OrganizationId` and `NodeId` fields to `TargetEntity` struct in `handler/processors.go` to store the GitHub GraphQL node IDs for the organization and the entity ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L70-R77),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L92-R101),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L117-R128),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L137-R150),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L157-R172),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L177-R194),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L197-R216),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L217-R238),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L237-R260),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L276-R301),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L317-R344),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L357-R386),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L454-R485),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L472-R505),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L516-R551),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L533-R570),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L564-R603))
* Add `nexusClient` parameter to `NewInterpreter` function in `lang/aladino/interpreter.go` and `lang/aladino/interpreter_internal_test.go` to pass the Nexus client to the interpreter ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becR357),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395L775-R780),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R800),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R1048))
* Add `executionID` parameter to `NewInterpreter` function in `lang/aladino/interpreter.go` and `lang/aladino/interpreter_internal_test.go` to pass the execution ID to the interpreter ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL360-R378),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R806),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395R1054))
* Add `GetNexusClient` and `GetExecutionID` methods to `Env` interface in `lang/aladino/env.go` to return the Nexus client and the execution ID ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R40),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R56))
* Implement `GetNexusClient` and `GetExecutionID` methods for `BaseEnv` struct in `lang/aladino/env.go` ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R93-R96),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R161-R164))
* Add `NexusClient` and `ExecutionID` fields to `BaseEnv` struct in `lang/aladino/env.go` ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R64),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R78))
* Add `nexusClient` and `executionID` parameters to `NewEvalEnv` function in `lang/aladino/env.go` and `lang/aladino/env_test.go` to pass the Nexus client and the execution ID to the environment ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R188),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R194),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R206),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9R218),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR55),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR61),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR89),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR95),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR124),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR130),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR190),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffR196))
* Add `nil` and `""` values as arguments to `mockAladinoInterpreter` and `mockEnvWith` functions in `engine/exec_test.go` and `lang/aladino/mocks.go` to match the new signatures ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2R438),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2R444),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2R715),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2R721),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-60b59276b5de7d54b1037102856a01cf3f454fd5793a4d9f57f2b01878ae927bR155),[link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-60b59276b5de7d54b1037102856a01cf3f454fd5793a4d9f57f2b01878ae927bR161))
* Register `createIssue` built-in action in `plugins/aladino/builtins.go` ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-ae30c911aa5a3b55cfee228b859bba3476c5700d9d3141d6180f16846399945cR156))
* Implement `createIssue` built-in action in `plugins/aladino/actions/createIssue.go` to create an issue in the Nexus service using the GraphQL client and the execution ID ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-41ea7df00da2fa952b086d7ddec1e7e79fe9f67b66f4fa48b0871b47595cea8fR1-R64))
* Define `AddExecutionMutation` struct in `runner.go` to represent the GraphQL mutation for inserting an execution in the Nexus service ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283R270-R275))
* Add `nexusClient` parameter to `Run` function in `runner.go` ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283R281))
* Initialize and execute `AddExecutionMutation` struct with `nexusClient` and organization ID in `Run` function in `runner.go` and obtain execution ID from the mutation response ([link](https://github.com/reviewpad/reviewpad/pull/968/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L289-R311))
