### PR TITLE
feat: rate limit information

### DIFF
--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -268,14 +268,14 @@ func addRateLimitQuery(body []byte) ([]byte, error) {
 
 	err := json.Unmarshal(body, graphQLRequest)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal GraphQL request: %s", err.Error())
 	}
 
 	doc, err := parser.Parse(parser.ParseParams{
 		Source: string(graphQLRequest.Query),
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse GraphQL request: %s", err.Error())
 	}
 
 	// if for some reason the query is empty, just return the body

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -133,9 +133,9 @@ type GraphQLRequest struct {
 type GraphQLRateLimitResponse struct {
 	Data struct {
 		RateLimit struct {
-			Limit     int64  `json:"limit"`
-			Cost      int64  `json:"cost"`
-			Remaining int64  `json:"remaining"`
+			Limit     int    `json:"limit"`
+			Cost      int    `json:"cost"`
+			Remaining int    `json:"remaining"`
 			ResetAt   string `json:"resetAt"`
 		} `json:"rateLimit"`
 	} `json:"data"`
@@ -216,12 +216,12 @@ func setRateLimitFields(fields logrus.Fields, requestType string, headers http.H
 	if requestType == "rest" {
 		limit, err := strconv.Atoi(headers.Get("x-ratelimit-limit"))
 		if err != nil {
-			return fields, err
+			return fields, fmt.Errorf("failed to convert x-ratelimit-limit header to int: %s", err.Error())
 		}
 
 		remaining, err := strconv.Atoi(headers.Get("x-ratelimit-remaining"))
 		if err != nil {
-			return fields, err
+			return fields, fmt.Errorf("failed to convert x-ratelimit-remaining header to int: %s", err.Error())
 		}
 
 		fields["rate_limit_per_hour"] = limit
@@ -235,7 +235,7 @@ func setRateLimitFields(fields logrus.Fields, requestType string, headers http.H
 	rateLimitResponse := &GraphQLRateLimitResponse{}
 
 	if err := json.Unmarshal(body, rateLimitResponse); err != nil {
-		return fields, err
+		return fields, fmt.Errorf("failed to unmarshal GraphQL response: %s", err.Error())
 	}
 
 	fields["rate_limit_per_hour"] = rateLimitResponse.Data.RateLimit.Limit

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
@@ -215,8 +216,18 @@ func (t *GithubClient) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func setRateLimitFields(fields logrus.Fields, requestType string, headers http.Header, body []byte) (logrus.Fields, error) {
 	if requestType == "rest" {
-		fields["rate_limit_per_hour"] = headers.Get("x-rate-limit")
-		fields["rate_limit_remaining"] = headers.Get("x-ratelimit-remaining")
+		limit, err := strconv.Atoi(headers.Get("x-ratelimit-limit"))
+		if err != nil {
+			return nil, err
+		}
+
+		remaining, err := strconv.Atoi(headers.Get("x-ratelimit-remaining"))
+		if err != nil {
+			return nil, err
+		}
+
+		fields["rate_limit_per_hour"] = limit
+		fields["rate_limit_remaining"] = remaining
 		fields["rate_limit_reset"] = headers.Get("x-ratelimit-reset")
 		fields["rate_limit_cost"] = 1
 

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -216,12 +216,12 @@ func setRateLimitFields(fields logrus.Fields, requestType string, headers http.H
 	if requestType == "rest" {
 		limit, err := strconv.Atoi(headers.Get("x-ratelimit-limit"))
 		if err != nil {
-			return nil, err
+			return fields, err
 		}
 
 		remaining, err := strconv.Atoi(headers.Get("x-ratelimit-remaining"))
 		if err != nil {
-			return nil, err
+			return fields, err
 		}
 
 		fields["rate_limit_per_hour"] = limit
@@ -235,7 +235,7 @@ func setRateLimitFields(fields logrus.Fields, requestType string, headers http.H
 	rateLimitResponse := &GraphQLRateLimitResponse{}
 
 	if err := json.Unmarshal(body, rateLimitResponse); err != nil {
-		return nil, err
+		return fields, err
 	}
 
 	fields["rate_limit_per_hour"] = rateLimitResponse.Data.RateLimit.Limit

--- a/codehost/github/client_internal_test.go
+++ b/codehost/github/client_internal_test.go
@@ -5,9 +5,13 @@
 package github
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
+	"net/textproto"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,6 +56,107 @@ func TestAddRateLimitQuery(t *testing.T) {
 			res, err := addRateLimitQuery(tt.body)
 			assert.Equal(t, tt.wantErr, err)
 			assert.Equal(t, tt.want, res)
+		})
+	}
+}
+
+func TestSetRateLimitFields(t *testing.T) {
+	tests := map[string]struct {
+		fields      logrus.Fields
+		requestType string
+		headers     http.Header
+		body        []byte
+		wantFields  logrus.Fields
+		wantErr     error
+	}{
+		"when request type is rest with no ratelimit headers": {
+			fields: logrus.Fields{
+				"test": "test",
+			},
+			requestType: "rest",
+			headers:     http.Header{},
+			body:        nil,
+			wantFields: logrus.Fields{
+				"test": "test",
+			},
+			wantErr: errors.New("failed to convert x-ratelimit-limit header to int: strconv.Atoi: parsing \"\": invalid syntax"),
+		},
+		"when request type is rest with no ratelimit-remaining header": {
+			fields: logrus.Fields{
+				"test": "test",
+			},
+			requestType: "rest",
+			headers: http.Header{
+				textproto.CanonicalMIMEHeaderKey("x-ratelimit-limit"): []string{"1"},
+			},
+			body: nil,
+			wantFields: logrus.Fields{
+				"test": "test",
+			},
+			wantErr: errors.New("failed to convert x-ratelimit-remaining header to int: strconv.Atoi: parsing \"\": invalid syntax"),
+		},
+		"when request type is rest": {
+			fields: logrus.Fields{
+				"test": "test",
+			},
+			requestType: "rest",
+			headers: http.Header{
+				textproto.CanonicalMIMEHeaderKey("x-ratelimit-limit"):     []string{"5000"},
+				textproto.CanonicalMIMEHeaderKey("x-ratelimit-remaining"): []string{"4999"},
+				textproto.CanonicalMIMEHeaderKey("x-ratelimit-reset"):     []string{"1628601600"},
+			},
+			body: nil,
+			wantFields: logrus.Fields{
+				"test":                 "test",
+				"rate_limit_per_hour":  5000,
+				"rate_limit_remaining": 4999,
+				"rate_limit_reset":     "1628601600",
+				"rate_limit_cost":      1,
+			},
+		},
+		"when request type is graphql with response error": {
+			fields: logrus.Fields{
+				"test": "test",
+			},
+			requestType: "graphql",
+			body: []byte(`{
+				"data": {
+			}`),
+			wantFields: logrus.Fields{
+				"test": "test",
+			},
+			wantErr: errors.New("failed to unmarshal GraphQL response: unexpected end of JSON input"),
+		},
+		"when request type is graphql": {
+			fields: logrus.Fields{
+				"test": "test",
+			},
+			requestType: "graphql",
+			body: []byte(`{
+				"data": {
+					"rateLimit": {
+						"limit": 5000,
+						"cost": 5,
+						"remaining": 4995,
+						"resetAt": "2021-08-10T00:00:00Z"
+					}
+				}
+			}`),
+			wantFields: logrus.Fields{
+				"test":                 "test",
+				"rate_limit_per_hour":  5000,
+				"rate_limit_remaining": 4995,
+				"rate_limit_reset":     "2021-08-10T00:00:00Z",
+				"rate_limit_cost":      5,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fields, err := setRateLimitFields(tt.fields, tt.requestType, tt.headers, tt.body)
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.wantFields, fields)
 		})
 	}
 }

--- a/codehost/github/client_internal_test.go
+++ b/codehost/github/client_internal_test.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2022 Explore.dev, Unipessoal Lda - All Rights Reserved
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddRateLimitQuery(t *testing.T) {
+	tests := map[string]struct {
+		body    []byte
+		want    []byte
+		wantErr error
+	}{
+		"when error is request": {
+			body: []byte(`{
+				"query": "mutation { login }"
+			`),
+			want:    nil,
+			wantErr: fmt.Errorf("failed to unmarshal GraphQL request: unexpected end of JSON input"),
+		},
+		"when error is query": {
+			body: []byte(`{
+				"query": "mutation { login "
+			}`),
+			want:    nil,
+			wantErr: fmt.Errorf("failed to parse GraphQL request: Syntax Error GraphQL (1:18) Expected Name, found EOF\n\n1: mutation { login \n                    ^\n"),
+		},
+		"when request is mutation": {
+			body: []byte(`{
+				"query": "mutation { login }"
+			}`),
+			want: []byte(`{
+				"query": "mutation { login }"
+			}`),
+		},
+		"when request is query": {
+			body: []byte(`{
+				"query": "query { username }"
+			}`),
+			want: []byte(`{"query":"{\n  username\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n"}`),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := addRateLimitQuery(tt.body)
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.want, res)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/go-github/v52 v52.0.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
+	github.com/graphql-go/graphql v0.8.1
 	github.com/hasura/go-graphql-client v0.9.3
 	github.com/jarcoal/httpmock v1.3.0
 	github.com/jinzhu/copier v0.3.5

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/graph-gophers/graphql-go v1.5.0 h1:fDqblo50TEpD0LY7RXk/LFVYEVqo3+tXMN
 github.com/graph-gophers/graphql-go v1.5.0/go.mod h1:YtmJZDLbF1YYNrlNAuiO5zAStUWc3XZT07iGsVqe1Os=
 github.com/graph-gophers/graphql-transport-ws v0.0.2 h1:DbmSkbIGzj8SvHei6n8Mh9eLQin8PtA8xY9eCzjRpvo=
 github.com/graph-gophers/graphql-transport-ws v0.0.2/go.mod h1:5BVKvFzOd2BalVIBFfnfmHjpJi/MZ5rOj8G55mXvZ8g=
+github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
+github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=


### PR DESCRIPTION
## Description
Add rate limit information to github api request logs

Closes #1056 

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Aug 23 08:47 UTC
This pull request includes the following changes:

1. The go.mod file includes the addition of the package `github.com/graphql-go/graphql` at version `v0.8.1`.
2. The go.sum file includes the addition of two new dependencies: "github.com/graphql-go/graphql" with version v0.8.1, and "github.com/hashicorp/go-hclog" with version v0.9.2.
3. The file "github_test.go" adds two test functions, `TestAddRateLimitQuery` and `TestSetRateLimitFields`, to the `github` package. These test functions cover the rate limit-related functions.
4. The file "client.go" includes several changes:
   - Added imports for additional packages.
   - Added a struct "GraphQLRequest" and a struct "GraphQLRateLimitResponse".
   - Modified the "RoundTrip" method to handle different types of requests and set rate limit fields in the log.
   - Added helper functions for setting rate limit fields, removing rate limit from the response, and adding rate limit query to the request.

Please review these changes and provide any necessary feedback.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fb056a</samp>

This pull request enhances the `github` package to use GraphQL for some API calls, and to monitor the rate limit status for both REST and GraphQL. It also adds a new dependency for GraphQL handling in the `go.mod` file.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4fb056a</samp>

*  Add `github.com/graphql-go/graphql` dependency to support GraphQL requests to GitHub API ([link](https://github.com/reviewpad/reviewpad/pull/1059/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R14))
*  Import `encoding/json` and `github.com/graphql-go/graphql/language/*` packages to marshal and unmarshal JSON data and manipulate GraphQL queries and documents ([link](https://github.com/reviewpad/reviewpad/pull/1059/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542R10), [link](https://github.com/reviewpad/reviewpad/pull/1059/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542R18-R20))
*  Replace `RoundTrip` method for `GithubClient` type in `codehost/github/client.go` to handle both REST and GraphQL requests, log request and response details, and obtain rate limit information by modifying GraphQL request and response bodies ([link](https://github.com/reviewpad/reviewpad/pull/1059/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542L37-L69), [link](https://github.com/reviewpad/reviewpad/pull/1059/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542R125-R325))
