### PR TITLE
feat: add label property to pad check

### DIFF
--- a/engine/lang.go
+++ b/engine/lang.go
@@ -233,11 +233,16 @@ type ReviewpadFile struct {
 type PadCheck struct {
 	Severity   string                 `yaml:"severity"`
 	Activation string                 `yaml:"activation"`
+	Label      string                 `yaml:"label"`
 	Parameters map[string]interface{} `yaml:"parameters"`
 }
 
 func (p PadCheck) equals(o PadCheck) bool {
 	if p.Severity != o.Severity {
+		return false
+	}
+
+	if p.Label != o.Label {
 		return false
 	}
 


### PR DESCRIPTION
## Description
add `label` property to pad check

Closes #1057 

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Aug 23 05:31 UTC
This pull request adds a "label" property to the PadCheck struct in the lang.go file. The "label" property is used to assign a label to each PadCheck object. This allows for easier identification and categorization of the PadCheck objects.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 430864d</samp>

Add custom labels for pad checks and update equality comparison. This allows users to specify different names for the same check in different languages or contexts, and ensures that checks are correctly identified by their label and type.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 430864d</samp>

*  Add `Label` field to `PadCheck` type to store check name ([link](https://github.com/reviewpad/reviewpad/pull/1063/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R236))
*  Update `equals` method for `PadCheck` to compare `Label` fields ([link](https://github.com/reviewpad/reviewpad/pull/1063/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701R245-R248))
