### PR TITLE
feat: add built-in dictionaryValueFromKey

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/migueleliasweb/go-github-mock v0.0.18
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/ohler55/ojg v1.18.5
-	github.com/reviewpad/api/go v0.0.0-20230711070927-6305682fbc0b
+	github.com/reviewpad/api/go v0.0.0-20230621093220-febd5695b708
 	github.com/reviewpad/go-conventionalcommits v0.10.0
 	github.com/reviewpad/go-lib v0.0.0-20230523100931-3276b99f2619
 	github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYr
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/reviewpad/api/go v0.0.0-20230711070927-6305682fbc0b h1:rhPMOZrwutKJIe70n1e/lihjn5fRanc7WI7avzVtchE=
-github.com/reviewpad/api/go v0.0.0-20230711070927-6305682fbc0b/go.mod h1:Ip1ZnFEOM9DSgAkjjKxBOV7LTIzj5MxKHirgaDRzGb0=
+github.com/reviewpad/api/go v0.0.0-20230621093220-febd5695b708 h1:q0JE5HmaeBiBH8NuLI7WsJ4JMSDlQkvvcEkiWGCT0Ks=
+github.com/reviewpad/api/go v0.0.0-20230621093220-febd5695b708/go.mod h1:Ip1ZnFEOM9DSgAkjjKxBOV7LTIzj5MxKHirgaDRzGb0=
 github.com/reviewpad/go-conventionalcommits v0.10.0 h1:49Fv1q5vougqA7g5mpFZ+W5sQs9kJ5F5zH7kCEwZ+w8=
 github.com/reviewpad/go-conventionalcommits v0.10.0/go.mod h1:NWUK2G+V+KrhmHW2fBAWGEgZFW8jUXqqBkm9mYJJNi4=
 github.com/reviewpad/go-lib v0.0.0-20230523100931-3276b99f2619 h1:TwttNjQ5548Q+ASYu6prIO4CNt2S9LQFZFfmO5794ds=

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -120,6 +120,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"any":                           functions.Any(),
 			"append":                        functions.AppendString(),
 			"contains":                      functions.Contains(),
+			"dictionaryValueFromKey":        functions.DictionaryValueFromKey(),
 			"extractMarkdownHeadingContent": functions.ExtractMarkdownHeadingContent(),
 			"isElementOf":                   functions.IsElementOf(),
 			"join":                          functions.Join(),

--- a/plugins/aladino/functions/dictionaryValueFromKey.go
+++ b/plugins/aladino/functions/dictionaryValueFromKey.go
@@ -1,0 +1,36 @@
+// Copyright 2023 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"fmt"
+
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+)
+
+func DictionaryValueFromKey() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           lang.BuildFunctionType([]lang.Type{lang.BuildStringType(), lang.BuildStringType()}, lang.BuildStringType()),
+		Code:           dictionaryValueFromKeyCode,
+		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest, entities.Issue},
+	}
+}
+
+func dictionaryValueFromKeyCode(e aladino.Env, args []lang.Value) (lang.Value, error) {
+	dictionaryName := args[0].(*lang.StringValue).Val
+	dictionaryKeyName := args[1].(*lang.StringValue).Val
+
+	if val, ok := e.GetRegisterMap()[fmt.Sprintf("@dictionary:%s", dictionaryName)]; ok {
+		if keyValue, ok := val.(*lang.DictionaryValue).Vals[dictionaryKeyName]; ok {
+			return keyValue, nil
+		} else {
+			return nil, fmt.Errorf("no key with name %v in dictionary %v", dictionaryKeyName, dictionaryName)
+		}
+	}
+
+	return nil, fmt.Errorf("no dictionary with name %v", dictionaryName)
+}


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jul 23 10:38 UTC
This pull request adds a new built-in function called "dictionaryValueFromKey" to the "aladino" plugin. This function allows retrieving the value of a specific key from a dictionary. The function takes two arguments: the name of the dictionary and the key to retrieve. If the dictionary and key exist, the function returns the corresponding value. Otherwise, it returns an error message. This patch also includes the necessary changes to the go.mod and go.sum files.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba8d429</samp>

Updated the reviewpad/api/go module and added a new aladino built-in function `dictionaryValueFromKey` that allows accessing values from predefined dictionaries in the aladino environment. This function can be used for both pull requests and issues.

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
**Show**: this pull request can be auto-merged and a code review should be done post-merge
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba8d429</samp>

*  Update go module dependency to use latest reviewpad/api/go version ([link](https://github.com/reviewpad/reviewpad/pull/999/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L22-R22))
*  Add dictionaryValueFromKey built-in function to aladino plugin system ([link](https://github.com/reviewpad/reviewpad/pull/999/files?diff=unified&w=0#diff-ae30c911aa5a3b55cfee228b859bba3476c5700d9d3141d6180f16846399945cR123), [link](https://github.com/reviewpad/reviewpad/pull/999/files?diff=unified&w=0#diff-ed5305a49208fa00a80e5090a3ba80eff5d17ccfe3b3e62fa19814436d178635R1-R36))
