### PR TITLE
feat: trigger on check

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -152,7 +152,7 @@ func run() error {
 
 	for _, targetEntity := range targetEntities {
 		log.Infof("Processing entity %s/%s#%d", targetEntity.Owner, targetEntity.Repo, targetEntity.Number)
-		_, _, _, err = reviewpad.Run(ctxReq, log, gitHubClient, codeHostClient, collectorClient, targetEntity, eventDetails, reviewpadFile, nil, dryRun, safeModeRun)
+		_, _, _, err = reviewpad.Run(ctxReq, log, gitHubClient, codeHostClient, collectorClient, targetEntity, eventDetails, reviewpadFile, nil, dryRun, safeModeRun, nil)
 		if err != nil {
 			return fmt.Errorf("error running reviewpad team edition. Details %v", err.Error())
 		}

--- a/engine/env.go
+++ b/engine/env.go
@@ -47,6 +47,7 @@ type Interpreter interface {
 	ProcessIterable(expr string) (lang.Value, error)
 	StoreTemporaryVariable(name string, value lang.Value)
 	ProcessDictionary(name string, dictionary map[string]string) error
+	GetChecksWithIssues() []string
 }
 
 type Env struct {

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -332,6 +332,22 @@ func ExecConfigurationFile(env *Env, file *ReviewpadFile) (ExitStatus, *Program,
 
 	// process workflows
 	for _, workflow := range file.Workflows {
+		if workflow.TriggerOnCheck != "" {
+			shouldRun := false
+			checksWithIssues := env.Interpreter.GetChecksWithIssues()
+
+			for _, check := range checksWithIssues {
+				if check == workflow.TriggerOnCheck {
+					shouldRun = true
+					break
+				}
+			}
+
+			if !shouldRun {
+				continue
+			}
+		}
+
 		log.Infof("executing workflow `%v`", workflow.Name)
 		workflowLog := log.WithField("workflow", workflow.Name)
 

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -440,6 +440,7 @@ func TestExecConfigurationFile(t *testing.T) {
 				engine.DefaultMockEventPayload,
 				builtIns,
 				nil,
+				nil,
 			)
 			if err != nil {
 				assert.FailNow(t, fmt.Sprintf("mockAladinoInterpreter: %v", err))
@@ -714,6 +715,7 @@ func mockAladinoInterpreter(githubClient *gh.GithubClient, codehostClient *codeh
 		engine.DefaultMockTargetEntity,
 		engine.DefaultMockEventPayload,
 		aladino.MockBuiltIns(),
+		nil,
 		nil,
 	)
 	if err != nil {

--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -61,12 +61,13 @@ func inlineModificator(file *ReviewpadFile) (*ReviewpadFile, error) {
 
 func processWorkflow(workflow PadWorkflow, currentRules []PadRule) (*PadWorkflow, []PadRule, error) {
 	wf := &PadWorkflow{
-		Name:        workflow.Name,
-		Description: workflow.Description,
-		AlwaysRun:   workflow.AlwaysRun,
-		Rules:       workflow.Rules,
-		Actions:     workflow.Actions,
-		On:          workflow.On,
+		Name:           workflow.Name,
+		Description:    workflow.Description,
+		AlwaysRun:      workflow.AlwaysRun,
+		Rules:          workflow.Rules,
+		Actions:        workflow.Actions,
+		On:             workflow.On,
+		TriggerOnCheck: workflow.TriggerOnCheck,
 	}
 
 	runs, runRules, err := normalizeRun(workflow.NonNormalizedRun, currentRules)

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -109,6 +109,7 @@ type PadWorkflow struct {
 	NonNormalizedActions any                         `yaml:"then"`
 	NonNormalizedElse    any                         `yaml:"else"`
 	NonNormalizedRun     any                         `yaml:"run"`
+	TriggerOnCheck       string                      `yaml:"trigger-on-check"`
 }
 
 type PadWorkflowRunBlock struct {

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -213,11 +213,12 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 		}
 
 		transformedWorkflows = append(transformedWorkflows, PadWorkflow{
-			Name:        workflow.Name,
-			On:          transformedOn,
-			Description: workflow.Description,
-			AlwaysRun:   workflow.AlwaysRun,
-			Runs:        workflow.Runs,
+			Name:           workflow.Name,
+			On:             transformedOn,
+			Description:    workflow.Description,
+			AlwaysRun:      workflow.AlwaysRun,
+			Runs:           workflow.Runs,
+			TriggerOnCheck: workflow.TriggerOnCheck,
 		})
 	}
 

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -330,7 +330,7 @@ func TestIntegration(t *testing.T) {
 			// execute the reviewpad files one by one and
 			// ensure there are no errors and exit statuses match
 			for i, file := range test.reviewpadFiles {
-				exitStatus, _, _, err := reviewpad.Run(ctxReq, logger, githubClient, codeHostClient, collector, targetEntity, eventDetails, file, nil, false, false)
+				exitStatus, _, _, err := reviewpad.Run(ctxReq, logger, githubClient, codeHostClient, collector, targetEntity, eventDetails, file, nil, false, false, nil)
 				assert.Equal(test.wantErr, err)
 				assert.Equal(test.exitStatus[i], exitStatus)
 			}

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -51,6 +51,7 @@ type Env interface {
 	GetCheckRunID() *int64
 	SetCheckRunConclusion(string)
 	GetCheckRunConclusion() string
+	GetChecksWithIssues() []string
 }
 
 type BaseEnv struct {
@@ -71,6 +72,7 @@ type BaseEnv struct {
 	ExecFatalErrorOccurred   error
 	CheckRunID               *int64
 	CheckRunConclusion       string
+	ChecksWithIssues         []string
 }
 
 func (e *BaseEnv) GetBuiltIns() *BuiltIns {
@@ -149,6 +151,10 @@ func (e *BaseEnv) GetCheckRunID() *int64 {
 	return e.CheckRunID
 }
 
+func (e *BaseEnv) GetChecksWithIssues() []string {
+	return e.ChecksWithIssues
+}
+
 func NewTypeEnv(e Env) TypeEnv {
 	builtInsType := make(map[string]lang.Type)
 	for builtInName, builtInFunction := range e.GetBuiltIns().Functions {
@@ -177,6 +183,7 @@ func NewEvalEnv(
 	eventPayload interface{},
 	builtIns *BuiltIns,
 	checkRunID *int64,
+	checksWithIssues []string,
 ) (Env, error) {
 	registerMap := RegisterMap(make(map[string]lang.Value))
 	report := &Report{Actions: make([]string, 0)}

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -206,6 +206,7 @@ func NewEvalEnv(
 		ExecWaitGroup:            &wg,
 		ExecMutex:                &mu,
 		CheckRunID:               checkRunID,
+		ChecksWithIssues:         checksWithIssues,
 	}
 
 	switch targetEntity.Kind {

--- a/lang/aladino/env_test.go
+++ b/lang/aladino/env_test.go
@@ -57,6 +57,7 @@ func TestNewEvalEnv_WhenGetPullRequestFilesFails(t *testing.T) {
 		nil,
 		aladino.MockBuiltIns(),
 		nil,
+		nil,
 	)
 
 	assert.Nil(t, env)
@@ -88,6 +89,7 @@ func TestNewEvalEnv_WhenNewFileFails(t *testing.T) {
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 		nil,
 	)
 
@@ -121,6 +123,7 @@ func TestNewEvalEnv(t *testing.T) {
 		aladino.DefaultMockTargetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 		nil,
 	)
 
@@ -185,6 +188,7 @@ func TestNewEvalEnv_WhenGetPullRequestFails(t *testing.T) {
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
+		nil,
 		nil,
 	)
 

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"errors"
+
 	"github.com/reviewpad/go-lib/entities"
 	"github.com/reviewpad/reviewpad/v4/codehost"
 	gh "github.com/reviewpad/reviewpad/v4/codehost/github"
@@ -346,6 +347,10 @@ func (i *Interpreter) GetCheckRunConclusion() string {
 	return i.Env.GetCheckRunConclusion()
 }
 
+func (i *Interpreter) GetChecksWithIssues() []string {
+	return i.Env.GetChecksWithIssues()
+}
+
 func NewInterpreter(
 	ctx context.Context,
 	logger *logrus.Entry,
@@ -357,8 +362,9 @@ func NewInterpreter(
 	eventPayload interface{},
 	builtIns *BuiltIns,
 	checkRunID *int64,
+	checksWithIssues []string,
 ) (engine.Interpreter, error) {
-	evalEnv, err := NewEvalEnv(ctx, logger, dryRun, githubClient, codeHostClient, collector, targetEntity, eventPayload, builtIns, checkRunID)
+	evalEnv, err := NewEvalEnv(ctx, logger, dryRun, githubClient, codeHostClient, collector, targetEntity, eventPayload, builtIns, checkRunID, checksWithIssues)
 	if err != nil {
 		return nil, err
 	}

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -776,6 +776,7 @@ func TestNewInterpreter_WhenNewEvalEnvFails(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	assert.Nil(t, gotInterpreter)
@@ -799,6 +800,7 @@ func TestNewInterpreter(t *testing.T) {
 		DefaultMockTargetEntity,
 		mockedEnv.GetEventPayload(),
 		mockedEnv.GetBuiltIns(),
+		nil,
 		nil,
 	)
 
@@ -1043,6 +1045,7 @@ func TestReportMetric(t *testing.T) {
 				env.GetCodeHostClient(),
 				env.GetCollector(),
 				env.GetTarget().GetTargetEntity(),
+				nil,
 				nil,
 				nil,
 				nil,

--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -157,6 +157,7 @@ func mockEnvWith(prOwner string, prRepoName string, prNum int, githubClient *gh.
 		eventPayload,
 		builtIns,
 		nil,
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/lang/type_internal_test.go
+++ b/lang/type_internal_test.go
@@ -254,3 +254,24 @@ func TestEquals_WhenArrayOfTypeComparedToDynamicArrayType(t *testing.T) {
 
 	assert.True(t, arrayOfType.Equals(dynamicArrayType))
 }
+
+func TestEquals_WhenTwoJSONTypes(t *testing.T) {
+	jsonType1 := BuildJSONType()
+	otherType := BuildJSONType()
+
+	assert.True(t, jsonType1.Equals(otherType))
+}
+
+func TestEquals_WhenTwoDictionaryTypes(t *testing.T) {
+	dictionaryType := BuildDictionaryType()
+	otherType := BuildDictionaryType()
+
+	assert.True(t, dictionaryType.Equals(otherType))
+}
+
+func TestEquals_WhenTwoDynamicArrayType(t *testing.T) {
+	dynamicArrayType := BuildDynamicArrayType()
+	otherType := BuildDynamicArrayType()
+
+	assert.True(t, dynamicArrayType.Equals(otherType))
+}

--- a/runner.go
+++ b/runner.go
@@ -278,6 +278,7 @@ func Run(
 	checkRunId *int64,
 	dryRun bool,
 	safeMode bool,
+	checksWithIssue []string,
 ) (engine.ExitStatus, *engine.Program, string, error) {
 	config, err := plugins_aladino.DefaultPluginConfig()
 	if err != nil {
@@ -286,7 +287,7 @@ func Run(
 
 	defer config.CleanupPluginConfig()
 
-	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, codeHostClient, collector, targetEntity, eventDetails.Payload, plugins_aladino.PluginBuiltInsWithConfig(config), checkRunId)
+	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, codeHostClient, collector, targetEntity, eventDetails.Payload, plugins_aladino.PluginBuiltInsWithConfig(config), checkRunId, checksWithIssue)
 	if err != nil {
 		return engine.ExitStatusFailure, nil, "", err
 	}


### PR DESCRIPTION
## Description
Introduces ability to trigger workflows when an issue is found by a check.
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Aug 23 18:47 UTC
This pull request includes the following changes:

1. In the `mocks.go` file, a new `nil` element is added to a function call. This change does not seem to have a significant impact but may be necessary for the overall functionality of the code.

2. The `run.go` file has been modified. On line 152, an additional argument `nil` is added to a function call to the `reviewpad.Run` function. These changes appear to be related to adjusting the parameters passed to the `reviewpad.Run` function.

3. Multiple function calls in different test cases have been modified in the `mocks_test.go` file. Specifically, a `nil` parameter is added in the functions `TestNewEvalEnv_WhenGetPullRequestFilesFails`, `TestNewEvalEnv_WhenNewFileFails`, `TestNewEvalEnv`, and `TestNewEvalEnv_WhenGetPullRequestFails`.

4. The `exec.go` file contains changes to the `ExecConfigurationFile` function. The changes introduce a check to determine if a workflow should run based on a triggering check. The function checks if any of the checks in `checksWithIssues` match the `triggerOnCheck` field of the workflow. If a match is found, the workflow should run; otherwise, it continues to the next workflow.

5. The `env.go` file has a new method `GetChecksWithIssues()` added to the `Interpreter` interface.

6. The `loader.go` file has changes in the `transform` function. The changes include adding a new field `TriggerOnCheck` to the `transformedWorkflows` struct in the `append` function call.

7. In the `integration_test.go` file, on line 330, a new argument `nil` is added to the function `reviewpad.Run()`.

8. The `inline_rules_normalizer.go` file contains changes to the `processWorkflow` function. These changes include adding the field `TriggerOnCheck` to the `wf` struct initialization.

9. The `interpreter_internal_test.go` file has changes related to adding `nil` values to the arguments of certain function calls in the test cases `TestNewInterpreter_WhenNewEvalEnvFails`, `TestNewInterpreter`, and `TestReportMetric`.

10. The `interpreter.go` file introduces a new function `GetChecksWithIssues()` to retrieve a slice of strings. Additionally, the `NewInterpreter` function is modified to accept an additional parameter `checksWithIssues` of type `[]string`.

11. In the `engine/lang.go` file, a new field `TriggerOnCheck` is added to the `PadWorkflow` struct.

12. The `engine/exec_test.go` file includes two changes. On line 444 and line 719, new `nil` values are added.

13. The `lang/type_internal_test.go` file has test cases added for the `Equals()` function. These tests compare various types and assert that the `Equals()` function correctly identifies identical types.

14. Changes in the `runner.go` file include a new parameter `checksWithIssue` added to the `Run` function. This parameter is used in the call to `aladino.NewInterpreter`. The `aladino.NewInterpreter` call is updated to include the `checksWithIssue` parameter.

15. The `env.go` file introduces changes to the `Env` interface and the `BaseEnv` struct. The `Env` interface now includes a new method `GetChecksWithIssues()`, which returns a slice of strings. The `BaseEnv` struct includes a new field `ChecksWithIssues` of type `[]string`. The `GetChecksWithIssues()` method is implemented in the `BaseEnv` struct to return the `ChecksWithIssues` field. The `NewEvalEnv()` function is also updated to receive a new parameter `checksWithIssues` of type `[]string` and assign it to the `ChecksWithIssues` field of the `BaseEnv` struct.

Please review these changes and ensure they align with the requirements of the system.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 05ba2b6</samp>

Add `TriggerOnCheck` field to `PadWorkflow` type to enable custom workflows based on checks. This change affects the `engine/lang.go` file.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<! -- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 05ba2b6</samp>

* Add a new field `TriggerOnCheck` to the `PadWorkflow` type to specify a check name that triggers the workflow execution ([link](https://github.com/reviewpad/reviewpad/pull/1018/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R112))
