### PR TITLE
feat: add hasAnyReviewers built-in

### DIFF
--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -642,3 +642,10 @@ func (t *PullRequestTarget) SetProjectField(projectTitle, fieldName, fieldValue 
 
 	return gh.ErrProjectHasNoSuchField
 }
+
+// GetAllReviewers returns the list of all reviewers of the pull request
+// meaning all the reviewers who have replied to the pull request.
+// and reviewers that have been requested to review the pull request but have not responded.
+func (t *PullRequestTarget) GetAllReviewers(ctx context.Context, owner, repo string, number int) ([]string, error) {
+	return t.githubClient.GetAllReviewers(ctx, owner, repo, number)
+}

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -107,6 +107,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"hasAnnotation":                          functions.HasAnnotation(),
 			"hasAnyCheckRunCompleted":                functions.HasAnyCheckRunCompleted(),
 			"hasAnyPendingReviews":                   functions.IsWaitingForReview(),
+			"hasAnyReviewers":                        functions.HasAnyReviewers(),
 			"hasAnyUnaddressedThreads":               functions.HasUnaddressedThreads(),
 			"hasBinaryFile":                          functions.HasBinaryFile(),
 			"hasCodePattern":                         functions.HasCodePattern(),

--- a/plugins/aladino/functions/hasAnyReviewers.go
+++ b/plugins/aladino/functions/hasAnyReviewers.go
@@ -1,0 +1,34 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"fmt"
+
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/codehost/github/target"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+)
+
+func HasAnyReviewers() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           lang.BuildFunctionType([]lang.Type{}, lang.BuildBoolType()),
+		Code:           hasAnyReviewersCode,
+		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest},
+	}
+}
+
+func hasAnyReviewersCode(e aladino.Env, args []lang.Value) (lang.Value, error) {
+	pr := e.GetTarget().(*target.PullRequestTarget)
+	targetEntity := e.GetTarget().GetTargetEntity()
+
+	reviewers, err := pr.GetAllReviewers(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, targetEntity.Number)
+	if err != nil {
+		return nil, fmt.Errorf("error getting reviewers. %v", err.Error())
+	}
+
+	return lang.BuildBoolValue(len(reviewers) > 0), nil
+}

--- a/plugins/aladino/functions/hasAnyReviewers_test.go
+++ b/plugins/aladino/functions/hasAnyReviewers_test.go
@@ -1,0 +1,157 @@
+package plugins_aladino_functions_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v4/plugins/aladino"
+	"github.com/reviewpad/reviewpad/v4/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var hasAnyReviewers = plugins_aladino.PluginBuiltIns().Functions["hasAnyReviewers"].Code
+
+func TestHasAnyReviewers(t *testing.T) {
+	tests := map[string]struct {
+		graphqlHandler func(http.ResponseWriter, *http.Request)
+		wantResult     lang.Value
+		wantErr        error
+	}{
+		"when graphql query errors": {
+			wantResult: (lang.Value)(nil),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: errors.New(`error getting reviewers. non-200 OK status code: 500 Internal Server Error body: ""`),
+		},
+		"when there are no reviewers": {
+			wantResult: lang.BuildBoolValue(false),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"reviewRequests": {
+									"nodes": []
+								},
+								"latestReviews": {
+									"nodes": []
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+		"when there are only requested reviewers": {
+			wantResult: lang.BuildBoolValue(true),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"reviewRequests": {
+									"nodes": [
+										{
+											"requestedReviewer": {
+												"login": "test"
+											}
+										},
+										{
+											"requestedReviewer": {
+												"slug": "test2"
+											}
+										}
+									]
+								},
+								"latestReviews": {
+									"nodes": []
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+		"when there are only latest reviews": {
+			wantResult: lang.BuildBoolValue(true),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"reviewRequests": {
+									"nodes": []
+								},
+								"latestReviews": {
+									"nodes": [
+										{
+											"author": {
+												"login": "test"
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+		"when there are both requested reviewers and latest reviews": {
+			wantResult: lang.BuildBoolValue(true),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"reviewRequests": {
+									"nodes": [
+										{
+											"requestedReviewer": {
+												"login": "test"
+											}
+										},
+										{
+											"requestedReviewer": {
+												"slug": "test2"
+											}
+										}
+									]
+								},
+								"latestReviews": {
+									"nodes": [
+										{
+											"author": {
+												"login": "test"
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := aladino.MockDefaultEnv(t, []mock.MockBackendOption{}, test.graphqlHandler, aladino.MockBuiltIns(), nil)
+
+			res, err := hasAnyReviewers(env, []lang.Value{})
+
+			assert.Equal(t, test.wantResult, res)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Adds a new `hasAnyReviewers` built-in
Closes #1025 
reviewpad:summary 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfb3172</samp>

This pull request adds a new feature to get all the reviewers of a pull request using the GitHub GraphQL API. It implements a new method for the `GithubClient` and the `PullRequestTarget` types, a new built-in function `hasAnyReviewers` for the Aladino plugin, and unit tests for the function.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dfb3172</samp>

*  Add `HasAnyReviewers` function to check if a pull request has any reviewers ([link](https://github.com/reviewpad/reviewpad/pull/1032/files?diff=unified&w=0#diff-9a5a2594b884e891936f3271599b34c72ffa62de813325bbd5e3aee7974b2e8fR1-R34), [link](https://github.com/reviewpad/reviewpad/pull/1032/files?diff=unified&w=0#diff-ae30c911aa5a3b55cfee228b859bba3476c5700d9d3141d6180f16846399945cR110))
  - Use `GetAllReviewers` method of `PullRequestTarget` to get a slice of reviewer logins ([link](https://github.com/reviewpad/reviewpad/pull/1032/files?diff=unified&w=0#diff-941cc2c2b19ac7ec6160457e465d3089df7aa23e19248596ec71396396dc7c54R645-R651))
  - Implement `GetAllReviewers` method of `GithubClient` using GraphQL query ([link](https://github.com/reviewpad/reviewpad/pull/1032/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09R898-R927), [link](https://github.com/reviewpad/reviewpad/pull/1032/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09R210-R235), [link](https://github.com/reviewpad/reviewpad/pull/1032/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09R16))
  - Define `GetAllReviewersQuery` struct to represent the GraphQL query ([link](https://github.com/reviewpad/reviewpad/pull/1032/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09R210-R235))
  - Import `github.com/shurcooL/graphql` package for GraphQL client ([link](https://github.com/reviewpad/reviewpad/pull/1032/files?diff=unified&w=0#diff-29b77f400aba0019f811c60bcf1b42ac02a43b6a69e1f7fd72df376e6d2efc09R16))
* Add unit tests for `HasAnyReviewers` function using mock GraphQL responses ([link](https://github.com/reviewpad/reviewpad/pull/1032/files?diff=unified&w=0#diff-0088618b3be15e14637a82907eb4e0d227c18afe7da0472909e60959dbb54a84R1-R157))
  - Use `codehost/github/target/pull_request_target.go` file for testing ([link](https://github.com/reviewpad/reviewpad/pull/1032/files?diff=unified&w=0#diff-941cc2c2b19ac7ec6160457e465d3089df7aa23e19248596ec71396396dc7c54R645-R651))
