### PR TITLE
refactor: change label not found log

### DIFF
--- a/plugins/aladino/actions/addLabel.go
+++ b/plugins/aladino/actions/addLabel.go
@@ -30,7 +30,7 @@ func addLabelCode(e aladino.Env, args []lang.Value) error {
 		labelName = val.(*lang.StringValue).Val
 	} else {
 		labelName = labelID
-		log.Warnf("the %v label was not found in the environment", labelID)
+		log.Infof("the '%v' label is not defined in the 'labels:' section", labelID)
 	}
 
 	return t.AddLabels([]string{labelName})

--- a/plugins/aladino/actions/removeLabel.go
+++ b/plugins/aladino/actions/removeLabel.go
@@ -30,7 +30,7 @@ func removeLabelCode(e aladino.Env, args []lang.Value) error {
 		labelName = val.(*lang.StringValue).Val
 	} else {
 		labelName = labelID
-		log.Warnf("the %v label was not found in the environment", labelID)
+		log.Infof("the '%v' label is not defined in the 'labels:' section", labelID)
 	}
 
 	return t.RemoveLabel(labelName)

--- a/plugins/aladino/actions/removeLabels.go
+++ b/plugins/aladino/actions/removeLabels.go
@@ -39,7 +39,7 @@ func removeLabelsCode(e aladino.Env, args []lang.Value) error {
 			labelName = val.(*lang.StringValue).Val
 		} else {
 			labelName = labelID
-			log.Warnf("the \"%v\" label was not found in the environment", labelID)
+			log.Infof("the '%v' label is not defined in the 'labels:' section", labelID)
 		}
 
 		err := t.RemoveLabel(labelName)


### PR DESCRIPTION
## Description
Changes log message printed when label not found in env.

Closes #1007
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Aug 23 11:36 UTC
This pull request refactors the code related to label manipulation in the aladino plugin. It changes the log messages for when a label is not found to provide more context by specifying that the label is not defined in the 'labels:' section. This change improves the clarity of the logs.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 17fffda</samp>

Changed the log level from warning to info and quoted the label ID in the `addLabel`, `removeLabel`, and `removeLabels` actions of the `aladino` plugin. This improves the user experience and the code consistency.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 17fffda</samp>

*  Lower log level and quote label ID for clarity in `addLabel`, `removeLabel`, and `removeLabels` actions ([link](https://github.com/reviewpad/reviewpad/pull/1010/files?diff=unified&w=0#diff-af0fa6fef5ab91292ff19999fb47493a2562c1dc11c50c632f51e6308fe3a19cL33-R33), [link](https://github.com/reviewpad/reviewpad/pull/1010/files?diff=unified&w=0#diff-a016e601d927ba63f583132466f4e68cae048466d9793ab19a101573f61ff6ceL33-R33), [link](https://github.com/reviewpad/reviewpad/pull/1010/files?diff=unified&w=0#diff-bb7cd828f37bc01e0a6cdb46dd9186206b139c48d6d51fd880882d2c410a7cccL42-R42))
