### PR TITLE
feat: rate limit percentage

### DIFF
--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -226,8 +226,11 @@ func setRateLimitFields(fields logrus.Fields, requestType string, headers http.H
 
 		fields["rate_limit_per_hour"] = limit
 		fields["rate_limit_remaining"] = remaining
+		fields["rate_limit_remaining_percentage"] = (float64(remaining) / float64(limit)) * 100
 		fields["rate_limit_reset"] = headers.Get("x-ratelimit-reset")
+		// we are setting the cost to 1 because for rest requests, the cost is always 1
 		fields["rate_limit_cost"] = 1
+		fields["rate_limit_cost_percentage"] = (1.0 / float64(limit)) * 100
 
 		return fields, nil
 	}
@@ -240,8 +243,10 @@ func setRateLimitFields(fields logrus.Fields, requestType string, headers http.H
 
 	fields["rate_limit_per_hour"] = rateLimitResponse.Data.RateLimit.Limit
 	fields["rate_limit_remaining"] = rateLimitResponse.Data.RateLimit.Remaining
+	fields["rate_limit_remaining_percentage"] = (float64(rateLimitResponse.Data.RateLimit.Remaining) / float64(rateLimitResponse.Data.RateLimit.Limit)) * 100
 	fields["rate_limit_reset"] = rateLimitResponse.Data.RateLimit.ResetAt
 	fields["rate_limit_cost"] = rateLimitResponse.Data.RateLimit.Cost
+	fields["rate_limit_cost_percentage"] = (float64(rateLimitResponse.Data.RateLimit.Cost) / float64(rateLimitResponse.Data.RateLimit.Limit)) * 100
 
 	return fields, nil
 }

--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -230,7 +230,7 @@ func setRateLimitFields(fields logrus.Fields, requestType string, headers http.H
 		fields["rate_limit_reset"] = headers.Get("x-ratelimit-reset")
 		// we are setting the cost to 1 because for rest requests, the cost is always 1
 		fields["rate_limit_cost"] = 1
-		fields["rate_limit_cost_percentage"] = (1.0 / float64(limit)) * 100
+		fields["rate_limit_cost_percentage"] = (1.0 / float64(remaining)) * 100
 
 		return fields, nil
 	}
@@ -246,7 +246,7 @@ func setRateLimitFields(fields logrus.Fields, requestType string, headers http.H
 	fields["rate_limit_remaining_percentage"] = (float64(rateLimitResponse.Data.RateLimit.Remaining) / float64(rateLimitResponse.Data.RateLimit.Limit)) * 100
 	fields["rate_limit_reset"] = rateLimitResponse.Data.RateLimit.ResetAt
 	fields["rate_limit_cost"] = rateLimitResponse.Data.RateLimit.Cost
-	fields["rate_limit_cost_percentage"] = (float64(rateLimitResponse.Data.RateLimit.Cost) / float64(rateLimitResponse.Data.RateLimit.Limit)) * 100
+	fields["rate_limit_cost_percentage"] = (float64(rateLimitResponse.Data.RateLimit.Cost) / float64(rateLimitResponse.Data.RateLimit.Remaining)) * 100
 
 	return fields, nil
 }

--- a/codehost/github/client_internal_test.go
+++ b/codehost/github/client_internal_test.go
@@ -107,11 +107,13 @@ func TestSetRateLimitFields(t *testing.T) {
 			},
 			body: nil,
 			wantFields: logrus.Fields{
-				"test":                 "test",
-				"rate_limit_per_hour":  5000,
-				"rate_limit_remaining": 4999,
-				"rate_limit_reset":     "1628601600",
-				"rate_limit_cost":      1,
+				"test":                            "test",
+				"rate_limit_per_hour":             5000,
+				"rate_limit_remaining":            4999,
+				"rate_limit_reset":                "1628601600",
+				"rate_limit_cost":                 1,
+				"rate_limit_remaining_percentage": 99.98,
+				"rate_limit_cost_percentage":      0.02,
 			},
 		},
 		"when request type is graphql with response error": {
@@ -143,11 +145,13 @@ func TestSetRateLimitFields(t *testing.T) {
 				}
 			}`),
 			wantFields: logrus.Fields{
-				"test":                 "test",
-				"rate_limit_per_hour":  5000,
-				"rate_limit_remaining": 4995,
-				"rate_limit_reset":     "2021-08-10T00:00:00Z",
-				"rate_limit_cost":      5,
+				"test":                            "test",
+				"rate_limit_per_hour":             5000,
+				"rate_limit_remaining":            4995,
+				"rate_limit_reset":                "2021-08-10T00:00:00Z",
+				"rate_limit_cost":                 5,
+				"rate_limit_remaining_percentage": 99.9,
+				"rate_limit_cost_percentage":      0.1,
 			},
 		},
 	}


### PR DESCRIPTION
## Description
Add rate limit percentages to request logs
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Aug 23 12:09 UTC
This pull request adds percentages to the request log. It introduces new fields "rate_limit_remaining_percentage" and "rate_limit_cost_percentage" to display the remaining and cost percentages respectively. Additionally, it refactors the code to use the remaining value to calculate the cost percentage. Lastly, it fixes an issue with the rounding of the percentages by adding a new "roundFloat" function.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d09e1d0</samp>

Enhance GitHub client to log more rate limit information. Update tests in `client_internal_test.go` and add new fields to `client.go` for both REST and GraphQL APIs.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d09e1d0</samp>

*  Add new fields to monitor rate limit usage of GitHub API client ([link](https://github.com/reviewpad/reviewpad/pull/1061/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542L229-R233), [link](https://github.com/reviewpad/reviewpad/pull/1061/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542L243-R249))
* Update test cases for `setRateLimitFields` function ([link](https://github.com/reviewpad/reviewpad/pull/1061/files?diff=unified&w=0#diff-7cb021f4419f9aec4a7fa3b994eb23c8f080d5ef4a0938960012a0fa0c5524c7L110-R116), [link](https://github.com/reviewpad/reviewpad/pull/1061/files?diff=unified&w=0#diff-7cb021f4419f9aec4a7fa3b994eb23c8f080d5ef4a0938960012a0fa0c5524c7L146-R154))
