### PR TITLE
Fix a broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Conceptually, the packages are divided into four categories:
 1. Engine: The engine is the package responsible for processing the YML file. This process is divided into two stages:
     - Process the YML file to determine which workflows are enabled. The outcome of this phase is a program with the actions that will be executed over the pull request.
     - Execution of the synthesised program.
-2. [Aladino Language](https://docs.reviewpad.com/guides/aladino/specification): This is the language that is used in the `spec` property of the rules and also the actions of the workflows. The engine of Reviewpad is not specific to Aladino - this means that it is possible to add support for a new language such as `Javascript` or `Golang` in these specifications.
+2. [Aladino Language](https://docs.reviewpad.com/guides/aladino-language): This is the language that is used in the `spec` property of the rules and also the actions of the workflows. The engine of Reviewpad is not specific to Aladino - this means that it is possible to add support for a new language such as `Javascript` or `Golang` in these specifications.
 3. Plugins: The plugin package contains the built-in functions and actions that act as an abstraction to the 3rd party services such as GitHub, Jira, etc. This package is specific to each supported specification language. In the case of `plugins/aladino`, it contains the implementations of the [built-ins](https://docs.reviewpad.com/guides/built-ins).
 4. Utilities: packages, such as the collector, that provide utilities that are used in multiple places.
 


### PR DESCRIPTION
Replaced a broken link to Aladino docs in README

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Jul 23 08:31 UTC
This pull request fixes a broken link in README. It replaces a broken link to Aladino docs in the README file. Now the link points to the correct location for the Aladino Language documentation.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0e3cb5</samp>

This pull request fixes a broken link in the `README.md` file of the reviewpad project. It updates the link to the Aladino language specification to point to the correct URL.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0e3cb5</samp>

* Update the link to the Aladino language specification in `README.md` ([link](https://github.com/reviewpad/reviewpad/pull/978/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R71))
