### PR TITLE
feat: add activation field to pad check

### DIFF
--- a/engine/lang.go
+++ b/engine/lang.go
@@ -231,6 +231,7 @@ type ReviewpadFile struct {
 
 type PadCheck struct {
 	Severity   string                 `yaml:"severity"`
+	Activation string                 `yaml:"activation"`
 	Parameters map[string]interface{} `yaml:"parameters"`
 }
 


### PR DESCRIPTION
## Description
Adds an activation parameter on `PadCheck` which can be used to activate or deactivate checks.
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Aug 23 09:02 UTC
This pull request adds an "activation" field to the PadCheck struct in the lang.go file.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e169823</samp>

Add `Activation` field to `PadCheck` type and use it to control when to run pad checks. This enables users to customize the pad check behavior for their repositories.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e169823</samp>

* Add a new field `Activation` to the `PadCheck` type to specify the activation mode of a pad check ([link](https://github.com/reviewpad/reviewpad/pull/1009/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R234))
