### PR TITLE
refactor: remove trigger on check property

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -152,7 +152,7 @@ func run() error {
 
 	for _, targetEntity := range targetEntities {
 		log.Infof("Processing entity %s/%s#%d", targetEntity.Owner, targetEntity.Repo, targetEntity.Number)
-		_, _, _, err = reviewpad.Run(ctxReq, log, gitHubClient, codeHostClient, collectorClient, targetEntity, eventDetails, reviewpadFile, nil, dryRun, safeModeRun, nil)
+		_, _, _, err = reviewpad.Run(ctxReq, log, gitHubClient, codeHostClient, collectorClient, targetEntity, eventDetails, reviewpadFile, nil, dryRun, safeModeRun)
 		if err != nil {
 			return fmt.Errorf("error running reviewpad team edition. Details %v", err.Error())
 		}

--- a/engine/env.go
+++ b/engine/env.go
@@ -47,7 +47,6 @@ type Interpreter interface {
 	ProcessIterable(expr string) (lang.Value, error)
 	StoreTemporaryVariable(name string, value lang.Value)
 	ProcessDictionary(name string, dictionary map[string]string) error
-	GetChecksWithIssues() []string
 }
 
 type Env struct {

--- a/engine/exec.go
+++ b/engine/exec.go
@@ -332,22 +332,6 @@ func ExecConfigurationFile(env *Env, file *ReviewpadFile) (ExitStatus, *Program,
 
 	// process workflows
 	for _, workflow := range file.Workflows {
-		if workflow.TriggerOnCheck != "" {
-			shouldRun := false
-			checksWithIssues := env.Interpreter.GetChecksWithIssues()
-
-			for _, check := range checksWithIssues {
-				if check == workflow.TriggerOnCheck {
-					shouldRun = true
-					break
-				}
-			}
-
-			if !shouldRun {
-				continue
-			}
-		}
-
 		log.Infof("executing workflow `%v`", workflow.Name)
 		workflowLog := log.WithField("workflow", workflow.Name)
 

--- a/engine/exec_test.go
+++ b/engine/exec_test.go
@@ -440,7 +440,6 @@ func TestExecConfigurationFile(t *testing.T) {
 				engine.DefaultMockEventPayload,
 				builtIns,
 				nil,
-				nil,
 			)
 			if err != nil {
 				assert.FailNow(t, fmt.Sprintf("mockAladinoInterpreter: %v", err))
@@ -715,7 +714,6 @@ func mockAladinoInterpreter(githubClient *gh.GithubClient, codehostClient *codeh
 		engine.DefaultMockTargetEntity,
 		engine.DefaultMockEventPayload,
 		aladino.MockBuiltIns(),
-		nil,
 		nil,
 	)
 	if err != nil {

--- a/engine/inline_rules_normalizer.go
+++ b/engine/inline_rules_normalizer.go
@@ -61,13 +61,12 @@ func inlineModificator(file *ReviewpadFile) (*ReviewpadFile, error) {
 
 func processWorkflow(workflow PadWorkflow, currentRules []PadRule) (*PadWorkflow, []PadRule, error) {
 	wf := &PadWorkflow{
-		Name:           workflow.Name,
-		Description:    workflow.Description,
-		AlwaysRun:      workflow.AlwaysRun,
-		Rules:          workflow.Rules,
-		Actions:        workflow.Actions,
-		On:             workflow.On,
-		TriggerOnCheck: workflow.TriggerOnCheck,
+		Name:        workflow.Name,
+		Description: workflow.Description,
+		AlwaysRun:   workflow.AlwaysRun,
+		Rules:       workflow.Rules,
+		Actions:     workflow.Actions,
+		On:          workflow.On,
 	}
 
 	runs, runRules, err := normalizeRun(workflow.NonNormalizedRun, currentRules)

--- a/engine/lang.go
+++ b/engine/lang.go
@@ -109,7 +109,6 @@ type PadWorkflow struct {
 	NonNormalizedActions any                         `yaml:"then"`
 	NonNormalizedElse    any                         `yaml:"else"`
 	NonNormalizedRun     any                         `yaml:"run"`
-	TriggerOnCheck       string                      `yaml:"trigger-on-check"`
 }
 
 type PadWorkflowRunBlock struct {

--- a/engine/loader.go
+++ b/engine/loader.go
@@ -213,12 +213,11 @@ func transform(file *ReviewpadFile) *ReviewpadFile {
 		}
 
 		transformedWorkflows = append(transformedWorkflows, PadWorkflow{
-			Name:           workflow.Name,
-			On:             transformedOn,
-			Description:    workflow.Description,
-			AlwaysRun:      workflow.AlwaysRun,
-			Runs:           workflow.Runs,
-			TriggerOnCheck: workflow.TriggerOnCheck,
+			Name:        workflow.Name,
+			On:          transformedOn,
+			Description: workflow.Description,
+			AlwaysRun:   workflow.AlwaysRun,
+			Runs:        workflow.Runs,
 		})
 	}
 

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -330,7 +330,7 @@ func TestIntegration(t *testing.T) {
 			// execute the reviewpad files one by one and
 			// ensure there are no errors and exit statuses match
 			for i, file := range test.reviewpadFiles {
-				exitStatus, _, _, err := reviewpad.Run(ctxReq, logger, githubClient, codeHostClient, collector, targetEntity, eventDetails, file, nil, false, false, nil)
+				exitStatus, _, _, err := reviewpad.Run(ctxReq, logger, githubClient, codeHostClient, collector, targetEntity, eventDetails, file, nil, false, false)
 				assert.Equal(test.wantErr, err)
 				assert.Equal(test.exitStatus[i], exitStatus)
 			}

--- a/lang/aladino/env.go
+++ b/lang/aladino/env.go
@@ -51,7 +51,6 @@ type Env interface {
 	GetCheckRunID() *int64
 	SetCheckRunConclusion(string)
 	GetCheckRunConclusion() string
-	GetChecksWithIssues() []string
 }
 
 type BaseEnv struct {
@@ -72,7 +71,6 @@ type BaseEnv struct {
 	ExecFatalErrorOccurred   error
 	CheckRunID               *int64
 	CheckRunConclusion       string
-	ChecksWithIssues         []string
 }
 
 func (e *BaseEnv) GetBuiltIns() *BuiltIns {
@@ -151,10 +149,6 @@ func (e *BaseEnv) GetCheckRunID() *int64 {
 	return e.CheckRunID
 }
 
-func (e *BaseEnv) GetChecksWithIssues() []string {
-	return e.ChecksWithIssues
-}
-
 func NewTypeEnv(e Env) TypeEnv {
 	builtInsType := make(map[string]lang.Type)
 	for builtInName, builtInFunction := range e.GetBuiltIns().Functions {
@@ -183,7 +177,6 @@ func NewEvalEnv(
 	eventPayload interface{},
 	builtIns *BuiltIns,
 	checkRunID *int64,
-	checksWithIssues []string,
 ) (Env, error) {
 	registerMap := RegisterMap(make(map[string]lang.Value))
 	report := &Report{Actions: make([]string, 0)}
@@ -206,7 +199,6 @@ func NewEvalEnv(
 		ExecWaitGroup:            &wg,
 		ExecMutex:                &mu,
 		CheckRunID:               checkRunID,
-		ChecksWithIssues:         checksWithIssues,
 	}
 
 	switch targetEntity.Kind {

--- a/lang/aladino/env_test.go
+++ b/lang/aladino/env_test.go
@@ -76,7 +76,6 @@ func TestNewEvalEnv_WhenGetPullRequestFilesFails(t *testing.T) {
 		nil,
 		aladino.MockBuiltIns(),
 		nil,
-		nil,
 	)
 
 	assert.Nil(t, env)
@@ -111,7 +110,6 @@ func TestNewEvalEnv_WhenNewFileFails(t *testing.T) {
 		nil,
 		aladino.MockBuiltIns(),
 		nil,
-		nil,
 	)
 
 	assert.Nil(t, env)
@@ -144,7 +142,6 @@ func TestNewEvalEnv(t *testing.T) {
 		aladino.DefaultMockTargetEntity,
 		nil,
 		aladino.MockBuiltIns(),
-		nil,
 		nil,
 	)
 
@@ -209,7 +206,6 @@ func TestNewEvalEnv_WhenGetPullRequestFails(t *testing.T) {
 		targetEntity,
 		nil,
 		aladino.MockBuiltIns(),
-		nil,
 		nil,
 	)
 

--- a/lang/aladino/interpreter.go
+++ b/lang/aladino/interpreter.go
@@ -351,10 +351,6 @@ func (i *Interpreter) GetCheckRunConclusion() string {
 	return i.Env.GetCheckRunConclusion()
 }
 
-func (i *Interpreter) GetChecksWithIssues() []string {
-	return i.Env.GetChecksWithIssues()
-}
-
 func NewInterpreter(
 	ctx context.Context,
 	logger *logrus.Entry,
@@ -366,9 +362,8 @@ func NewInterpreter(
 	eventPayload interface{},
 	builtIns *BuiltIns,
 	checkRunID *int64,
-	checksWithIssues []string,
 ) (engine.Interpreter, error) {
-	evalEnv, err := NewEvalEnv(ctx, logger, dryRun, githubClient, codeHostClient, collector, targetEntity, eventPayload, builtIns, checkRunID, checksWithIssues)
+	evalEnv, err := NewEvalEnv(ctx, logger, dryRun, githubClient, codeHostClient, collector, targetEntity, eventPayload, builtIns, checkRunID)
 	if err != nil {
 		return nil, err
 	}

--- a/lang/aladino/interpreter_internal_test.go
+++ b/lang/aladino/interpreter_internal_test.go
@@ -776,7 +776,6 @@ func TestNewInterpreter_WhenNewEvalEnvFails(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		nil,
 	)
 
 	assert.Nil(t, gotInterpreter)
@@ -800,7 +799,6 @@ func TestNewInterpreter(t *testing.T) {
 		DefaultMockTargetEntity,
 		mockedEnv.GetEventPayload(),
 		mockedEnv.GetBuiltIns(),
-		nil,
 		nil,
 	)
 
@@ -1045,7 +1043,6 @@ func TestReportMetric(t *testing.T) {
 				env.GetCodeHostClient(),
 				env.GetCollector(),
 				env.GetTarget().GetTargetEntity(),
-				nil,
 				nil,
 				nil,
 				nil,

--- a/lang/aladino/mocks.go
+++ b/lang/aladino/mocks.go
@@ -157,7 +157,6 @@ func mockEnvWith(prOwner string, prRepoName string, prNum int, githubClient *gh.
 		eventPayload,
 		builtIns,
 		nil,
-		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/runner.go
+++ b/runner.go
@@ -278,7 +278,6 @@ func Run(
 	checkRunId *int64,
 	dryRun bool,
 	safeMode bool,
-	checksWithIssue []string,
 ) (engine.ExitStatus, *engine.Program, string, error) {
 	config, err := plugins_aladino.DefaultPluginConfig()
 	if err != nil {
@@ -287,7 +286,7 @@ func Run(
 
 	defer config.CleanupPluginConfig()
 
-	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, codeHostClient, collector, targetEntity, eventDetails.Payload, plugins_aladino.PluginBuiltInsWithConfig(config), checkRunId, checksWithIssue)
+	aladinoInterpreter, err := aladino.NewInterpreter(ctx, log, dryRun, gitHubClient, codeHostClient, collector, targetEntity, eventDetails.Payload, plugins_aladino.PluginBuiltInsWithConfig(config), checkRunId)
 	if err != nil {
 		return engine.ExitStatusFailure, nil, "", err
 	}


### PR DESCRIPTION
## Description
Removes the `trigger-on-check` property to decouple reviewpad check from reviewpad automate.
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 16 Oct 23 07:42 UTC
This pull request includes several file diffs. Here is a summary of the changes made:

- The file `engine/lang.go` has the following changes:
  - Line 109: The `TriggerOnCheck` field has been removed from the `PadWorkflow` struct.
  - A new struct `PadWorkflowRunBlock` has been added.

- The file `interpreter/interpreter.go` has the following changes:
  - The function `GetChecksWithIssues()` has been removed from the `Interpreter` struct.
  - The parameters `checksWithIssues []string` and `checksWithIssues` have been removed from the `NewInterpreter` function and its invocation.

- The file `run.go` has the following changes:
  - Line 152: The log message now includes the entity owner, repository, and number.
  - Line 155: The "nil" argument in the "reviewpad.Run" function call has been removed.

- The file `transformer/transformer.go` has the following changes:
  - The `PadWorkflow` struct in the `transformedWorkflows` slice has been modified. The fields `TriggerOnCheck` have been removed, and the remaining fields have been reordered.

- The file `env.go` has the following changes:
  - Line 47: The method `GetChecksWithIssues()` has been removed from the `Interpreter` interface.

- The file `testfile.go` has the following changes:
  - Some code initializing a variable to nil in several test functions has been removed.

- The file `exec.go` has the following changes:
  - Lines 332-347: The conditional block checking `TriggerOnCheck` before running a workflow has been removed.

- The file `mocks.go` has the following changes:
  - Removed a `nil` argument from a function call on line 162.

- The file `exec_test.go` has the following changes:
  - Line 4: Removed a `nil` argument.
  - Line 14: Removed a `nil` argument.

- The file `inline_rules_normalizer.go` has the following changes:
  - In the `processWorkflow` function, the `TriggerOnCheck` field of the `wf` variable has been removed.
  - The indentation of fields in the `wf` variable has been modified.

- The file `integration_test.go` has the following changes:
  - In the `TestIntegration` function, the last argument `nil` in the `reviewpad.Run` call has been removed.

- The file `run.go` has the following changes:
  - The `checksWithIssue` variable has been removed from the function signature and the corresponding `NewInterpreter` function call.

- The file `interpreter/interpreter.go` has the following changes:
  - The `GetChecksWithIssues` method has been removed from the `Env` interface.
  - The `ChecksWithIssues` field has been removed from the `BaseEnv` struct.
  - The `checksWithIssues` parameter has been removed from the `NewEvalEnv` function signature and its assignment.

Please let me know if you need further assistance or have any questions.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1447652</samp>

Removed the `checksWithIssues` parameter and the `TriggerOnCheck` field from various functions and structs in the `engine` and `lang/aladino` packages. These were obsolete and not used by the new workflow trigger logic based on the `On` field. Simplified the code and the tests accordingly.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1447652</samp>

*  Remove `TriggerOnCheck` field from `PadWorkflow` struct and related logic from `ExecConfigurationFile` function as it was deprecated and replaced by `On` field ([link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-a265bb7df9128e988c6354a6c19295529954daecf10338751f3d394e0298185fL335-L350), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-ea18868fc6cfa08e95023e74934900b2af69a653d53a65a962abe70616a132f6L64-R69), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701L112), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-31e0d9a2beee99e1ca91227b4cf55fc6b934b0d3bfef25a56fdf5fbf28879c92L216-R220))
* Remove `GetChecksWithIssues` method from `Interpreter` and `Env` interfaces and related fields and parameters from structs and functions as it was no longer needed by the engine or the aladino language ([link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-bd383b1ff56f0a02ff20cb2df318417891c9954441067394d8ad3ec8a30638c2L50), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9L54), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL354-L357))
* Remove `checksWithIssues` parameter and argument from `NewInterpreter` function and calls as it was no longer needed by the aladino language or the engine ([link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-097124149197567e1cf6684921ce58756d78c728779094d2491510b7a4cb8becL369-R366), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395L779), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395L804), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L281), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L290-R289))
* Remove `checksWithIssues` parameter and argument from `NewEvalEnv` function and calls as it was no longer needed by the aladino language or the engine ([link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9L186), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffL79), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffL114), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffL148), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-198f822b075fad638def7e1dc052aa4768888e48eea77314bbbf2e6860d454ffL213))
* Remove `ChecksWithIssues` field from `BaseEnv` struct and related assignments as it was no longer needed by the aladino language or the engine ([link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9L75), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9L154-L157), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-0ef0485c737ac47081f43d655de666e169819da6b26501fa14df7b7ba75f61e9L209))
* Remove `checksWithIssues` parameter and argument from `mockEnvWith` function and calls as it was no longer needed by the aladino language or the engine ([link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-60b59276b5de7d54b1037102856a01cf3f454fd5793a4d9f57f2b01878ae927bL160), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-a8b156f457738bc0d213990057f16c3297db4c42eed08cd5b0aa56c619e6a395L1051))
* Remove `nil` argument representing the `checksWithIssues` parameter from `mockAladinoInterpreter` calls in tests as the parameter was removed from the function ([link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2L443), [link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2L719))
* Remove test case `TestExecConfigurationFile_WhenWorkflowHasTriggerOnCheck` from `engine/exec_test.go` as it was no longer relevant ([link](https://github.com/reviewpad/reviewpad/pull/1093/files?diff=unified&w=0#diff-70964c6dbba9fc7c26598e6ace703c137eff62c72bca86ec506392ac138ca3c2L719))
