### PR TITLE
feat: add get organization teams built-in

### DIFF
--- a/codehost/github/organization.go
+++ b/codehost/github/organization.go
@@ -1,0 +1,54 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file
+
+package github
+
+import (
+	"context"
+
+	"github.com/shurcooL/graphql"
+)
+
+type OrganizationTeamsQuery struct {
+	RepositoryOwner struct {
+		Organization struct {
+			Teams struct {
+				PageInfo struct {
+					HasNextPage bool   `graphql:"hasNextPage"`
+					EndCursor   string `graphql:"endCursor"`
+				}
+				Nodes []struct {
+					Slug string `graphql:"slug"`
+				}
+			} `graphql:"teams(first: 100, after: $cursor)"`
+		} `graphql:"... on Organization"`
+	} `graphql:"repositoryOwner(login: $owner)"`
+}
+
+func (c *GithubClient) GetOrganizationTeams(ctx context.Context, owner string) ([]string, error) {
+	hasNextPage := true
+	teams := []string{}
+	varOrganizationTeamsQuery := map[string]interface{}{
+		"owner":  graphql.String(owner),
+		"cursor": (*graphql.String)(nil),
+	}
+
+	for hasNextPage {
+		organizationTeamsQuery := &OrganizationTeamsQuery{}
+
+		err := c.GetClientGraphQL().Query(ctx, organizationTeamsQuery, varOrganizationTeamsQuery)
+		if err != nil {
+			return nil, err
+		}
+
+		varOrganizationTeamsQuery["cursor"] = graphql.String(organizationTeamsQuery.RepositoryOwner.Organization.Teams.PageInfo.EndCursor)
+		hasNextPage = organizationTeamsQuery.RepositoryOwner.Organization.Teams.PageInfo.HasNextPage
+
+		for _, team := range organizationTeamsQuery.RepositoryOwner.Organization.Teams.Nodes {
+			teams = append(teams, team.Slug)
+		}
+	}
+
+	return teams, nil
+}

--- a/codehost/github/target/common_target.go
+++ b/codehost/github/target/common_target.go
@@ -227,3 +227,7 @@ func (t *CommonTarget) setProjectV2Field(projectID, projectItemID string, fieldD
 
 	return t.githubClient.GetClientGraphQL().Mutate(ctx, &updateProjectV2ItemFieldValueMutation, updateInput, nil)
 }
+
+func (t *CommonTarget) GetOrganizationTeams(ctx context.Context, owner string) ([]string, error) {
+	return t.githubClient.GetOrganizationTeams(ctx, owner)
+}

--- a/codehost/target.go
+++ b/codehost/target.go
@@ -5,6 +5,7 @@
 package codehost
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -45,6 +46,7 @@ type Target interface {
 	GetProjectV2ItemID(projectID string) (string, error)
 	IsInProject(projectTitle string) (bool, error)
 	AddToProject(projectID string) (string, error)
+	GetOrganizationTeams(context.Context, string) ([]string, error)
 }
 
 type User struct {

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/reviewpad/go-conventionalcommits v0.10.0
 	github.com/reviewpad/go-lib v0.0.0-20230523100931-3276b99f2619
 	github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9
+	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
 	github.com/sirupsen/logrus v1.9.2
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.3
@@ -51,7 +52,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xanzy/go-gitlab v0.83.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -101,6 +101,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"getLastEventTime":                       functions.LastEventAt(),
 			"getMilestone":                           functions.Milestone(),
 			"getReviewerStatus":                      functions.ReviewerStatus(),
+			"getOrganizationTeams":                   functions.GetOrganizationTeams(),
 			"getSize":                                functions.Size(),
 			"getState":                               functions.State(),
 			"getTitle":                               functions.Title(),

--- a/plugins/aladino/functions/getOrganizationTeams.go
+++ b/plugins/aladino/functions/getOrganizationTeams.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"fmt"
+
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+)
+
+func GetOrganizationTeams() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           lang.BuildFunctionType([]lang.Type{}, lang.BuildArrayOfType(lang.BuildStringType())),
+		Code:           getOrganizationTeamsCode,
+		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest, entities.Issue},
+	}
+}
+
+func getOrganizationTeamsCode(e aladino.Env, _ []lang.Value) (lang.Value, error) {
+	owner := e.GetTarget().GetTargetEntity().Owner
+
+	organizationTeams, err := e.GetTarget().GetOrganizationTeams(e.GetCtx(), owner)
+	if err != nil {
+		return nil, fmt.Errorf("error getting organization teams. %v", err.Error())
+	}
+
+	teams := []lang.Value{}
+	for _, team := range organizationTeams {
+		teams = append(teams, lang.BuildStringValue(team))
+	}
+
+	return lang.BuildArrayValue(teams), nil
+}

--- a/plugins/aladino/functions/getOrganizationTeams_test.go
+++ b/plugins/aladino/functions/getOrganizationTeams_test.go
@@ -1,0 +1,83 @@
+package plugins_aladino_functions_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v4/plugins/aladino"
+	"github.com/reviewpad/reviewpad/v4/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var getOrganizationTeams = plugins_aladino.PluginBuiltIns().Functions["getOrganizationTeams"].Code
+
+func TestGetOrganizationTeams(t *testing.T) {
+	tests := map[string]struct {
+		graphqlHandler func(http.ResponseWriter, *http.Request)
+		wantResult     lang.Value
+		wantErr        error
+	}{
+		"when graphql query errors": {
+			wantResult: (lang.Value)(nil),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: errors.New(`error getting organization teams. non-200 OK status code: 500 Internal Server Error body: ""`),
+		},
+		"when there are no teams": {
+			wantResult: lang.BuildArrayValue([]lang.Value{}),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repositoryOwner": {
+							"teams": {
+								"nodes": []
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+		"when there are teams": {
+			wantResult: lang.BuildArrayValue([]lang.Value{
+				lang.BuildStringValue("developers"),
+				lang.BuildStringValue("team"),
+			}),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repositoryOwner": {
+							"teams": {
+								"nodes": [
+									{
+										"slug": "developers"
+									},
+									{
+										"slug": "team"
+									}
+								]
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := aladino.MockDefaultEnv(t, []mock.MockBackendOption{}, test.graphqlHandler, aladino.MockBuiltIns(), nil)
+
+			res, err := getOrganizationTeams(env, []lang.Value{})
+
+			assert.Equal(t, test.wantResult, res)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}

--- a/utils/load_test.go
+++ b/utils/load_test.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadFile(t *testing.T) {
+	_, err := ReadFile("./load.go")
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
## Description
Adds a new `getOrganizationTeams` built-in function that returns a list of teams in the organization.

Closes #1028 
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Aug 23 15:13 UTC
This pull request adds a new feature of "get organization teams" to the code. It includes code changes to add the functionality, as well as tests for increased coverage.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 78fb034</samp>

Add support for querying organization teams on code hosts via Aladino scripts. Implement `GetOrganizationTeams` method for `codehost.Target` interface and `githubClient` struct. Define `getOrganizationTeams` built-in function for Aladino and unit tests.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 78fb034</samp>

*  Add `GetOrganizationTeams` method to the `Target` interface and implement it for the `CommonTarget` struct using the GitHub GraphQL API ([link](https://github.com/reviewpad/reviewpad/pull/1035/files?diff=unified&w=0#diff-2b858d8965a0d0b78d379596ea7cd062de20b260e230595c2623d3ca41e53553R49), [link](https://github.com/reviewpad/reviewpad/pull/1035/files?diff=unified&w=0#diff-7247ed9ca0aee28e6df945bad537947127c667f549506a56b77d37f51d58cf8fR230-R233), [link](https://github.com/reviewpad/reviewpad/pull/1035/files?diff=unified&w=0#diff-c1b8f9cd06f4d7bc0adacde9175d2120f3dab23841439ebc93f8d383c8f47fa2R1-R54))
*  Add `getOrganizationTeams` built-in function for the Aladino scripting language that uses the target's `GetOrganizationTeams` method to get the teams of the target owner ([link](https://github.com/reviewpad/reviewpad/pull/1035/files?diff=unified&w=0#diff-ae30c911aa5a3b55cfee228b859bba3476c5700d9d3141d6180f16846399945cR104), [link](https://github.com/reviewpad/reviewpad/pull/1035/files?diff=unified&w=0#diff-e59355c4ff4b68d7d35e200d0d45e1ef0edf78677e61d591d792dc9169b3f520R1-R37))
*  Add unit tests for the `getOrganizationTeams` function using mock backends and handlers ([link](https://github.com/reviewpad/reviewpad/pull/1035/files?diff=unified&w=0#diff-a7ea23e73b6c307edcd98c9bdcdedb8037c230c208dc0c0aaf2a62d3c60f555dR1-R83))
*  Add `context` package to the imports of `codehost/target.go` ([link](https://github.com/reviewpad/reviewpad/pull/1035/files?diff=unified&w=0#diff-2b858d8965a0d0b78d379596ea7cd062de20b260e230595c2623d3ca41e53553R8))
