### PR TITLE
refactor: treat github api request logging errors as warninig

### DIFF
--- a/codehost/github/client.go
+++ b/codehost/github/client.go
@@ -191,7 +191,7 @@ func (t *GithubClient) RoundTrip(req *http.Request) (*http.Response, error) {
 	fields, err := setRateLimitFields(fields, requestType, res.Header, resBody)
 	if err != nil {
 		if t.logger != nil {
-			t.logger.WithError(err).Error("failed to set rate limit fields")
+			t.logger.WithError(err).Warn("failed to set rate limit fields")
 		}
 	}
 


### PR DESCRIPTION
## Description
Treat github api request logging errors as warning in order not to generate false error alarms
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Aug 23 17:25 UTC
This pull request refactors the code to treat logging errors related to GitHub API requests as warnings instead of errors. Specifically, in the `RoundTrip` function of the `GithubClient`, the logger is updated to use the `Warn` level instead of `Error` when there is a failure in setting rate limit fields.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c101e41</samp>

Lowered log level of rate limit error in `codehost/github/client.go`. This was done to improve the logging and error handling of the GitHub client.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c101e41</samp>

* Lowered the log level for rate limit errors in `codehost/github/client.go` ([link](https://github.com/reviewpad/reviewpad/pull/1062/files?diff=unified&w=0#diff-a6123c786d6a131c29028de57d01fb8a8ca037d76da92501a09f11100c3a2542L194-R194),   ). This reduces the noise of non-critical errors and aligns with the existing log level for similar errors in the same file.
