### PR TITLE
feat: add get user teams built-in

### DIFF
--- a/codehost/client_test.go
+++ b/codehost/client_test.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package codehost
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHostInfo(t *testing.T) {
+	hostInfo, err := GetHostInfo("https://github.com")
+	assert.Nil(t, err)
+	assert.Equal(t, &HostInfo{
+		HostUri: "https://github.com",
+	}, hostInfo)
+}

--- a/codehost/github/organization.go
+++ b/codehost/github/organization.go
@@ -26,6 +26,22 @@ type OrganizationTeamsQuery struct {
 	} `graphql:"repositoryOwner(login: $owner)"`
 }
 
+type UserTeamsQuery struct {
+	RepositoryOwner struct {
+		Organization struct {
+			Teams struct {
+				PageInfo struct {
+					HasNextPage bool   `graphql:"hasNextPage"`
+					EndCursor   string `graphql:"endCursor"`
+				}
+				Nodes []struct {
+					Slug string `graphql:"slug"`
+				}
+			} `graphql:"teams(first: 100, userLogins: [$login], after: $cursor)"`
+		} `graphql:"... on Organization"`
+	} `graphql:"repositoryOwner(login: $owner)"`
+}
+
 func (c *GithubClient) GetOrganizationTeams(ctx context.Context, owner string) ([]string, error) {
 	hasNextPage := true
 	teams := []string{}
@@ -46,6 +62,34 @@ func (c *GithubClient) GetOrganizationTeams(ctx context.Context, owner string) (
 		hasNextPage = organizationTeamsQuery.RepositoryOwner.Organization.Teams.PageInfo.HasNextPage
 
 		for _, team := range organizationTeamsQuery.RepositoryOwner.Organization.Teams.Nodes {
+			teams = append(teams, team.Slug)
+		}
+	}
+
+	return teams, nil
+}
+
+func (c *GithubClient) GetUserTeams(ctx context.Context, owner string, login string) ([]string, error) {
+	hasNextPage := true
+	teams := []string{}
+	varUserTeamsQuery := map[string]interface{}{
+		"owner":  graphql.String(owner),
+		"login":  graphql.String(login),
+		"cursor": (*graphql.String)(nil),
+	}
+
+	for hasNextPage {
+		userTeamsQuery := &UserTeamsQuery{}
+
+		err := c.GetClientGraphQL().Query(ctx, userTeamsQuery, varUserTeamsQuery)
+		if err != nil {
+			return nil, err
+		}
+
+		varUserTeamsQuery["cursor"] = graphql.String(userTeamsQuery.RepositoryOwner.Organization.Teams.PageInfo.EndCursor)
+		hasNextPage = userTeamsQuery.RepositoryOwner.Organization.Teams.PageInfo.HasNextPage
+
+		for _, team := range userTeamsQuery.RepositoryOwner.Organization.Teams.Nodes {
 			teams = append(teams, team.Slug)
 		}
 	}

--- a/codehost/github/target/common_target.go
+++ b/codehost/github/target/common_target.go
@@ -231,3 +231,7 @@ func (t *CommonTarget) setProjectV2Field(projectID, projectItemID string, fieldD
 func (t *CommonTarget) GetOrganizationTeams(ctx context.Context, owner string) ([]string, error) {
 	return t.githubClient.GetOrganizationTeams(ctx, owner)
 }
+
+func (t *CommonTarget) GetUserTeams(ctx context.Context, login string) ([]string, error) {
+	return t.githubClient.GetUserTeams(ctx, t.targetEntity.Owner, login)
+}

--- a/codehost/target.go
+++ b/codehost/target.go
@@ -47,6 +47,7 @@ type Target interface {
 	IsInProject(projectTitle string) (bool, error)
 	AddToProject(projectID string) (string, error)
 	GetOrganizationTeams(context.Context, string) ([]string, error)
+	GetUserTeams(context.Context, string) ([]string, error)
 }
 
 type User struct {

--- a/plugins/aladino/builtins.go
+++ b/plugins/aladino/builtins.go
@@ -101,6 +101,7 @@ func PluginBuiltInsWithConfig(config *PluginConfig) *aladino.BuiltIns {
 			"getLastEventTime":                       functions.LastEventAt(),
 			"getMilestone":                           functions.Milestone(),
 			"getReviewers":                           functions.GetReviewers(),
+			"getUserTeams":                           functions.GetUserTeams(),
 			"getReviewerStatus":                      functions.ReviewerStatus(),
 			"getOrganizationTeams":                   functions.GetOrganizationTeams(),
 			"getSize":                                functions.Size(),

--- a/plugins/aladino/functions/getUserTeams.go
+++ b/plugins/aladino/functions/getUserTeams.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package plugins_aladino_functions
+
+import (
+	"fmt"
+
+	"github.com/reviewpad/go-lib/entities"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+)
+
+func GetUserTeams() *aladino.BuiltInFunction {
+	return &aladino.BuiltInFunction{
+		Type:           lang.BuildFunctionType([]lang.Type{lang.BuildStringType()}, lang.BuildArrayOfType(lang.BuildStringType())),
+		Code:           getUserTeams,
+		SupportedKinds: []entities.TargetEntityKind{entities.PullRequest, entities.Issue},
+	}
+}
+
+func getUserTeams(e aladino.Env, args []lang.Value) (lang.Value, error) {
+	login := args[0].(*lang.StringValue).Val
+
+	userTeams, err := e.GetTarget().GetUserTeams(e.GetCtx(), login)
+	if err != nil {
+		return nil, fmt.Errorf("error getting user teams. %v", err.Error())
+	}
+
+	teams := []lang.Value{}
+	for _, team := range userTeams {
+		teams = append(teams, lang.BuildStringValue(team))
+	}
+
+	return lang.BuildArrayValue(teams), nil
+}

--- a/plugins/aladino/functions/getUserTeams_test.go
+++ b/plugins/aladino/functions/getUserTeams_test.go
@@ -1,0 +1,85 @@
+package plugins_aladino_functions_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/reviewpad/reviewpad/v4/lang"
+	"github.com/reviewpad/reviewpad/v4/lang/aladino"
+	plugins_aladino "github.com/reviewpad/reviewpad/v4/plugins/aladino"
+	"github.com/reviewpad/reviewpad/v4/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var getUserTeams = plugins_aladino.PluginBuiltIns().Functions["getUserTeams"].Code
+
+func TestGetUserTeams(t *testing.T) {
+	tests := map[string]struct {
+		graphqlHandler func(http.ResponseWriter, *http.Request)
+		wantResult     lang.Value
+		wantErr        error
+	}{
+		"when graphql query errors": {
+			wantResult: (lang.Value)(nil),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: errors.New(`error getting user teams. non-200 OK status code: 500 Internal Server Error body: ""`),
+		},
+		"when there are no teams": {
+			wantResult: lang.BuildArrayValue([]lang.Value{}),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repositoryOwner": {
+							"teams": {
+								"nodes": []
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+		"when there are teams": {
+			wantResult: lang.BuildArrayValue([]lang.Value{
+				lang.BuildStringValue("developers"),
+				lang.BuildStringValue("team"),
+			}),
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				utils.MustWrite(w, `{
+					"data": {
+						"repositoryOwner": {
+							"teams": {
+								"nodes": [
+									{
+										"slug": "developers"
+									},
+									{
+										"slug": "team"
+									}
+								]
+							}
+						}
+					}
+				}`)
+			},
+			wantErr: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := aladino.MockDefaultEnv(t, []mock.MockBackendOption{}, test.graphqlHandler, aladino.MockBuiltIns(), nil)
+
+			res, err := getUserTeams(env, []lang.Value{
+				lang.BuildStringValue(""),
+			})
+
+			assert.Equal(t, test.wantResult, res)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Adds a new `getUserTeams` built-in

Closes #1030 
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Aug 23 16:11 UTC
This pull request adds a new feature to the codebase, which is the addition of a built-in function called "get user teams". It also includes the necessary changes to support this new function in the codebase.

The first patch in this pull request adds the implementation of the "get user teams" function in the codebase. It includes changes to the GitHub client and organization files to support querying user teams from the GitHub API. It also includes the necessary tests for this new function.

The second patch in this pull request increases code coverage by adding a new test file for the codehost package. The test file includes a test for the "GetHostInfo" function.

Overall, this pull request introduces a new built-in function called "get user teams" and improves code coverage with additional tests.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c68867</samp>

This pull request adds a new feature to query the teams of a user in a GitHub organization. It extends the `Target` interface and the `GithubClient` type with a new `GetUserTeams` method and implements it for different target types. It also adds a new aladino built-in function `getUserTeams` that exposes this feature to the scripting language. It includes unit tests and a mock GraphQL server for testing.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c68867</samp>

*  Define a new struct `UserTeamsQuery` to represent a GraphQL query for user teams in a GitHub organization ([link](https://github.com/reviewpad/reviewpad/pull/1039/files?diff=unified&w=0#diff-c1b8f9cd06f4d7bc0adacde9175d2120f3dab23841439ebc93f8d383c8f47fa2R29-R44))
* Add a new method `GetUserTeams` to the `GithubClient` type that executes the `UserTeamsQuery` and returns a slice of team slugs ([link](https://github.com/reviewpad/reviewpad/pull/1039/files?diff=unified&w=0#diff-c1b8f9cd06f4d7bc0adacde9175d2120f3dab23841439ebc93f8d383c8f47fa2R71-R98))
* Add a new method `GetUserTeams` to the `Target` interface that is implemented by different types of targets ([link](https://github.com/reviewpad/reviewpad/pull/1039/files?diff=unified&w=0#diff-2b858d8965a0d0b78d379596ea7cd062de20b260e230595c2623d3ca41e53553R50))
* Add a new method `GetUserTeams` to the `CommonTarget` type that wraps the `GithubClient` method and passes the target entity owner and login ([link](https://github.com/reviewpad/reviewpad/pull/1039/files?diff=unified&w=0#diff-7247ed9ca0aee28e6df945bad537947127c667f549506a56b77d37f51d58cf8fR234-R237))
* Add a new built-in function `getUserTeams` to the aladino plugin that takes a login and returns an array of team slugs or an error ([link](https://github.com/reviewpad/reviewpad/pull/1039/files?diff=unified&w=0#diff-ae30c911aa5a3b55cfee228b859bba3476c5700d9d3141d6180f16846399945cR104), [link](https://github.com/reviewpad/reviewpad/pull/1039/files?diff=unified&w=0#diff-4fe9c3323b0e5550950c609a3a3365faba441fa0bcbbecb567151c5db4fd6818R1-R37))
* Add unit tests for the `getUserTeams` function using a mock GraphQL server ([link](https://github.com/reviewpad/reviewpad/pull/1039/files?diff=unified&w=0#diff-04b12257ecf76f84d696680b426bfb3c4dbf25a3fc5cfa7d3adb424cbf654f4bR1-R85))
