### PR TITLE
feat: add checks

### DIFF
--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -24,6 +24,7 @@ func inlineModificator(file *ReviewpadFile) (*ReviewpadFile, error) {
 		Extends:        file.Extends,
 		Imports:        file.Imports,
 		Groups:         file.Groups,
+		Checks:         file.Checks,
 		Rules:          file.Rules,
 		Labels:         file.Labels,
 		Workflows:      file.Workflows,

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -252,6 +252,7 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 		MetricsOnMerge: file.MetricsOnMerge,
 		Imports:        file.Imports,
 		Extends:        file.Extends,
+		Checks:         file.Checks,
 		Groups:         file.Groups,
 		Rules:          transformedRules,
 		Labels:         file.Labels,
@@ -315,7 +316,7 @@ func processImports(file *ReviewpadFile, env *LoadEnv) (*ReviewpadFile, error) {
 		// remove from the stack
 		delete(env.Stack, idHash)
 
-		// append labels, rules and workflows
+		file.appendChecks(subTreeFile)
 		file.appendLabels(subTreeFile)
 		file.appendGroups(subTreeFile)
 		file.appendRules(subTreeFile)

--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -87,6 +87,7 @@ func TestLoadWithAST(t *testing.T) {
 		IgnoreErrors:   &noIgnoreErrors,
 		MetricsOnMerge: &noMetricsOnMerge,
 		Extends:        []string{},
+		Checks:         map[string]engine.PadCheck{},
 		Dictionaries: []engine.PadDictionary{
 			{
 				Name: "teams",


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Jul 23 16:45 UTC
This pull request adds checks to the Reviewpad file. It also includes some code refactoring and test improvements. Overall, it adds 61 insertions and modifies 5 deletions across 4 files.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82bdf31</samp>

This pull request adds support for checks in reviewpad files, which are custom rules or validations for the code under review. It defines the `PadCheck` struct and its methods, and modifies the `ReviewpadFile` struct and its methods to handle checks. It also updates the loader, the inline rules normalizer, and the loader test to work with checks.

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
**Show**: this pull request can be auto-merged and a code review should be done post-merge
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82bdf31</samp>

*  Add the `Checks` field to the `inlineModificator` struct to allow custom checks for rules or pipelines ([link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-ea18868fc6cfa08e95023e74934900b2af69a653d53a65a962abe70616a132f6R27))
*  Remove unused edition constants from the `engine` package ([link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701L14-R15))
*  Add the `Checks` field to the `ReviewpadFile` struct and the `PadCheck` struct to represent checks in the reviewpad file ([link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R223), [link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R232-R254))
*  Modify the `equals` and `extend` methods of the `ReviewpadFile` struct to compare and merge checks ([link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701L391-R445), [link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R539))
*  Add the `Checks` field to the `ReviewpadFileAST` struct and copy it in the `transform` function ([link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-31e0d9a2beee99e1ca91227b4cf55fc6b934b0d3bfef25a56fdf5fbf28879c92R255), [link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-31e0d9a2beee99e1ca91227b4cf55fc6b934b0d3bfef25a56fdf5fbf28879c92L318-R319))
*  Add the `appendChecks` method to the `ReviewpadFile` struct and call it in the `processImports` function to handle imported checks ([link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701L391-R445), [link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-31e0d9a2beee99e1ca91227b4cf55fc6b934b0d3bfef25a56fdf5fbf28879c92L318-R319))
*  Update the `TestLoadWithAST` function to initialize the `Checks` field in the expected reviewpad file ([link](https://github.com/reviewpad/reviewpad/pull/987/files?diff=unified&w=0#diff-34dfef4f19eb650bf2195f706d2705bf093264d5e8f1e902c97a9d378a7988e9R90))
