### PR TITLE
feat: wrap github client round tripper to track requests

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -32,7 +32,7 @@ var checkCmd = &cobra.Command{
 
 		log := log.NewLogger(logLevel)
 		ctx := context.Background()
-		githubClient := gh.NewGithubClientFromToken(ctx, token)
+		githubClient := gh.NewGithubClientFromToken(ctx, token, log)
 
 		data, err := os.ReadFile(reviewpadFilePath)
 		if err != nil {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -107,7 +107,7 @@ func run() error {
 	}
 
 	ctx := context.Background()
-	gitHubClient := gh.NewGithubClientFromToken(ctx, token)
+	gitHubClient := gh.NewGithubClientFromToken(ctx, token, log)
 	collectorClient, err := collector.NewCollector(mixpanelToken, repositoryOwner, string(entityKind), "local-cli", nil)
 	if err != nil {
 		log.Errorf("error creating new collector: %v", err)

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -54,10 +54,10 @@ func (t *RequestCountTransport) RoundTrip(req *http.Request) (*http.Response, er
 
 	if t.client.logger != nil {
 		t.client.logger.WithFields(logrus.Fields{
-			"method":        req.Method,
-			"url":           req.URL.String(),
-			"body":          string(body),
-			"current_count": t.client.totalRequests,
+			"method":                req.Method,
+			"url":                   req.URL.String(),
+			"body":                  string(body),
+			"current_request_count": t.client.totalRequests,
 		}).Debug("github client request")
 	}
 

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v52/github"
@@ -40,6 +41,11 @@ type RequestCountTransport struct {
 func (t *RequestCountTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var body []byte
 	var err error
+	requestType := "rest"
+
+	if strings.Contains(req.URL.Path, "graphql") {
+		requestType = "graphql"
+	}
 
 	t.client.totalRequests++
 
@@ -58,6 +64,7 @@ func (t *RequestCountTransport) RoundTrip(req *http.Request) (*http.Response, er
 			"url":                   req.URL.String(),
 			"body":                  string(body),
 			"current_request_count": t.client.totalRequests,
+			"request_type":          requestType,
 		}).Debug("github client request")
 	}
 

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -143,15 +143,11 @@ func (c *GithubClient) GetTotalRequests() uint64 {
 	return c.totalRequests
 }
 
-func (c *GithubClient) WithLogger(logger *logrus.Entry) *GithubClient {
-	return &GithubClient{
-		clientREST:    c.clientREST,
-		clientGQL:     c.clientGQL,
-		rawClientGQL:  c.rawClientGQL,
-		token:         c.token,
-		totalRequests: c.totalRequests,
-		logger:        logger,
-	}
+func (c *GithubClient) WithLoggerComponent(component string) {
+	c.logger = c.logger.WithFields(logrus.Fields{
+		"component":     component,
+		"new_component": component,
+	})
 }
 
 func NewGithubAppClient(gitHubAppID int64, gitHubAppPrivateKey []byte) (*GithubAppClient, error) {

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -143,6 +143,16 @@ func (c *GithubClient) GetTotalRequests() uint64 {
 	return c.totalRequests
 }
 
+func (c *GithubClient) WithLogger(logger *logrus.Entry) *GithubClient {
+	return &GithubClient{
+		clientREST:   c.clientREST,
+		clientGQL:    c.clientGQL,
+		rawClientGQL: c.rawClientGQL,
+		token:        c.token,
+		logger:       logger,
+	}
+}
+
 func NewGithubAppClient(gitHubAppID int64, gitHubAppPrivateKey []byte) (*GithubAppClient, error) {
 	transport, err := ghinstallation.NewAppsTransport(http.DefaultTransport, gitHubAppID, gitHubAppPrivateKey)
 	if err != nil {

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -143,11 +143,15 @@ func (c *GithubClient) GetTotalRequests() uint64 {
 	return c.totalRequests
 }
 
-func (c *GithubClient) WithLoggerComponent(component string) {
-	c.logger = c.logger.WithFields(logrus.Fields{
-		"component":     component,
-		"new_component": component,
-	})
+func (c *GithubClient) WithLogger(logger *logrus.Entry) *GithubClient {
+	return &GithubClient{
+		clientREST:    c.clientREST,
+		clientGQL:     c.clientGQL,
+		rawClientGQL:  c.rawClientGQL,
+		token:         c.token,
+		totalRequests: c.totalRequests,
+		logger:        logger,
+	}
 }
 
 func NewGithubAppClient(gitHubAppID int64, gitHubAppPrivateKey []byte) (*GithubAppClient, error) {

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -5,37 +5,75 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v52/github"
 	"github.com/hasura/go-graphql-client"
 	"github.com/shurcooL/githubv4"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
 type GithubClient struct {
-	clientREST   *github.Client
-	clientGQL    *githubv4.Client
-	rawClientGQL *graphql.Client
-	token        string
+	clientREST    *github.Client
+	clientGQL     *githubv4.Client
+	rawClientGQL  *graphql.Client
+	token         string
+	totalRequests uint64
+	logger        *logrus.Entry
 }
 
 type GithubAppClient struct {
 	*github.Client
 }
 
-func NewGithubClient(clientREST *github.Client, clientGQL *githubv4.Client, rawClientGQL *graphql.Client) *GithubClient {
+type RequestCountTransport struct {
+	base   http.RoundTripper
+	client *GithubClient
+}
+
+func (t *RequestCountTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body []byte
+	var err error
+
+	t.client.totalRequests++
+
+	if req.Body != nil {
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	if t.client.logger != nil {
+		t.client.logger.WithFields(logrus.Fields{
+			"method":        req.Method,
+			"url":           req.URL.String(),
+			"body":          string(body),
+			"current_count": t.client.totalRequests,
+		}).Debug("github client request")
+	}
+
+	return t.base.RoundTrip(req)
+}
+
+func NewGithubClient(clientREST *github.Client, clientGQL *githubv4.Client, rawClientGQL *graphql.Client, logger *logrus.Entry) *GithubClient {
 	return &GithubClient{
 		clientREST:   clientREST,
 		clientGQL:    clientGQL,
 		rawClientGQL: rawClientGQL,
+		logger:       logger,
 	}
 }
 
-func NewGithubClientFromToken(ctx context.Context, token string) *GithubClient {
+func NewGithubClientFromToken(ctx context.Context, token string, logger *logrus.Entry) *GithubClient {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
@@ -45,12 +83,19 @@ func NewGithubClientFromToken(ctx context.Context, token string) *GithubClient {
 	clientGQL := githubv4.NewClient(tc)
 	rawClientGQL := graphql.NewClient("https://api.github.com/graphql", tc)
 
-	return &GithubClient{
+	client := &GithubClient{
 		clientREST:   clientREST,
 		clientGQL:    clientGQL,
 		rawClientGQL: rawClientGQL,
 		token:        token,
+		logger:       logger,
 	}
+
+	// override the transport to count requests
+	oauth2Transport := tc.Transport
+	tc.Transport = &RequestCountTransport{base: oauth2Transport, client: client}
+
+	return client
 }
 
 // FIXME: Remove these to hide the implementation details.
@@ -85,6 +130,10 @@ func (c *GithubClient) GetAuthenticatedUserLogin() (string, error) {
 	}
 
 	return userLogin.Viewer.Login, nil
+}
+
+func (c *GithubClient) GetTotalRequests() uint64 {
+	return c.totalRequests
 }
 
 func NewGithubAppClient(gitHubAppID int64, gitHubAppPrivateKey []byte) (*GithubAppClient, error) {

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -145,11 +145,12 @@ func (c *GithubClient) GetTotalRequests() uint64 {
 
 func (c *GithubClient) WithLogger(logger *logrus.Entry) *GithubClient {
 	return &GithubClient{
-		clientREST:   c.clientREST,
-		clientGQL:    c.clientGQL,
-		rawClientGQL: c.rawClientGQL,
-		token:        c.token,
-		logger:       logger,
+		clientREST:    c.clientREST,
+		clientGQL:     c.clientGQL,
+		rawClientGQL:  c.rawClientGQL,
+		token:         c.token,
+		totalRequests: c.totalRequests,
+		logger:        logger,
 	}
 }
 

--- a/engine/mocks.go
+++ b/engine/mocks.go
@@ -119,7 +119,7 @@ func MockGithubClient(clientOptions []mock.MockBackendOption) *gh.GithubClient {
 	githubClientREST := github.NewClient(mock.NewMockedHTTPClient(mocks...))
 
 	// TODO: mock the graphQL client
-	return gh.NewGithubClient(githubClientREST, nil, nil)
+	return gh.NewGithubClient(githubClientREST, nil, nil, nil)
 }
 
 func MockEnvWith(githubClient *gh.GithubClient, interpreter Interpreter, targetEntity *entities.TargetEntity, eventDetails *entities.EventDetails) (*Env, error) {

--- a/handler/processors.go
+++ b/handler/processors.go
@@ -31,7 +31,7 @@ func ParseEvent(log *logrus.Entry, rawEvent string) (*ActionEvent, error) {
 	return event, nil
 }
 
-func processUnsupportedEvent(log *logrus.Entry, eventPayload interface{}) ([]*entities.TargetEntity, *entities.EventDetails, error) {
+func processUnsupportedEvent(eventPayload interface{}) ([]*entities.TargetEntity, *entities.EventDetails, error) {
 	return nil, nil, fmt.Errorf("unsupported event payload type: %T", eventPayload)
 }
 
@@ -656,35 +656,35 @@ func ProcessEvent(log *logrus.Entry, event *ActionEvent) ([]*entities.TargetEnti
 	// Handle github events triggered by actions
 	// For more information, visit: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
 	case *github.BranchProtectionRuleEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.CheckRunEvent:
 		return processCheckRunEvent(log, *event.Token, payload)
 	case *github.CheckSuiteEvent:
 		return processCheckSuiteEvent(log, *event.Token, payload)
 	case *github.CommitCommentEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.ContentReferenceEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.CreateEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.DeleteEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.DeployKeyEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.DeploymentEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.DeploymentStatusEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.DiscussionEvent:
 		return processDiscussionEvent(log, payload)
 	case *github.DiscussionCommentEvent:
 		return processDiscussionCommentEvent(log, payload)
 	case *github.ForkEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.GitHubAppAuthorizationEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.GollumEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.InstallationEvent:
 		return processInstallationEvent(log, payload)
 	case *github.InstallationRepositoriesEvent:
@@ -694,35 +694,35 @@ func ProcessEvent(log *logrus.Entry, event *ActionEvent) ([]*entities.TargetEnti
 	case *github.IssuesEvent:
 		return processIssuesEvent(log, payload)
 	case *github.LabelEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.MarketplacePurchaseEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.MemberEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.MembershipEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.MetaEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.MilestoneEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.OrganizationEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.OrgBlockEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.PackageEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.PageBuildEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.PingEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.ProjectEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.ProjectCardEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.ProjectColumnEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.PublicEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.PullRequestEvent:
 		return processPullRequestEvent(log, payload)
 	case *github.PullRequestReviewEvent:
@@ -730,44 +730,44 @@ func ProcessEvent(log *logrus.Entry, event *ActionEvent) ([]*entities.TargetEnti
 	case *github.PullRequestReviewCommentEvent:
 		return processPullRequestReviewCommentEvent(log, payload)
 	case *github.PullRequestReviewThreadEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.PullRequestTargetEvent:
 		return processPullRequestTargetEvent(log, payload)
 	case *github.PushEvent:
 		return processPushEvent(log, *event.Token, payload)
 	case *github.ReleaseEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.RepositoryEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.RepositoryDispatchEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.RepositoryImportEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.RepositoryVulnerabilityAlertEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.SecretScanningAlertEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.StarEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.StatusEvent:
 		return processStatusEvent(log, *event.Token, payload)
 	case *github.TeamEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.TeamAddEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.UserEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.WatchEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.WorkflowDispatchEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.WorkflowJobEvent:
-		return processUnsupportedEvent(log, payload)
+		return processUnsupportedEvent(payload)
 	case *github.WorkflowRunEvent:
 		return processWorkflowRunEvent(log, *event.Token, payload)
 	}
 
-	return processUnsupportedEvent(log, eventPayload)
+	return processUnsupportedEvent(eventPayload)
 }
 
 func GetEventSender(eventPayload interface{}) string {

--- a/handler/processors.go
+++ b/handler/processors.go
@@ -31,7 +31,7 @@ func ParseEvent(log *logrus.Entry, rawEvent string) (*ActionEvent, error) {
 	return event, nil
 }
 
-func processUnsupportedEvent(eventPayload interface{}) ([]*entities.TargetEntity, *entities.EventDetails, error) {
+func processUnsupportedEvent(log *logrus.Entry, eventPayload interface{}) ([]*entities.TargetEntity, *entities.EventDetails, error) {
 	return nil, nil, fmt.Errorf("unsupported event payload type: %T", eventPayload)
 }
 
@@ -41,7 +41,7 @@ func processCronEvent(log *logrus.Entry, token string, e *ActionEvent) ([]*entit
 	ctx, canc := context.WithTimeout(context.Background(), time.Minute*10)
 	defer canc()
 
-	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token)
+	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token, log)
 
 	repoParts := strings.SplitN(*e.Repository, "/", 2)
 
@@ -254,7 +254,7 @@ func processStatusEvent(log *logrus.Entry, token string, e *github.StatusEvent) 
 	ctx, canc := context.WithTimeout(context.Background(), time.Minute*10)
 	defer canc()
 
-	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token)
+	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token, log)
 
 	prs, err := ghClient.GetPullRequests(ctx, *e.Repo.Owner.Login, *e.Repo.Name)
 	if err != nil {
@@ -294,7 +294,7 @@ func processWorkflowRunEvent(log *logrus.Entry, token string, e *github.Workflow
 
 	ctx, canc := context.WithTimeout(context.Background(), time.Minute*10)
 	defer canc()
-	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token)
+	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token, log)
 
 	prs, err := ghClient.GetPullRequests(ctx, *e.Repo.Owner.Login, *e.Repo.Name)
 	if err != nil {
@@ -336,7 +336,7 @@ func processPushEvent(log *logrus.Entry, token string, e *github.PushEvent) ([]*
 	ctx, canc := context.WithTimeout(context.Background(), time.Minute*10)
 	defer canc()
 
-	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token)
+	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token, log)
 
 	repoParts := strings.SplitN(*e.GetRepo().FullName, "/", 2)
 
@@ -439,7 +439,7 @@ func processCheckRunEvent(log *logrus.Entry, token string, event *github.CheckRu
 
 	//  if the head is from a forked repository the pull_requests array will be empty on check run events
 	if len(event.CheckRun.PullRequests) == 0 {
-		prs, err := getPullRequests(token, event.GetRepo().GetFullName())
+		prs, err := getPullRequests(token, event.GetRepo().GetFullName(), log)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -501,7 +501,7 @@ func processCheckSuiteEvent(log *logrus.Entry, token string, event *github.Check
 	if len(event.CheckSuite.PullRequests) == 0 {
 		log.Infof("no pull requests found in check suite event. fetching all pull requests for repository %v", event.GetRepo().GetFullName())
 
-		prs, err := getPullRequests(token, event.GetRepo().GetFullName())
+		prs, err := getPullRequests(token, event.GetRepo().GetFullName(), log)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -554,7 +554,7 @@ func processCheckSuiteEventForMergeQueue(log *logrus.Entry, token string, event 
 		return nil, nil, fmt.Errorf("error converting pr number to int: %w", err)
 	}
 
-	pr, err := getPullRequest(token, event.GetRepo().GetFullName(), prNumber)
+	pr, err := getPullRequest(token, event.GetRepo().GetFullName(), prNumber, log)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -571,11 +571,11 @@ func processCheckSuiteEventForMergeQueue(log *logrus.Entry, token string, event 
 	}, eventDetails, nil
 }
 
-func getPullRequest(token, fullName string, prNumber int) (*github.PullRequest, error) {
+func getPullRequest(token, fullName string, prNumber int, log *logrus.Entry) (*github.PullRequest, error) {
 	ctx, canc := context.WithTimeout(context.Background(), time.Minute*10)
 	defer canc()
 
-	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token)
+	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token, log)
 
 	repoParts := strings.SplitN(fullName, "/", 2)
 
@@ -590,11 +590,11 @@ func getPullRequest(token, fullName string, prNumber int) (*github.PullRequest, 
 	return pr, nil
 }
 
-func getPullRequests(token, fullName string) ([]*github.PullRequest, error) {
+func getPullRequests(token, fullName string, log *logrus.Entry) ([]*github.PullRequest, error) {
 	ctx, canc := context.WithTimeout(context.Background(), time.Minute*10)
 	defer canc()
 
-	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token)
+	ghClient := reviewpad_gh.NewGithubClientFromToken(ctx, token, log)
 
 	repoParts := strings.SplitN(fullName, "/", 2)
 
@@ -656,35 +656,35 @@ func ProcessEvent(log *logrus.Entry, event *ActionEvent) ([]*entities.TargetEnti
 	// Handle github events triggered by actions
 	// For more information, visit: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
 	case *github.BranchProtectionRuleEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.CheckRunEvent:
 		return processCheckRunEvent(log, *event.Token, payload)
 	case *github.CheckSuiteEvent:
 		return processCheckSuiteEvent(log, *event.Token, payload)
 	case *github.CommitCommentEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.ContentReferenceEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.CreateEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.DeleteEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.DeployKeyEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.DeploymentEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.DeploymentStatusEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.DiscussionEvent:
 		return processDiscussionEvent(log, payload)
 	case *github.DiscussionCommentEvent:
 		return processDiscussionCommentEvent(log, payload)
 	case *github.ForkEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.GitHubAppAuthorizationEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.GollumEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.InstallationEvent:
 		return processInstallationEvent(log, payload)
 	case *github.InstallationRepositoriesEvent:
@@ -694,35 +694,35 @@ func ProcessEvent(log *logrus.Entry, event *ActionEvent) ([]*entities.TargetEnti
 	case *github.IssuesEvent:
 		return processIssuesEvent(log, payload)
 	case *github.LabelEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.MarketplacePurchaseEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.MemberEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.MembershipEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.MetaEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.MilestoneEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.OrganizationEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.OrgBlockEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.PackageEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.PageBuildEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.PingEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.ProjectEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.ProjectCardEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.ProjectColumnEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.PublicEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.PullRequestEvent:
 		return processPullRequestEvent(log, payload)
 	case *github.PullRequestReviewEvent:
@@ -730,44 +730,44 @@ func ProcessEvent(log *logrus.Entry, event *ActionEvent) ([]*entities.TargetEnti
 	case *github.PullRequestReviewCommentEvent:
 		return processPullRequestReviewCommentEvent(log, payload)
 	case *github.PullRequestReviewThreadEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.PullRequestTargetEvent:
 		return processPullRequestTargetEvent(log, payload)
 	case *github.PushEvent:
 		return processPushEvent(log, *event.Token, payload)
 	case *github.ReleaseEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.RepositoryEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.RepositoryDispatchEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.RepositoryImportEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.RepositoryVulnerabilityAlertEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.SecretScanningAlertEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.StarEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.StatusEvent:
 		return processStatusEvent(log, *event.Token, payload)
 	case *github.TeamEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.TeamAddEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.UserEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.WatchEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.WorkflowDispatchEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.WorkflowJobEvent:
-		return processUnsupportedEvent(payload)
+		return processUnsupportedEvent(log, payload)
 	case *github.WorkflowRunEvent:
 		return processWorkflowRunEvent(log, *event.Token, payload)
 	}
 
-	return processUnsupportedEvent(eventPayload)
+	return processUnsupportedEvent(log, eventPayload)
 }
 
 func GetEventSender(eventPayload interface{}) string {

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -93,7 +93,7 @@ func TestIntegration(t *testing.T) {
 	require.NotEqual(repoOwner, "")
 	require.NotEqual(repoName, "")
 
-	githubClient := github.NewGithubClientFromToken(ctx, githubToken)
+	githubClient := github.NewGithubClientFromToken(ctx, githubToken, logger)
 
 	testID := uuid.NewString()
 	repoFullName := fmt.Sprintf("%s/%s", repoOwner, repoName)

--- a/lang/aladino/env_test.go
+++ b/lang/aladino/env_test.go
@@ -111,7 +111,7 @@ func TestNewEvalEnv(t *testing.T) {
 	}, nil)
 
 	ctx := context.Background()
-	mockedGithubClient := gh.NewGithubClient(nil, nil, nil)
+	mockedGithubClient := gh.NewGithubClient(nil, nil, nil, nil)
 
 	gotEnv, err := aladino.NewEvalEnv(
 		ctx,

--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -211,7 +211,7 @@ func MockDefaultGithubClient(ghApiClientOptions []mock.MockBackendOption, ghGrap
 		rawClientGQL = graphql.NewClient("https://api.github.com/graphql", &http.Client{Transport: localRoundTripper{handler: mux}})
 	}
 
-	return gh.NewGithubClient(client, clientGQL, rawClientGQL)
+	return gh.NewGithubClient(client, clientGQL, rawClientGQL, nil)
 }
 
 func MockDefaultGithubAppClient(ghApiClientOptions []mock.MockBackendOption) *gh.GithubAppClient {

--- a/runner.go
+++ b/runner.go
@@ -280,10 +280,6 @@ func Run(
 	safeMode bool,
 	checksWithIssue []string,
 ) (engine.ExitStatus, *engine.Program, string, error) {
-	gitHubClient = gitHubClient.WithLogger(log.WithFields(logrus.Fields{
-		"component": "reviewpad",
-	}))
-
 	config, err := plugins_aladino.DefaultPluginConfig()
 	if err != nil {
 		return engine.ExitStatusFailure, nil, "", err

--- a/runner.go
+++ b/runner.go
@@ -280,6 +280,8 @@ func Run(
 	safeMode bool,
 	checksWithIssue []string,
 ) (engine.ExitStatus, *engine.Program, string, error) {
+	log = log.WithField("component", "reviewpad")
+
 	config, err := plugins_aladino.DefaultPluginConfig()
 	if err != nil {
 		return engine.ExitStatusFailure, nil, "", err

--- a/runner.go
+++ b/runner.go
@@ -280,7 +280,9 @@ func Run(
 	safeMode bool,
 	checksWithIssue []string,
 ) (engine.ExitStatus, *engine.Program, string, error) {
-	log = log.WithField("component", "reviewpad")
+	gitHubClient = gitHubClient.WithLogger(log.WithFields(logrus.Fields{
+		"component": "reviewpad",
+	}))
 
 	config, err := plugins_aladino.DefaultPluginConfig()
 	if err != nil {


### PR DESCRIPTION
## Description
Wrap the github client round tripper to identify how many api requests we are making to github
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Aug 23 05:35 UTC
This pull request includes changes made to several files. Here is a summary of the modifications:

1. In the `env_test.go` file, the `TestNewEvalEnv` function has been modified and an additional argument has been added to the `mockedGithubClient` variable.

2. The file `processors.go` has been updated with changes in multiple places, including the addition of a new parameter `log` of type `logrus.Entry` in function calls to `NewGithubClientFromToken()` and `getPullRequests()`.

3. In the `client.go` file, there have been various changes including imports, addition of new fields and methods, and modifications to the `NewGithubClient` and `NewGithubClientFromToken` functions.

4. The `engine/mocks.go` file has a modification on line 122 where an additional argument `nil` has been added to the `gh.NewGithubClient` method call.

5. In the `integration_test.go` file, the `githubClient` initialization has been modified to include a `logger` parameter for better tracking and debugging.

6. The `mocks.go` file includes modifications to the `MockDefaultGithubClient` function where an additional argument `nil` is added to the `gh.NewGithubClient` call.

7. In the `run.go` file, there is a modification on line 107 where the `gh.NewGithubClientFromToken` call now includes an additional `log` parameter.

8. Lastly, in the `check.go` file, there are modifications on lines 32 and 37 where the `githubClient` variable and the `os.ReadFile` function are updated with new parameters.

Please review these changes in the context of the overall codebase and assess their impact.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at be772a9</samp>

This pull request adds a feature to count and log the GitHub API requests made by the `GithubClient` struct in the `github` package. It also modifies several functions and tests in other packages to pass a `log` parameter to the `GithubClient` constructor or use a `nil` value for the logger. This feature enables debugging and monitoring of the GitHub client interactions.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at be772a9</samp>

*  Modify `NewGithubClientFromToken` function to accept a `logger` parameter and use a `RequestCountTransport` to count and log GitHub API requests ([link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-251191d61bca9248a9edd7b5f6d0029c2c15870638a916839a94802c35a218bfL35-R35), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-90ee5300adc85797bd4537cc53f7b93a501cad3d1bd40d87d77a8520258e718bL110-R110), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542L48-R98), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-9b7a3b53805076bfb45db73a24bab5d6feffca2bc29371ff665affbf6c97841cL122-R122), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L44-R44), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L257-R257), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L297-R297), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L339-R339), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L574-R578), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L593-R597), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffL114-R114), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-60b59276b5de7d54b1037102856a01cf3f454fd5793a4d9f57f2b01878ae927bL214-R214))
* Add `RequestCountTransport` struct to implement `http.RoundTripper` interface and wrap another `http.RoundTripper` instance ([link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542L30-R76))
* Add `totalRequests` and `logger` fields to `GithubClient` struct and a `GetTotalRequests` method to return the request count ([link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542L16-R28), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542R135-R138))
* Modify `processUnsupportedEvent` function to accept a `log` parameter and use it instead of the global `log` variable ([link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L34-R34), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L659-R659), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L665-R677), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L683-R687), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L697-R725), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L733-R733), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L739-R770))
* Pass the `log` variable to the `getPullRequests` and `getPullRequest` helper functions ([link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L442-R442), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L504-R504), [link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-d07de10e776881f04ef3111a10250bfc72303ef3f0c71ffdd259c95632cbdfa3L557-R557))
* Import `bytes` and `io` packages to read and copy the request body in the `RequestCountTransport` struct ([link](https://github.com/reviewpad/reviewpad/pull/1054/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542L8-R11))
