### PR TITLE
feat: remove label property from check

### DIFF
--- a/engine/lang.go
+++ b/engine/lang.go
@@ -232,16 +232,11 @@ type ReviewpadFile struct {
 type PadCheck struct {
 	Severity   string                 `yaml:"severity"`
 	Activation string                 `yaml:"activation"`
-	Label      string                 `yaml:"label"`
 	Parameters map[string]interface{} `yaml:"parameters"`
 }
 
 func (p PadCheck) equals(o PadCheck) bool {
 	if p.Severity != o.Severity {
-		return false
-	}
-
-	if p.Label != o.Label {
 		return false
 	}
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Oct 23 08:15 UTC
This pull request removes the label property from the check in the engine/lang.go file. The label property is no longer needed and has been deleted.
<!-- reviewpad:summarize:end --> 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd0559b</samp>

Refactored the `PadCheck` type and its comparison logic in `engine/lang.go` to remove unnecessary data and simplify the code.

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd0559b</samp>

* Remove `Label` field from `PadCheck` type and simplify `equals` method by skipping `Label` comparison ([link](https://github.com/reviewpad/reviewpad/pull/1097/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701L235), [link](https://github.com/reviewpad/reviewpad/pull/1097/files?diff=unified&w=0#diff-75c510fa57c2a4141549710b101cacf6718f98bbcd315480f224178a824a3701L244-L247)) in `engine/lang.go`
