### PR TITLE
fix: dictionaryValueFromKey return type

### DIFF
--- a/engine/loader_test.go
+++ b/engine/loader_test.go
@@ -370,7 +370,7 @@ func TestLoad(t *testing.T) {
 		"when the file has invalid extends": {
 			inputReviewpadFilePath: "testdata/loader/reviewpad_with_invalid_extends.yml",
 			inputContext:           context.Background(),
-			wantErr:                "fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/action/blob/main/main.go",
+			wantErr:                "fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/reviewpad/blob/main/reviewpad.yml",
 		},
 		"when the file has an extends": {
 			inputReviewpadFilePath: "testdata/loader/reviewpad_with_extends.yml",

--- a/plugins/aladino/functions/dictionaryValueFromKey.go
+++ b/plugins/aladino/functions/dictionaryValueFromKey.go
@@ -14,7 +14,7 @@ import (
 
 func DictionaryValueFromKey() *aladino.BuiltInFunction {
 	return &aladino.BuiltInFunction{
-		Type:           lang.BuildFunctionType([]lang.Type{lang.BuildStringType(), lang.BuildStringType()}, lang.BuildStringType()),
+		Type:           lang.BuildFunctionType([]lang.Type{lang.BuildStringType(), lang.BuildStringType()}, lang.BuildArrayOfType(lang.BuildStringType())),
 		Code:           dictionaryValueFromKeyCode,
 		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest, entities.Issue},
 	}

--- a/utils/url_test.go
+++ b/utils/url_test.go
@@ -36,19 +36,19 @@ func TestValidateUrl(t *testing.T) {
 			url:              "https://github.com/reviewpad/.github/blo/main/reviewpad-models/common.yml",
 			expectedBranch:   nil,
 			expectedFilePath: "",
-			expectedErr:      errors.New("fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/action/blob/main/main.go"),
+			expectedErr:      errors.New("fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/reviewpad/blob/main/reviewpad.yml"),
 		},
 		"url without https": {
 			url:              "github.com/reviewpad/.github/blob/main/reviewpad-models/common.yml",
 			expectedBranch:   nil,
 			expectedFilePath: "",
-			expectedErr:      errors.New("fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/action/blob/main/main.go"),
+			expectedErr:      errors.New("fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/reviewpad/blob/main/reviewpad.yml"),
 		},
 		"invalid github url": {
 			url:              "https://gitlab.com/reviewpad/.github/blo/main/reviewpad-models/common.yml",
 			expectedBranch:   nil,
 			expectedFilePath: "",
-			expectedErr:      errors.New("fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/action/blob/main/main.go"),
+			expectedErr:      errors.New("fatal: url must be a link to a GitHub blob, e.g. https://github.com/reviewpad/reviewpad/blob/main/reviewpad.yml"),
 		},
 	}
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Jul 23 07:43 UTC
This pull request includes two patches. 

The first patch fixes the return type of the `DictionaryValueFromKey` function in the `dictionaryValueFromKey.go` file. The return type was changed from `string` to `[]string`.

The second patch fixes the unit tests in the `loader_test.go` and `url_test.go` files. The changes involve updating the expected error messages for some test cases.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43ffb07</samp>

Changed the return type of `DictionaryValueFromKey` function to support filtering by multiple labels. Updated `plugins/aladino/functions/dictionaryValueFromKey.go` to reflect this change.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43ffb07</samp>

* Change the return type of `DictionaryValueFromKey` to an array of strings ([link](https://github.com/reviewpad/reviewpad/pull/1003/files?diff=unified&w=0#diff-ed5305a49208fa00a80e5090a3ba80eff5d17ccfe3b3e62fa19814436d178635L17-R17))
