### PR TITLE
feat: add get reviewers built-in

### DIFF
--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -646,8 +646,8 @@ func (t *PullRequestTarget) SetProjectField(projectTitle, fieldName, fieldValue 
 // GetAllReviewers returns the list of all reviewers of the pull request
 // meaning all the reviewers who have replied to the pull request.
 // and reviewers that have been requested to review the pull request but have not responded.
-func (t *PullRequestTarget) GetAllReviewers(ctx context.Context, owner, repo string, number int) ([]string, error) {
-	return t.githubClient.GetAllReviewers(ctx, owner, repo, number)
+func (t *PullRequestTarget) GetAllReviewers(ctx context.Context, owner, repo, state string, number int) ([]string, error) {
+	return t.githubClient.GetAllReviewers(ctx, owner, repo, state, number)
 }
 
 func (t *PullRequestTarget) GetAllReviewersApproved(ctx context.Context, owner, repo string, number int) (bool, error) {

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -153,6 +153,10 @@ func summarizeAlias(str string) string {
 	return strings.ReplaceAll(str, "$summarize()", `$robinSummarize("default", "openai-gpt-4")`)
 }
 
+func addDefaultsGetReviewers(str string) string {
+	return strings.ReplaceAll(str, "$getReviewers()", "$getReviewers(\"\")")
+}
+
 func transformAladinoExpression(str string) string {
 	transformedActionStr := str
 
@@ -172,6 +176,7 @@ func transformAladinoExpression(str string) string {
 		addDefaultsToRequestedAssignees,
 		addEmptyFilterToHasCodeWithoutSemanticChanges,
 		summarizeAlias,
+		addDefaultsGetReviewers,
 	}
 
 	for i := range transformations {

--- a/engine/transform_internal_test.go
+++ b/engine/transform_internal_test.go
@@ -431,6 +431,14 @@ func TestTransformAladinoExpression(t *testing.T) {
 			arg:     `$assignReviewer(["john", "jane"], $maxReviewers, $strategy)`,
 			wantVal: `$assignReviewer(["john", "jane"], $maxReviewers, $strategy)`,
 		},
+		"getReviewers": {
+			arg:     `$getReviewers()`,
+			wantVal: `$getReviewers("")`,
+		},
+		"getReviewers approved": {
+			arg:     `$getReviewers("APPROVED")`,
+			wantVal: `$getReviewers("APPROVED")`,
+		},
 		// TODO: test addDefaultTotalRequestedReviewers
 	}
 

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -100,6 +100,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"getLabels":                              functions.Labels(),
 			"getLastEventTime":                       functions.LastEventAt(),
 			"getMilestone":                           functions.Milestone(),
+			"getReviewers":                           functions.GetReviewers(),
 			"getReviewerStatus":                      functions.ReviewerStatus(),
 			"getOrganizationTeams":                   functions.GetOrganizationTeams(),
 			"getSize":                                functions.Size(),

--- a/plugins/aladino/functions/getReviewers.go
+++ b/plugins/aladino/functions/getReviewers.go
@@ -1,0 +1,40 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"fmt"
+
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/codehost/github/target"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+)
+
+func GetReviewers() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           lang.BuildFunctionType([]lang.Type{lang.BuildStringType()}, lang.BuildArrayOfType(lang.BuildStringType())),
+		Code:           getReviewersCode,
+		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest},
+	}
+}
+
+func getReviewersCode(e aladino.Env, args []lang.Value) (lang.Value, error) {
+	state := args[0].(*lang.StringValue).Val
+	pr := e.GetTarget().(*target.PullRequestTarget)
+	targetEntity := e.GetTarget().GetTargetEntity()
+
+	filteredReviewers, err := pr.GetAllReviewers(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, state, targetEntity.Number)
+	if err != nil {
+		return nil, fmt.Errorf("error getting all reviewers. %v", err.Error())
+	}
+
+	reviewers := []lang.Value{}
+	for _, reviewer := range filteredReviewers {
+		reviewers = append(reviewers, lang.BuildStringValue(reviewer))
+	}
+
+	return lang.BuildArrayValue(reviewers), nil
+}

--- a/plugins/aladino/functions/getReviewers_test.go
+++ b/plugins/aladino/functions/getReviewers_test.go
@@ -1,0 +1,158 @@
+package plugins_aladino_functions_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v4/plugins/aladino"
+	"github.com/reviewpad/reviewpad/v4/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var getReviewers = plugins_aladino.PluginBuiltIns().Functions["getReviewers"].Code
+
+func TestGetReviewers(t *testing.T) {
+	tests := map[string]struct {
+		graphqlHandler func(http.ResponseWriter, *http.Request)
+		wantResult     lang.Value
+		wantErr        error
+		state          string
+	}{
+		"when graphql query errors": {
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: errors.New(`error getting all reviewers. non-200 OK status code: 500 Internal Server Error body: ""`),
+		},
+		"when there are no reviewers": {
+			wantResult: lang.BuildArrayValue([]lang.Value{}),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"reviewRequests": {
+									"nodes": []
+								},
+								"latestReviews": {
+									"nodes": []
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+		"when there is no filter": {
+			wantResult: lang.BuildArrayValue([]lang.Value{
+				lang.BuildStringValue("test1"),
+				lang.BuildStringValue("test2"),
+				lang.BuildStringValue("test3"),
+			}),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"reviewRequests": {
+									"nodes": [
+										{
+											"requestedReviewer": {
+												"login": "test1"
+											}
+										},
+										{
+											"requestedReviewer": {
+												"slug": "test2"
+											}
+										}
+									]
+								},
+								"latestReviews": {
+									"nodes": [
+										{
+											"state": "APPROVED",
+											"author": {
+												"login": "test3"
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+		"when approved only": {
+			state: "approved",
+			wantResult: lang.BuildArrayValue([]lang.Value{
+				lang.BuildStringValue("test3"),
+			}),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repository": {
+							"pullRequest": {
+								"reviewRequests": {
+									"nodes": [
+										{
+											"requestedReviewer": {
+												"login": "test1"
+											}
+										},
+										{
+											"requestedReviewer": {
+												"slug": "test2"
+											}
+										}
+									]
+								},
+								"latestReviews": {
+									"nodes": [
+										{
+											"state": "APPROVED",
+											"author": {
+												"login": "test3"
+											}
+										},
+										{
+											"state": "CHANGES_REQUESTED",
+											"author": {
+												"login": "test4"
+											}
+										},
+										{
+											"state": "COMMENTED",
+											"author": {
+												"login": "test5"
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := aladino.MockDefaultEnv(t, []mock.MockBackendOption{}, test.graphqlHandler, aladino.MockBuiltIns(), nil)
+
+			res, err := getReviewers(env, []lang.Value{lang.BuildStringValue(test.state)})
+
+			assert.Equal(t, test.wantResult, res)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}

--- a/plugins/aladino/functions/hasAnyReviewers.go
+++ b/plugins/aladino/functions/hasAnyReviewers.go
@@ -25,7 +25,7 @@ func hasAnyReviewersCode(e aladino.Env, args []lang.Value) (lang.Value, error) {
 	pr := e.GetTarget().(*target.PullRequestTarget)
 	targetEntity := e.GetTarget().GetTargetEntity()
 
-	reviewers, err := pr.GetAllReviewers(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, targetEntity.Number)
+	reviewers, err := pr.GetAllReviewers(e.GetCtx(), targetEntity.Owner, targetEntity.Repo, "", targetEntity.Number)
 	if err != nil {
 		return nil, fmt.Errorf("error getting reviewers. %v", err.Error())
 	}


### PR DESCRIPTION
## Description
Add `getReviewers` built-in function

Closes #1029 
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Aug 23 15:45 UTC
This pull request includes the following changes:

1. The file `hasAnyReviewers.go` has been modified to include an additional empty string argument in the `pr.GetAllReviewers` function call.

2. The file `engine/transform.go` has undergone several changes:
   - A new function `addDefaultsGetReviewers` has been added.
   - The function `summarizeAlias` now replaces a specific string with a new string.
   - The function `transformAladinoExpression` now includes the `addDefaultsGetReviewers` function.

3. The file `getReviewers_test.go` is a new file that has been added. It contains test cases for the `getReviewers` function in the `plugins/aladino/functions` package. The test cases cover different scenarios such as handling GraphQL query errors, handling cases when there are no reviewers, handling cases with no filter, and handling cases with approved only state.

4. The diff in the file `engine/transform_internal_test.go` includes the following changes:
   - A new test case has been added for the `getReviewers` function.
   - The new test case checks if the `arg` value `$getReviewers()` is transformed to `$getReviewers("")` and if `$getReviewers("APPROVED")` is transformed to itself.
   - There is a TODO comment indicating a future test case for `addDefaultTotalRequestedReviewers`.

5. The file `getReviewers.go` is a new file under the `plugins/aladino/functions` package. It contains a function named `GetReviewers` that returns a built-in function structure. The built-in function supports specific kinds of entities and has an implementation called `getReviewersCode`. The `getReviewersCode` function retrieves the state, pull request, and target entity from the environment and calls the `GetAllReviewers` function to filter and retrieve reviewers based on the provided parameters.

6. The diff in the file `plugins/aladino/builtins.go` includes the addition of a new function called `getReviewers()` in the `PluginBuiltInsWithConfig` function.

7. The file `pull_request_target.go` has been modified to include an additional `state` parameter in the `GetAllReviewers` method of the `PullRequestTarget` struct. The `GetAllReviewersApproved` method remains unchanged.

Let me know if you need further assistance with this pull request.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42aae31</samp>

No summary available (Limit exceeded: required to process 80549 tokens, but only 50000 are allowed per call)

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42aae31</samp>

No walkthrough available (Limit exceeded: required to process 80549 tokens, but only 50000 are allowed per call)
