### PR TITLE
feat: add has label built-in

### DIFF
--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -115,6 +115,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"hasFileExtensions":                      functions.HasFileExtensions(),
 			"hasFileName":                            functions.HasFileName(),
 			"hasFilePattern":                         functions.HasFilePattern(),
+			"hasLabel":                               functions.HasLabel(),
 			"hasGitConflicts":                        functions.HasGitConflicts(),
 			"hasLinearHistory":                       functions.HasLinearHistory(),
 			"hasLinkedIssues":                        functions.HasLinkedIssues(),

--- a/plugins/aladino/functions/hasLabel.go
+++ b/plugins/aladino/functions/hasLabel.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+)
+
+func HasLabel() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           lang.BuildFunctionType([]lang.Type{lang.BuildStringType()}, lang.BuildBoolType()),
+		Code:           hasLabelCode,
+		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest, entities.Issue},
+	}
+}
+
+func hasLabelCode(e aladino.Env, args []lang.Value) (lang.Value, error) {
+	label := args[0].(*lang.StringValue)
+
+	labels := e.GetTarget().GetLabels()
+	for _, l := range labels {
+		if l.Name == label.Val {
+			return lang.BuildTrueValue(), nil
+		}
+	}
+
+	return lang.BuildFalseValue(), nil
+}

--- a/plugins/aladino/functions/hasLabel_test.go
+++ b/plugins/aladino/functions/hasLabel_test.go
@@ -1,0 +1,49 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions_test
+
+import (
+	"testing"
+
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v4/plugins/aladino"
+	"github.com/stretchr/testify/assert"
+)
+
+var hasLabel = plugins_aladino.PluginBuiltIns().Functions["hasLabel"].Code
+
+func TestHasLabel(t *testing.T) {
+	tests := map[string]struct {
+		wantResult lang.Value
+		wantErr    error
+		label      string
+	}{
+		"when label exists": {
+			wantResult: lang.BuildTrueValue(),
+			label:      "large",
+		},
+		"when another label exists": {
+			wantResult: lang.BuildTrueValue(),
+			label:      "enhancement",
+		},
+		"when label does not exist": {
+			wantResult: lang.BuildFalseValue(),
+			label:      "small",
+		},
+	}
+	for name, test := range tests {
+
+		t.Run(name, func(t *testing.T) {
+			env := aladino.MockDefaultEnv(t, []mock.MockBackendOption{}, nil, aladino.MockBuiltIns(), nil)
+
+			res, err := hasLabel(env, []lang.Value{lang.BuildStringValue(test.label)})
+
+			assert.Equal(t, test.wantResult, res)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description
adds new `hasLabel` built-in

Closes #1026 

reviewpad:summary 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ae99b3</samp>

Add `hasLabel` built-in function for Aladino language. This function allows filtering or sorting pull requests or issues based on their labels. The change includes the function implementation, registration, and tests in the `plugins/aladino` package.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9ae99b3</samp>

*  Register the `hasLabel` built-in function for the Aladino language ([link](https://github.com/reviewpad/reviewpad/pull/1033/files?diff=unified&w=0#diff-ae30c911aa5a3b55cfee228b859bba3476c5700d9d3141d6180f16846399945cR118))
* Implement the `hasLabel` function in `plugins/aladino/functions/hasLabel.go` ([link](https://github.com/reviewpad/reviewpad/pull/1033/files?diff=unified&w=0#diff-c51e7339cbf73023c95044900d814dd57542414ebbe3c4084799ce539c706875R1-R32))
* Add unit tests for the `hasLabel` function in `plugins/aladino/functions/hasLabel_test.go` ([link](https://github.com/reviewpad/reviewpad/pull/1033/files?diff=unified&w=0#diff-802979e792ef1a6a3474e4f46bdb82818b14a7718c1d06eb0292dc85854629e5R1-R49))
