### PR TITLE
feat: add has only approved reviews built-in

### DIFF
--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -649,3 +649,7 @@ func (t *PullRequestTarget) SetProjectField(projectTitle, fieldName, fieldValue 
 func (t *PullRequestTarget) GetAllReviewers(ctx context.Context, owner, repo string, number int) ([]string, error) {
 	return t.githubClient.GetAllReviewers(ctx, owner, repo, number)
 }
+
+func (t *PullRequestTarget) GetAllReviewersApproved(ctx context.Context, owner, repo string, number int) (bool, error) {
+	return t.githubClient.GetAllReviewersApproved(ctx, owner, repo, number)
+}

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -116,6 +116,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"hasFileName":                            functions.HasFileName(),
 			"hasFilePattern":                         functions.HasFilePattern(),
 			"hasLabel":                               functions.HasLabel(),
+			"hasOnlyApprovedReviews":                 functions.HasOnlyApprovedReviews(),
 			"hasGitConflicts":                        functions.HasGitConflicts(),
 			"hasLinearHistory":                       functions.HasLinearHistory(),
 			"hasLinkedIssues":                        functions.HasLinkedIssues(),

--- a/plugins/aladino/functions/hasOnlyApprovedReviews.go
+++ b/plugins/aladino/functions/hasOnlyApprovedReviews.go
@@ -1,0 +1,34 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"fmt"
+
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/codehost/github/target"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+)
+
+func HasOnlyApprovedReviews() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           lang.BuildFunctionType([]lang.Type{}, lang.BuildBoolType()),
+		Code:           hasOnlyApprovedReviewsCode,
+		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest},
+	}
+}
+
+func hasOnlyApprovedReviewsCode(e aladino.Env, args []lang.Value) (lang.Value, error) {
+	pr := e.GetTarget().(*target.PullRequestTarget)
+	targetEntity := e.GetTarget().GetTargetEntity()
+
+	hasOnlyApprovedReviews, err := pr.GetAllReviewersApproved(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, targetEntity.Number)
+	if err != nil {
+		return nil, fmt.Errorf("error getting approved reviews. %v", err.Error())
+	}
+
+	return lang.BuildBoolValue(hasOnlyApprovedReviews), nil
+}

--- a/plugins/aladino/functions/hasOnlyApprovedReviews_test.go
+++ b/plugins/aladino/functions/hasOnlyApprovedReviews_test.go
@@ -1,0 +1,124 @@
+package plugins_aladino_functions_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v4/plugins/aladino"
+	"github.com/reviewpad/reviewpad/v4/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var hasOnlyApprovedReviews = plugins_aladino.PluginBuiltIns().Functions["hasOnlyApprovedReviews"].Code
+
+func TestHasOnlyApprovedReviews(t *testing.T) {
+	tests := map[string]struct {
+		graphqlHandler func(http.ResponseWriter, *http.Request)
+		wantResult     lang.Value
+		wantErr        error
+	}{
+		"when graphql query errors": {
+			wantResult: (lang.Value)(nil),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: errors.New(`error getting approved reviews. non-200 OK status code: 500 Internal Server Error body: ""`),
+		},
+		"when there are review requests with no response": {
+			wantResult: lang.BuildBoolValue(false),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"reviewRequests": {
+									"totalCount": 2
+								},
+								"latestReviews": {
+									"nodes": [
+										{
+											"state": "APPROVED"
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+		"when all reviewers have responded but one with requested changes": {
+			wantResult: lang.BuildBoolValue(false),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"reviewRequests": {
+									"totalCount": 0
+								},
+								"latestReviews": {
+									"nodes": [
+										{
+											"state": "APPROVED"
+										},
+										{
+											"state": "CHANGES_REQUESTED"
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+		"when all reviewers have responded with approval": {
+			wantResult: lang.BuildBoolValue(true),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"reviewRequests": {
+									"totalCount": 0
+								},
+								"latestReviews": {
+									"nodes": [
+										{
+											"state": "APPROVED"
+										},
+										{
+											"state": "APPROVED"
+										},
+										{
+											"state": "APPROVED"
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := aladino.MockDefaultEnv(t, []mock.MockBackendOption{}, test.graphqlHandler, aladino.MockBuiltIns(), nil)
+
+			res, err := hasOnlyApprovedReviews(env, []lang.Value{})
+
+			assert.Equal(t, test.wantResult, res)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Add `hasOnlyApprovedReviews` built-in function which returns a boolean indicating if a pr has been approved by everybody.

Closes #1027 
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Aug 23 10:44 UTC
This pull request adds a new built-in function called "hasOnlyApprovedReviews" to the Aladino plugin. The function checks if all reviewers of a pull request have approved the changes. It includes changes to the codebase to implement the function, as well as tests for the new function.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c90540</samp>

No summary available (Limit exceeded: required to process 51259 tokens, but only 50000 are allowed per call)

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c90540</samp>

No walkthrough available (Limit exceeded: required to process 51259 tokens, but only 50000 are allowed per call)
