### PR TITLE
refactor: don't recreate patch every time

### DIFF
--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -70,13 +70,13 @@ func NewPullRequestTarget(ctx context.Context, targetEntity *entities.TargetEnti
 	}, nil
 }
 
-func NewPullRequestTargetWithPatch(ctx context.Context, targetEntity *entities.TargetEntity, githubClient *gh.GithubClient, codehostClient *codehost.CodeHostClient, pr *pbc.PullRequest, patch Patch) (*PullRequestTarget, error) {
+func NewPullRequestTargetWithoutPatch(ctx context.Context, targetEntity *entities.TargetEntity, githubClient *gh.GithubClient, codehostClient *codehost.CodeHostClient, pr *pbc.PullRequest) (*PullRequestTarget, error) {
 	return &PullRequestTarget{
 		NewCommonTarget(ctx, targetEntity, githubClient),
 		ctx,
 		pr,
 		githubClient,
-		patch,
+		nil,
 	}, nil
 }
 

--- a/codehost/github/target/pull_request_target.go
+++ b/codehost/github/target/pull_request_target.go
@@ -70,6 +70,16 @@ func NewPullRequestTarget(ctx context.Context, targetEntity *entities.TargetEnti
 	}, nil
 }
 
+func NewPullRequestTargetWithPatch(ctx context.Context, targetEntity *entities.TargetEntity, githubClient *gh.GithubClient, codehostClient *codehost.CodeHostClient, pr *pbc.PullRequest, patch Patch) (*PullRequestTarget, error) {
+	return &PullRequestTarget{
+		NewCommonTarget(ctx, targetEntity, githubClient),
+		ctx,
+		pr,
+		githubClient,
+		patch,
+	}, nil
+}
+
 func (t *PullRequestTarget) GetNodeID() string {
 	return t.PullRequest.GetId()
 }

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"errors"
+
 	"github.com/reviewpad/go-lib/entities"
 	"github.com/reviewpad/reviewpad/v4/codehost"
 	gh "github.com/reviewpad/reviewpad/v4/codehost/github"
@@ -236,7 +237,9 @@ func (i *Interpreter) ExecStatement(statement *engine.Statement) error {
 				return err
 			}
 
-			pullRequestTarget, err := target.NewPullRequestTarget(ctx, targetEntity, githubClient, codeHostClient, pullRequest)
+			patch := i.Env.GetTarget().(*target.PullRequestTarget).Patch
+
+			pullRequestTarget, err := target.NewPullRequestTargetWithPatch(ctx, targetEntity, githubClient, codeHostClient, pullRequest, patch)
 			if err != nil {
 				return err
 			}

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -239,10 +239,12 @@ func (i *Interpreter) ExecStatement(statement *engine.Statement) error {
 
 			patch := i.Env.GetTarget().(*target.PullRequestTarget).Patch
 
-			pullRequestTarget, err := target.NewPullRequestTargetWithPatch(ctx, targetEntity, githubClient, codeHostClient, pullRequest, patch)
+			pullRequestTarget, err := target.NewPullRequestTargetWithoutPatch(ctx, targetEntity, githubClient, codeHostClient, pullRequest)
 			if err != nil {
 				return err
 			}
+			pullRequestTarget.Patch = patch
+
 			i.Env.(*BaseEnv).Target = pullRequestTarget
 		}
 	}


### PR DESCRIPTION
## Description
the `NewPullRequestTarget` function fetches the patch from the API everytime which is a problem if it's called multiple times, this PR introduces a new function `NewPullRequestTargetWithPatch` which can be passed the patch so that it's possible to reuse the patch that was already fetched.

Closes #1078 

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Sep 23 11:04 UTC
This pull request adds a new function to create a pull request target that can receive a patch. It also refactors an existing function to clarify its purpose. The changes include modifications to the `pull_request_target.go` and `interpreter.go` files.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d92737d</samp>

This pull request enables the Aladino script to modify the GitHub pull request target using the `apply` command. It does this by passing the patch data from the environment to the `PullRequestTarget` constructor and storing it in the struct.

## Code review and merge strategy

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d92737d</samp>

*  Add new constructor function for `PullRequestTarget` that takes patch data as an argument ([link](https://github.com/reviewpad/reviewpad/pull/1080/files?diff=unified&w=0#diff-941cc2c2b19ac7ec6160457e465d3089df7aa23e19248596ec71396396dc7c54R74-R83))
*  Update `ExecStatement` function in `interpreter.go` to use the new constructor function and pass the patch data from the environment ([link](https://github.com/reviewpad/reviewpad/pull/1080/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL239-R242))
*  Add an empty line to `interpreter.go` for readability ([link](https://github.com/reviewpad/reviewpad/pull/1080/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becR13))
